### PR TITLE
Release 0.2.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
         run: uvx twine check dist/*
 
       - name: Upload dist artifacts
-        uses: actions/upload-artifact@v8
+        uses: actions/upload-artifact@v7
         with:
           name: dist
           path: dist/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,10 +75,11 @@ drift gating, and the GitHub-Actions Node 24 prep.
 
 ### Packaging / CI
 
-- `actions/upload-artifact` v4 → v8, `actions/download-artifact` v4 →
+- `actions/upload-artifact` v4 → v7, `actions/download-artifact` v4 →
   v8, `actions/setup-python` v5 → v6 — clears the GitHub Node 24
-  default cutover (2026-06-02). `setup-uv` had already moved v6 → v7
-  in `0.2.14.dev0`.
+  default cutover (2026-06-02). (`upload-artifact` has no v8 line yet;
+  v7 is the current major.) `setup-uv` had already moved v6 → v7 in
+  `0.2.14.dev0`.
 - Version pins refreshed from `0.2.13` to `0.2.14` across `docs/ACP.md`
   and the developer-guide install / version-check examples.
 

--- a/docs/releases/v0.2.14.md
+++ b/docs/releases/v0.2.14.md
@@ -1,0 +1,98 @@
+# Agentao 0.2.14
+
+Maintenance follow-up to `0.2.13` GA. The headline is a **tool-call
+resilience layer** for local / open-source LLM backends whose
+function-call output drifts from the OpenAI tool-call schema, so the
+runtime can keep calling tools instead of crashing on minor
+formatting violations. The same release also carries per-session
+isolation polish, replay-schema drift gating in CI, the GitHub Actions
+Node 24 prep, and disk-bounded log rotation.
+
+No breaking changes. The full Added / Changed / Fixed / Packaging
+breakdown is in the [CHANGELOG.md `[0.2.14]` entry](../../CHANGELOG.md).
+
+## Highlights
+
+- **Tool-call repair / outbound sanitize subsystem** (`agentao/runtime/`):
+  three cooperating modules sit between the LLM and the tool dispatcher
+  so models like GLM, DeepSeek, Kimi and local Ollama still land in a
+  runnable shape.
+  - `arg_repair.py`: conservative JSON repair for malformed function
+    arguments — double-encoded JSON, fenced JSON, lenient Python
+    literals, trailing commas, bracket imbalance. No punctuation
+    guessing.
+  - `name_repair.py`: fuzzy matching that maps near-miss tool names
+    (CamelCase / suffix variants) onto a registered tool when the score
+    is unambiguous.
+  - `sanitize.py`: outbound scrubbing — replaces lone UTF-16 surrogates
+    and re-emits canonical compact JSON for repaired arguments before
+    assistant / tool messages reach strict provider APIs.
+
+  Wired into `chat_loop`, `tool_planning`, and `tool_runner`; repair is
+  invisible to the model itself (only logged), so prompt-cache
+  behaviour is preserved. Coverage:
+  `tests/test_tool_argument_repair.py`, `tests/test_tool_name_repair.py`,
+  `tests/test_outbound_sanitize.py`, helper `tests/support/tool_calls.py`.
+  Documented in developer-guide §5.1 ("Tool-call normalization").
+- **Per-instance background-task store**: the background-agent registry
+  is now per-`Agentao` instance rather than process-global, so
+  concurrent ACP sessions and multi-tenant embeddings no longer leak
+  handles across each other. Adds path-containment guards and prompt
+  diagnostics surfacing.
+- **Replay JSON Schema export + CI drift gate**: `agentao/replay/`
+  ships an exported JSON Schema (`tests/test_replay_schema.py`) and
+  fails fast in CI when `agentao/replay/events.py` evolves without the
+  schema being regenerated.
+- **`ToolRunner` decomposition**: the monolithic `tool_runner` was
+  split into focused `tool_planning`, `tool_runner` (executor), and
+  `tool_result_formatter` modules under `agentao/runtime/`. Public
+  `Agentao.chat()` contract preserved.
+- **Bounded log rotation**: `agentao.log` now uses
+  `RotatingFileHandler(maxBytes=10_000_000, backupCount=5)` instead of
+  a plain `FileHandler`, capping disk footprint at ~60 MB. The home-dir
+  fallback (`~/.agentao/agentao.log`) gets the same rotation. Long-
+  running sessions that previously grew the log into the hundreds of
+  megabytes now self-cap.
+
+## Packaging / CI
+
+- `actions/upload-artifact` v4 → v8, `actions/download-artifact` v4 →
+  v8, `actions/setup-python` v5 → v6 — clears the GitHub Node 24
+  default-runtime cutover (2026-06-02). `setup-uv` had already moved
+  v6 → v7 in `0.2.14.dev0`.
+- Version pins refreshed from `0.2.13` to `0.2.14` across `docs/ACP.md`
+  and the developer-guide install / version-check examples.
+
+## Release Summary
+
+- **Version:** `0.2.14`
+- **Git tag:** `v0.2.14`
+- **GitHub release type:** regular release, **not** pre-release
+- **Publish workflow:** `.github/workflows/publish.yml`
+
+## Install
+
+```bash
+pip install -U agentao
+```
+
+## Maintainer Checklist
+
+1. Ensure `agentao/__init__.py` reports `0.2.14`.
+2. Run the smoke path:
+   `uv run python -m pytest tests/ && uv build && uv run twine check dist/*`.
+3. Push the tag:
+
+   ```bash
+   git push origin v0.2.14
+   ```
+
+4. Create the GitHub release for `v0.2.14`.
+5. Leave **Set as a pre-release** unchecked so
+   `.github/workflows/publish.yml` publishes to PyPI (the workflow's
+   tag-vs-package version consistency check will validate alignment
+   before upload).
+
+## Full Changelog
+
+See [CHANGELOG.md](../../CHANGELOG.md) for the `0.2.14` entry.

--- a/docs/releases/v0.2.14.md
+++ b/docs/releases/v0.2.14.md
@@ -56,9 +56,10 @@ breakdown is in the [CHANGELOG.md `[0.2.14]` entry](../../CHANGELOG.md).
 
 ## Packaging / CI
 
-- `actions/upload-artifact` v4 → v8, `actions/download-artifact` v4 →
+- `actions/upload-artifact` v4 → v7, `actions/download-artifact` v4 →
   v8, `actions/setup-python` v5 → v6 — clears the GitHub Node 24
-  default-runtime cutover (2026-06-02). `setup-uv` had already moved
+  default-runtime cutover (2026-06-02). (`upload-artifact` has no v8
+  line yet; v7 is the current major.) `setup-uv` had already moved
   v6 → v7 in `0.2.14.dev0`.
 - Version pins refreshed from `0.2.13` to `0.2.14` across `docs/ACP.md`
   and the developer-guide install / version-check examples.


### PR DESCRIPTION
# Agentao 0.2.14

Maintenance follow-up to `0.2.13` GA. The headline is a **tool-call
resilience layer** for local / open-source LLM backends whose
function-call output drifts from the OpenAI tool-call schema, so the
runtime can keep calling tools instead of crashing on minor
formatting violations. The same release also carries per-session
isolation polish, replay-schema drift gating in CI, the GitHub Actions
Node 24 prep, and disk-bounded log rotation.

No breaking changes. The full Added / Changed / Fixed / Packaging
breakdown is in the [CHANGELOG.md `[0.2.14]` entry](../../CHANGELOG.md).

## Highlights

- **Tool-call repair / outbound sanitize subsystem** (`agentao/runtime/`):
  three cooperating modules sit between the LLM and the tool dispatcher
  so models like GLM, DeepSeek, Kimi and local Ollama still land in a
  runnable shape.
  - `arg_repair.py`: conservative JSON repair for malformed function
    arguments — double-encoded JSON, fenced JSON, lenient Python
    literals, trailing commas, bracket imbalance. No punctuation
    guessing.
  - `name_repair.py`: fuzzy matching that maps near-miss tool names
    (CamelCase / suffix variants) onto a registered tool when the score
    is unambiguous.
  - `sanitize.py`: outbound scrubbing — replaces lone UTF-16 surrogates
    and re-emits canonical compact JSON for repaired arguments before
    assistant / tool messages reach strict provider APIs.

  Wired into `chat_loop`, `tool_planning`, and `tool_runner`; repair is
  invisible to the model itself (only logged), so prompt-cache
  behaviour is preserved. Coverage:
  `tests/test_tool_argument_repair.py`, `tests/test_tool_name_repair.py`,
  `tests/test_outbound_sanitize.py`, helper `tests/support/tool_calls.py`.
  Documented in developer-guide §5.1 ("Tool-call normalization").
- **Per-instance background-task store**: the background-agent registry
  is now per-`Agentao` instance rather than process-global, so
  concurrent ACP sessions and multi-tenant embeddings no longer leak
  handles across each other. Adds path-containment guards and prompt
  diagnostics surfacing.
- **Replay JSON Schema export + CI drift gate**: `agentao/replay/`
  ships an exported JSON Schema (`tests/test_replay_schema.py`) and
  fails fast in CI when `agentao/replay/events.py` evolves without the
  schema being regenerated.
- **`ToolRunner` decomposition**: the monolithic `tool_runner` was
  split into focused `tool_planning`, `tool_runner` (executor), and
  `tool_result_formatter` modules under `agentao/runtime/`. Public
  `Agentao.chat()` contract preserved.
- **Bounded log rotation**: `agentao.log` now uses
  `RotatingFileHandler(maxBytes=10_000_000, backupCount=5)` instead of
  a plain `FileHandler`, capping disk footprint at ~60 MB. The home-dir
  fallback (`~/.agentao/agentao.log`) gets the same rotation. Long-
  running sessions that previously grew the log into the hundreds of
  megabytes now self-cap.

## Packaging / CI

- `actions/upload-artifact` v4 → v8, `actions/download-artifact` v4 →
  v8, `actions/setup-python` v5 → v6 — clears the GitHub Node 24
  default-runtime cutover (2026-06-02). `setup-uv` had already moved
  v6 → v7 in `0.2.14.dev0`.
- Version pins refreshed from `0.2.13` to `0.2.14` across `docs/ACP.md`
  and the developer-guide install / version-check examples.

## Release Summary

- **Version:** `0.2.14`
- **Git tag:** `v0.2.14`
- **GitHub release type:** regular release, **not** pre-release
- **Publish workflow:** `.github/workflows/publish.yml`

## Install

```bash
pip install -U agentao
```

## Maintainer Checklist

1. Ensure `agentao/__init__.py` reports `0.2.14`.
2. Run the smoke path:
   `uv run python -m pytest tests/ && uv build && uv run twine check dist/*`.
3. Push the tag:

   ```bash
   git push origin v0.2.14
   ```

4. Create the GitHub release for `v0.2.14`.
5. Leave **Set as a pre-release** unchecked so
   `.github/workflows/publish.yml` publishes to PyPI (the workflow's
   tag-vs-package version consistency check will validate alignment
   before upload).

## Full Changelog

See [CHANGELOG.md](../../CHANGELOG.md) for the `0.2.14` entry.
