### PR TITLE
feat(replay): export JSON Schema and enforce drift detection in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,28 @@ on:
 
 jobs:
   # ─────────────────────────────────────────────────────────────
+  # Job 0 · Generated-schema drift check (fast fail signal)
+  # ─────────────────────────────────────────────────────────────
+  schema-check:
+    name: Schema drift
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+
+      - name: Install Python 3.12
+        run: uv python install 3.12
+
+      - name: Install dependencies
+        run: uv sync --python 3.12
+
+      - name: Verify replay schemas match agentao/replay/events.py
+        run: uv run --python 3.12 python scripts/write_replay_schema.py --check
+
+  # ─────────────────────────────────────────────────────────────
   # Job 1 · Unit tests across Python 3.10 / 3.11 / 3.12
   # ─────────────────────────────────────────────────────────────
   test:

--- a/agentao/replay/events.py
+++ b/agentao/replay/events.py
@@ -75,9 +75,14 @@ class EventKind:
     SESSION_LOADED = "session_loaded"
     SESSION_FORKED = "session_forked"
 
-    ALL = frozenset({
+    # Versioned partitions. ``V1_0`` is the original event set and is
+    # never retroactively grown — adding a kind is always a v1.1+ event.
+    # ``V1_1_NEW`` holds only what 1.1 added; readers that want the full
+    # 1.1 vocabulary use :data:`V1_1` (the union). The schema generator
+    # in :mod:`agentao.replay.schema` consumes these sets directly so
+    # that the committed schema files stay in lock-step with the code.
+    V1_0 = frozenset({
         REPLAY_HEADER,
-        REPLAY_FOOTER,
         SESSION_STARTED,
         SESSION_ENDED,
         SESSION_SAVED,
@@ -94,7 +99,10 @@ class EventKind:
         SUBAGENT_STARTED,
         SUBAGENT_COMPLETED,
         ERROR,
-        # v1.1
+    })
+
+    V1_1_NEW = frozenset({
+        REPLAY_FOOTER,
         TOOL_RESULT,
         LLM_CALL_STARTED,
         LLM_CALL_COMPLETED,
@@ -117,6 +125,12 @@ class EventKind:
         SESSION_LOADED,
         SESSION_FORKED,
     })
+
+    V1_1 = V1_0 | V1_1_NEW
+
+    # Back-compat alias. Existing callers that imported ``EventKind.ALL``
+    # keep working; new code should pick the version-specific set.
+    ALL = V1_1
 
 
 @dataclass

--- a/agentao/replay/schema.py
+++ b/agentao/replay/schema.py
@@ -1,0 +1,143 @@
+"""JSON Schema generator for replay events.
+
+Code is the source of truth: :class:`agentao.replay.events.EventKind`
+declares the kind vocabulary per schema version, and :class:`ReplayEvent`
+declares the envelope shape. This module emits the on-disk schema files
+under ``schemas/`` from those declarations.
+
+Design notes:
+
+- The schema is a discriminated union from day one — every kind gets its
+  own ``oneOf`` variant pinning ``kind`` to a ``const``. Per-kind payload
+  shapes will be tightened in follow-ups; on the first cut every variant
+  carries the same lenient ``payload`` (``object``, additional properties
+  allowed) so the structural skeleton is in place without blocking
+  emission sites that have not been audited yet.
+- The envelope is strict (``additionalProperties: false``). Adding a new
+  envelope field is a breaking change; payload extensibility is what
+  makes the format forward-compatible.
+- Each schema version pins a separate file. v1.0 schema accepts only the
+  v1.0 kind enum; v1.1 schema accepts the full v1.1 vocabulary. A 1.0
+  replay file must keep validating against ``schemas/replay-event-1.0.json``
+  forever — that is the backward-compatibility promise documented in
+  ``docs/replay/schema-policy.md``.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, FrozenSet, Iterable
+
+from .events import EventKind
+
+
+SCHEMA_DIALECT = "https://json-schema.org/draft/2020-12/schema"
+
+
+def _kinds_for_version(version: str) -> FrozenSet[str]:
+    if version == "1.0":
+        return EventKind.V1_0
+    if version == "1.1":
+        return EventKind.V1_1
+    raise ValueError(f"unknown replay schema version: {version!r}")
+
+
+def _envelope_properties() -> Dict[str, dict]:
+    """Shared envelope properties — every event carries these regardless of kind."""
+    return {
+        "event_id": {"type": "string", "minLength": 1},
+        "session_id": {"type": "string", "minLength": 1},
+        "instance_id": {"type": "string", "minLength": 1},
+        "seq": {"type": "integer", "minimum": 0},
+        "ts": {"type": "string", "format": "date-time"},
+        "turn_id": {"type": ["string", "null"]},
+        "parent_turn_id": {"type": ["string", "null"]},
+        "payload": {
+            "type": "object",
+            "additionalProperties": True,
+        },
+    }
+
+
+def _kind_variant(kind: str) -> dict:
+    """One ``oneOf`` branch — pins ``kind`` to a constant string.
+
+    Payload remains lenient at this stage. When per-kind payload shapes
+    are added, this function (or a successor that takes a per-kind
+    payload schema) is the only place that needs to change.
+    """
+    return {
+        "type": "object",
+        "properties": {
+            "kind": {"const": kind},
+        },
+        "required": ["kind"],
+    }
+
+
+def build_event_schema(version: str) -> dict:
+    """Return the JSON Schema document for replay events at ``version``.
+
+    The returned dict is JSON-serializable and deterministic — repeated
+    calls produce structurally identical output (kinds are enumerated in
+    sorted order).
+    """
+    kinds = sorted(_kinds_for_version(version))
+    envelope = _envelope_properties()
+    return {
+        "$schema": SCHEMA_DIALECT,
+        "$id": f"urn:agentao:schema:replay-event:{version}",
+        "title": f"Agentao replay event (v{version})",
+        "description": (
+            "One JSONL line in a replay file. Source of truth: "
+            "agentao/replay/events.py - regenerate via "
+            "scripts/write_replay_schema.py."
+        ),
+        "type": "object",
+        "required": [
+            "event_id",
+            "session_id",
+            "instance_id",
+            "seq",
+            "ts",
+            "kind",
+            "payload",
+        ],
+        "additionalProperties": False,
+        "properties": {
+            **envelope,
+            "kind": {
+                "type": "string",
+                "enum": kinds,
+            },
+        },
+        "oneOf": [_kind_variant(kind) for kind in kinds],
+    }
+
+
+SUPPORTED_VERSIONS: tuple = ("1.0", "1.1")
+
+
+def render(version: str) -> str:
+    """Return the canonical text form for the schema at ``version``.
+
+    Trailing newline + 2-space indent + ``sort_keys=True`` make the file
+    deterministic on disk so ``git diff --exit-code`` is meaningful.
+    """
+    return json.dumps(build_event_schema(version), indent=2, sort_keys=True) + "\n"
+
+
+def write_all(out_dir: Path, versions: Iterable[str] = SUPPORTED_VERSIONS) -> Dict[str, Path]:
+    """Write one schema file per version under ``out_dir``.
+
+    Returns a ``{version: path}`` map of files written, in declaration
+    order. Creates ``out_dir`` if missing.
+    """
+    out_dir.mkdir(parents=True, exist_ok=True)
+    written: Dict[str, Path] = {}
+    for version in versions:
+        path = out_dir / f"replay-event-{version}.json"
+        path.write_text(render(version), encoding="utf-8")
+        written[version] = path
+    return written

--- a/docs/replay/schema-policy.md
+++ b/docs/replay/schema-policy.md
@@ -1,0 +1,121 @@
+# Replay schema versioning policy
+
+This document defines how the JSON Schema files under `schemas/` evolve.
+It exists so that "what does `SCHEMA_VERSION = "1.1"` mean?" has a
+machine-checkable answer instead of living in a dataclass docstring.
+
+## Source of truth
+
+```
+agentao/replay/events.py    # EventKind vocabulary + ReplayEvent envelope
+agentao/replay/schema.py    # emitter that turns those into JSON Schema
+schemas/replay-event-*.json # generated artefact, committed to the repo
+```
+
+Code is canonical. The schema file is a generated artifact and must
+never be hand-edited — `scripts/write_replay_schema.py --check` runs in
+CI and fails on drift.
+
+## What `SCHEMA_VERSION` covers
+
+The `SCHEMA_VERSION` constant in `agentao/replay/events.py` describes
+the **on-disk JSONL format**: envelope shape + kind vocabulary +
+per-kind payload contract (the third tier is being introduced
+incrementally). Every change to that on-disk format must bump the
+version under the rules below.
+
+## Compatibility rules
+
+### Minor bump (`1.x` -> `1.(x+1)`)
+
+Allowed without notice:
+
+- Adding a new event kind to `EventKind`.
+- Adding a new **optional** field to the envelope (rare; envelope is
+  intentionally narrow).
+- Adding a new optional field to a kind's payload schema once that
+  payload is modelled.
+- Tightening a previously-permissive payload schema in a way that every
+  existing emitter already satisfies (i.e. discovering that a field was
+  always present and marking it required).
+
+A 1.0 reader **may** see kinds it does not recognise from a 1.1+ writer
+and **must** skip them rather than error. This is the forward-compat
+contract.
+
+### Major bump (`1.x` -> `2.0`)
+
+Required when:
+
+- Removing or renaming an envelope field, or changing its type.
+- Removing or renaming an existing event kind. (Replacing one with
+  another is a remove + add; both halves are major.)
+- Changing the meaning of an existing field (e.g. switching `ts` from
+  ISO-8601 to epoch seconds).
+- Tightening a payload schema in a way that existing on-disk replays
+  would fail validation.
+
+Major bumps freeze the previous schema file. `schemas/replay-event-1.1.json`
+keeps validating every replay file written under `1.x`, indefinitely.
+
+### Deprecation
+
+A kind or field is deprecated by:
+
+1. Marking it `"deprecated": true` in the schema (JSON Schema 2019-09+).
+2. Adding a one-line note in `EventKind` and the policy changelog below.
+3. Continuing to emit it for at least one minor cycle so readers can
+   adapt.
+
+Removal is a major bump; deprecation alone never is.
+
+## Unknown-fields policy
+
+| Layer    | Policy                              | Why                                                                  |
+|----------|-------------------------------------|----------------------------------------------------------------------|
+| Envelope | `additionalProperties: false`       | The envelope is small and shared. Surprises here mean a bug.         |
+| `kind`   | `enum` of the version's vocabulary  | Discriminator must be exhaustive for `oneOf` to type-check cleanly.  |
+| Payload  | `additionalProperties: true` (now)  | Per-kind payloads are still being modelled. Lenient until tightened. |
+
+When per-kind payloads land, each variant should pick its own
+`additionalProperties` setting. Long-tail diagnostic kinds may stay
+lenient; protocol-shaped kinds (everything that another runtime might
+re-emit) should be strict.
+
+## Backward-compatibility guarantees
+
+- A replay file written under `SCHEMA_VERSION = X` validates against
+  `schemas/replay-event-X.json` forever.
+- The reader at `SCHEMA_VERSION = X` accepts any file that validates
+  against `schemas/replay-event-Y.json` for `Y <= X` within the same
+  major.
+- Cross-major reads are best-effort: the reader may opt to load a 1.x
+  file under a 2.x reader, but is not required to.
+
+The fixture suite in `tests/test_replay_schema.py` enforces the first
+guarantee for every committed schema version. New major versions must
+add a fresh fixture before merge.
+
+## Regeneration
+
+```bash
+# Rewrite schemas/ from agentao/replay/events.py
+uv run python scripts/write_replay_schema.py
+
+# CI invocation (fails on drift)
+uv run python scripts/write_replay_schema.py --check
+```
+
+The script is intentionally tiny: anything more than "render and write"
+belongs in `agentao/replay/schema.py` so it is unit-testable.
+
+## Changelog
+
+- **1.0** (initial) — envelope + 17 kinds covering session, turn, user,
+  assistant, tool confirm/start/output/complete, subagent, error.
+- **1.1** — adds `replay_footer` plus 21 kinds covering tool_result,
+  llm_call_*, ask_user_*, background_notification_injected,
+  context_compressed, session_summary_written, skill_*, memory_*,
+  model_changed, permission_mode_changed, readonly_mode_changed,
+  plugin_hook_fired, session_loaded, session_forked. Backward-compatible
+  with 1.0 — every 1.0 kind survives.

--- a/schemas/replay-event-1.0.json
+++ b/schemas/replay-event-1.0.json
@@ -1,0 +1,266 @@
+{
+  "$id": "urn:agentao:schema:replay-event:1.0",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "One JSONL line in a replay file. Source of truth: agentao/replay/events.py - regenerate via scripts/write_replay_schema.py.",
+  "oneOf": [
+    {
+      "properties": {
+        "kind": {
+          "const": "assistant_text_chunk"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "assistant_thought_chunk"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "error"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "replay_header"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "session_ended"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "session_saved"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "session_started"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "subagent_completed"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "subagent_started"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "tool_completed"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "tool_confirmation_requested"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "tool_confirmation_resolved"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "tool_output_chunk"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "tool_started"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "turn_completed"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "turn_started"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "user_message"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    }
+  ],
+  "properties": {
+    "event_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "instance_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "kind": {
+      "enum": [
+        "assistant_text_chunk",
+        "assistant_thought_chunk",
+        "error",
+        "replay_header",
+        "session_ended",
+        "session_saved",
+        "session_started",
+        "subagent_completed",
+        "subagent_started",
+        "tool_completed",
+        "tool_confirmation_requested",
+        "tool_confirmation_resolved",
+        "tool_output_chunk",
+        "tool_started",
+        "turn_completed",
+        "turn_started",
+        "user_message"
+      ],
+      "type": "string"
+    },
+    "parent_turn_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "payload": {
+      "additionalProperties": true,
+      "type": "object"
+    },
+    "seq": {
+      "minimum": 0,
+      "type": "integer"
+    },
+    "session_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "ts": {
+      "format": "date-time",
+      "type": "string"
+    },
+    "turn_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "event_id",
+    "session_id",
+    "instance_id",
+    "seq",
+    "ts",
+    "kind",
+    "payload"
+  ],
+  "title": "Agentao replay event (v1.0)",
+  "type": "object"
+}

--- a/schemas/replay-event-1.1.json
+++ b/schemas/replay-event-1.1.json
@@ -1,0 +1,530 @@
+{
+  "$id": "urn:agentao:schema:replay-event:1.1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "additionalProperties": false,
+  "description": "One JSONL line in a replay file. Source of truth: agentao/replay/events.py - regenerate via scripts/write_replay_schema.py.",
+  "oneOf": [
+    {
+      "properties": {
+        "kind": {
+          "const": "ask_user_answered"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "ask_user_requested"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "assistant_text_chunk"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "assistant_thought_chunk"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "background_notification_injected"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "context_compressed"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "error"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "llm_call_completed"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "llm_call_delta"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "llm_call_io"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "llm_call_started"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "memory_cleared"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "memory_delete"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "memory_write"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "model_changed"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "permission_mode_changed"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "plugin_hook_fired"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "readonly_mode_changed"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "replay_footer"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "replay_header"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "session_ended"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "session_forked"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "session_loaded"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "session_saved"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "session_started"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "session_summary_written"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "skill_activated"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "skill_deactivated"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "subagent_completed"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "subagent_started"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "tool_completed"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "tool_confirmation_requested"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "tool_confirmation_resolved"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "tool_output_chunk"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "tool_result"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "tool_started"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "turn_completed"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "turn_started"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    },
+    {
+      "properties": {
+        "kind": {
+          "const": "user_message"
+        }
+      },
+      "required": [
+        "kind"
+      ],
+      "type": "object"
+    }
+  ],
+  "properties": {
+    "event_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "instance_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "kind": {
+      "enum": [
+        "ask_user_answered",
+        "ask_user_requested",
+        "assistant_text_chunk",
+        "assistant_thought_chunk",
+        "background_notification_injected",
+        "context_compressed",
+        "error",
+        "llm_call_completed",
+        "llm_call_delta",
+        "llm_call_io",
+        "llm_call_started",
+        "memory_cleared",
+        "memory_delete",
+        "memory_write",
+        "model_changed",
+        "permission_mode_changed",
+        "plugin_hook_fired",
+        "readonly_mode_changed",
+        "replay_footer",
+        "replay_header",
+        "session_ended",
+        "session_forked",
+        "session_loaded",
+        "session_saved",
+        "session_started",
+        "session_summary_written",
+        "skill_activated",
+        "skill_deactivated",
+        "subagent_completed",
+        "subagent_started",
+        "tool_completed",
+        "tool_confirmation_requested",
+        "tool_confirmation_resolved",
+        "tool_output_chunk",
+        "tool_result",
+        "tool_started",
+        "turn_completed",
+        "turn_started",
+        "user_message"
+      ],
+      "type": "string"
+    },
+    "parent_turn_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "payload": {
+      "additionalProperties": true,
+      "type": "object"
+    },
+    "seq": {
+      "minimum": 0,
+      "type": "integer"
+    },
+    "session_id": {
+      "minLength": 1,
+      "type": "string"
+    },
+    "ts": {
+      "format": "date-time",
+      "type": "string"
+    },
+    "turn_id": {
+      "type": [
+        "string",
+        "null"
+      ]
+    }
+  },
+  "required": [
+    "event_id",
+    "session_id",
+    "instance_id",
+    "seq",
+    "ts",
+    "kind",
+    "payload"
+  ],
+  "title": "Agentao replay event (v1.1)",
+  "type": "object"
+}

--- a/scripts/write_replay_schema.py
+++ b/scripts/write_replay_schema.py
@@ -1,0 +1,73 @@
+"""Regenerate replay-event JSON Schema files under ``schemas/``.
+
+Usage::
+
+    uv run python scripts/write_replay_schema.py          # rewrite files
+    uv run python scripts/write_replay_schema.py --check  # CI drift check
+
+In ``--check`` mode the script writes nothing; it compares the generator
+output to the committed file and exits non-zero on any drift, listing
+which schemas need regeneration. This is the contract that turns the
+emitter into a real anti-drift mechanism — without it, generation is
+just another way for the schemas to fall out of date.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+# Allow running as ``python scripts/write_replay_schema.py`` from the repo root.
+ROOT = Path(__file__).resolve().parent.parent
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from agentao.replay.schema import SUPPORTED_VERSIONS, render  # noqa: E402
+
+
+def _schema_path(version: str) -> Path:
+    return ROOT / "schemas" / f"replay-event-{version}.json"
+
+
+def _check() -> int:
+    drift = []
+    for version in SUPPORTED_VERSIONS:
+        path = _schema_path(version)
+        expected = render(version)
+        actual = path.read_text(encoding="utf-8") if path.exists() else ""
+        if expected != actual:
+            drift.append(path)
+    if drift:
+        print("Replay schema drift detected. Regenerate with:", file=sys.stderr)
+        print("    uv run python scripts/write_replay_schema.py", file=sys.stderr)
+        for path in drift:
+            print(f"  - {path.relative_to(ROOT)}", file=sys.stderr)
+        return 1
+    print("Replay schemas up to date.")
+    return 0
+
+
+def _write() -> int:
+    out_dir = ROOT / "schemas"
+    out_dir.mkdir(parents=True, exist_ok=True)
+    for version in SUPPORTED_VERSIONS:
+        path = _schema_path(version)
+        path.write_text(render(version), encoding="utf-8")
+        print(f"wrote {path.relative_to(ROOT)}")
+    return 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if committed schemas drift from the generator output.",
+    )
+    args = parser.parse_args(argv)
+    return _check() if args.check else _write()
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_replay_schema.py
+++ b/tests/test_replay_schema.py
@@ -1,0 +1,129 @@
+"""Replay schema generator + drift detection.
+
+These tests are the contract that makes the generator useful. The
+generator only matters if (a) committed files cannot drift from the
+code, and (b) the structural promises of the schema policy hold.
+Without these tests, ``schemas/`` is just another way for the format to
+fall out of sync.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from agentao.replay.events import EventKind, SCHEMA_VERSION
+from agentao.replay.schema import (
+    SUPPORTED_VERSIONS,
+    build_event_schema,
+    render,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+SCHEMAS_DIR = REPO_ROOT / "schemas"
+
+
+# ---------------------------------------------------------------------------
+# Drift detection: committed files must equal the generator output.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("version", SUPPORTED_VERSIONS)
+def test_committed_schema_matches_generator(version: str) -> None:
+    path = SCHEMAS_DIR / f"replay-event-{version}.json"
+    assert path.exists(), (
+        f"{path.relative_to(REPO_ROOT)} is missing. "
+        "Run: uv run python scripts/write_replay_schema.py"
+    )
+    expected = render(version)
+    actual = path.read_text(encoding="utf-8")
+    assert actual == expected, (
+        f"Schema drift for v{version}. "
+        "Run: uv run python scripts/write_replay_schema.py"
+    )
+
+
+def test_render_is_deterministic() -> None:
+    for version in SUPPORTED_VERSIONS:
+        first = render(version)
+        second = render(version)
+        assert first == second
+
+
+# ---------------------------------------------------------------------------
+# Structural invariants of the emitted schema.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("version", SUPPORTED_VERSIONS)
+def test_kind_enum_matches_eventkind(version: str) -> None:
+    schema = build_event_schema(version)
+    enum_kinds = set(schema["properties"]["kind"]["enum"])
+    expected = EventKind.V1_0 if version == "1.0" else EventKind.V1_1
+    assert enum_kinds == set(expected)
+
+
+@pytest.mark.parametrize("version", SUPPORTED_VERSIONS)
+def test_oneof_covers_every_kind(version: str) -> None:
+    schema = build_event_schema(version)
+    enum_kinds = set(schema["properties"]["kind"]["enum"])
+    variant_kinds = {
+        variant["properties"]["kind"]["const"] for variant in schema["oneOf"]
+    }
+    assert variant_kinds == enum_kinds
+
+
+@pytest.mark.parametrize("version", SUPPORTED_VERSIONS)
+def test_envelope_is_strict(version: str) -> None:
+    schema = build_event_schema(version)
+    assert schema["additionalProperties"] is False
+    required = set(schema["required"])
+    assert required == {
+        "event_id",
+        "session_id",
+        "instance_id",
+        "seq",
+        "ts",
+        "kind",
+        "payload",
+    }
+
+
+@pytest.mark.parametrize("version", SUPPORTED_VERSIONS)
+def test_payload_remains_lenient_until_per_kind_modeling(version: str) -> None:
+    """Until per-kind payload schemas land, payload stays lenient.
+
+    This test is intentionally a tripwire: the day we model a kind's
+    payload, this test changes shape (or splits per-kind). Better to
+    notice that explicitly than to silently regress to a free-form
+    payload everywhere.
+    """
+    schema = build_event_schema(version)
+    payload = schema["properties"]["payload"]
+    assert payload == {"type": "object", "additionalProperties": True}
+
+
+def test_v11_is_superset_of_v10() -> None:
+    """Backward-compat promise: 1.0 vocabulary survives into 1.1."""
+    assert EventKind.V1_0 <= EventKind.V1_1
+
+
+def test_schema_version_constant_matches_latest_supported() -> None:
+    """``SCHEMA_VERSION`` must always name the highest supported version."""
+    assert SCHEMA_VERSION == SUPPORTED_VERSIONS[-1]
+
+
+# ---------------------------------------------------------------------------
+# JSON validity: each schema file is parseable and references its own URN.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("version", SUPPORTED_VERSIONS)
+def test_committed_schema_is_valid_json(version: str) -> None:
+    path = SCHEMAS_DIR / f"replay-event-{version}.json"
+    data = json.loads(path.read_text(encoding="utf-8"))
+    assert data["$id"] == f"urn:agentao:schema:replay-event:{version}"
+    assert "oneOf" in data


### PR DESCRIPTION
## Summary

- Replay's `SCHEMA_VERSION = "1.1"` was a promise without a contract: version history lived in a docstring, no machine-checkable shape, drift was already compounding. This makes the schema a generated artefact with code as source of truth, and pins it via CI.
- Adds a discriminated-union JSON Schema emitter (`agentao/replay/schema.py`), committed schema files (`schemas/replay-event-{1.0,1.1}.json`), a regen + drift-check script, a fast-fail CI job, and a versioning policy doc.
- Defers per-kind payload tightening to follow-ups — current schemas are envelope-strict / payload-lenient with a tripwire test that will fire the first time a payload is modeled.

## Changes

- `agentao/replay/events.py` — split `EventKind.ALL` into versioned `V1_0` / `V1_1_NEW` / `V1_1` partitions; `ALL` kept as a back-compat alias. No production callers consume `ALL` directly.
- `agentao/replay/schema.py` — deterministic emitter producing `oneOf`-by-`kind` JSON Schema with strict envelope.
- `scripts/write_replay_schema.py` — regenerate (`uv run python scripts/...`) or `--check` (CI mode, non-zero on drift).
- `schemas/replay-event-{1.0,1.1}.json` — committed artefacts.
- `.github/workflows/ci.yml` — new `Schema drift` job runs `--check` (~30s) in parallel with the test matrix.
- `tests/test_replay_schema.py` — 15 tests covering drift, determinism, structural invariants, payload-lenient tripwire, 1.1 ⊇ 1.0, version-constant alignment.
- `docs/replay/schema-policy.md` — minor/major/deprecation rules, layer-by-layer unknown-fields policy, backward-compat guarantee.

## Test plan

- [x] `uv run python -m pytest tests/test_replay_schema.py -v` (15 passed)
- [x] `uv run python -m pytest tests/test_replay.py tests/test_replay_redact.py tests/test_replay_schema.py -q` (124 passed, no regression)
- [x] `uv run python scripts/write_replay_schema.py --check` (exit 0 after generation)
- [x] Verified drift detection: editing `schemas/replay-event-1.1.json` by hand → `--check` exits 1 with regen instructions
- [ ] CI `Schema drift` job green on this PR

## Follow-ups (intentionally not in this PR)

- Per-kind payload tightening — the `test_payload_remains_lenient_until_per_kind_modeling` tripwire will fail and force an explicit policy choice (lenient diagnostic kinds vs strict protocol kinds) per CLAUDE.md.
- jsonschema-based round-trip validator for writer output (needs `jsonschema` dependency, kept out of this PR to minimize blast radius).
- Same schema-as-contract treatment for `.agentao/acp.json` and `plugin.json` per the agreed ordering.

🤖 Generated with [Claude Code](https://claude.com/claude-code)