### PR TITLE
chore: bump to 0.2.15.dev0

### DIFF
--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.2.14"
+__version__ = "0.2.15.dev0"
 
 # Lazy exports via PEP 562 module __getattr__.
 #


### PR DESCRIPTION
## Summary
- Standard post-release dev bump on `agentao/__init__.py` after `0.2.14` GA.
- Matches the naming convention from `ce83cc3` (`0.2.14.dev0`).

## Test plan
- [x] `uv run python -c 'import agentao; print(agentao.__version__)'` → `0.2.15.dev0`
- [ ] CI matrix passes