### PR TITLE
chore(release): 0.2.15

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ env/
 .agentao_memory.json
 chatagent.log
 *.log
+*.log.*
 .chatagent/
 .agentao/
 .claude/

--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.2.14"
+__version__ = "0.2.15.dev0"
 
 # Lazy exports via PEP 562 module __getattr__.
 #

--- a/agentao/acp/__main__.py
+++ b/agentao/acp/__main__.py
@@ -10,7 +10,16 @@ As subsequent issues land, each adds its own ``register(server)`` call below.
 
 import sys
 
-from . import initialize, session_cancel, session_load, session_new, session_prompt
+from . import (
+    initialize,
+    session_cancel,
+    session_list_models,
+    session_load,
+    session_new,
+    session_prompt,
+    session_set_mode,
+    session_set_model,
+)
 from .server import AcpServer
 
 
@@ -64,11 +73,14 @@ def _ensure_acp_utf8_stdio() -> None:
 def main() -> None:
     _ensure_acp_utf8_stdio()
     server = AcpServer()  # attaches to real sys.stdin / sys.stdout with guards
-    initialize.register(server)      # Issue 02: initialize handshake
-    session_new.register(server)     # Issue 04: session/new creation
-    session_prompt.register(server)  # Issue 06: session/prompt turn execution
-    session_cancel.register(server)  # Issue 09: session/cancel turn cancellation
-    session_load.register(server)    # Issue 10: session/load + history replay
+    initialize.register(server)
+    session_new.register(server)
+    session_prompt.register(server)
+    session_cancel.register(server)
+    session_load.register(server)
+    session_set_model.register(server)
+    session_set_mode.register(server)
+    session_list_models.register(server)
     server.run()
 
 

--- a/agentao/acp/_handler_utils.py
+++ b/agentao/acp/_handler_utils.py
@@ -1,0 +1,91 @@
+"""Internal helpers shared by ACP session/* handlers.
+
+Centralizes the boilerplate that gates every ``session/*`` request:
+
+  1. server has completed the ``initialize`` handshake
+  2. ``params`` is a JSON object
+  3. ``sessionId`` is a non-empty string
+  4. the session exists and is still active
+
+Existing handlers (``session_cancel``, ``session_load``, ``session_prompt``)
+predate this module and continue to inline the same checks; the helper is
+used by the newer ``set_model`` / ``set_mode`` / ``list_models`` modules.
+"""
+
+from __future__ import annotations
+
+import contextlib
+from typing import TYPE_CHECKING, Any, Iterator
+
+from .models import AcpSessionState
+from .protocol import INVALID_REQUEST, SERVER_NOT_INITIALIZED
+from .server import JsonRpcHandlerError
+from .session_manager import SessionNotFoundError
+
+if TYPE_CHECKING:
+    from .server import AcpServer
+
+
+def require_active_session(
+    server: "AcpServer", params: Any, method: str
+) -> AcpSessionState:
+    """Validate the request envelope and return the live session state.
+
+    Raises ``JsonRpcHandlerError(SERVER_NOT_INITIALIZED)`` if the connection
+    is pre-handshake, ``TypeError`` for bad param shape (the dispatcher maps
+    that to ``INVALID_PARAMS``), or ``JsonRpcHandlerError(INVALID_REQUEST)``
+    for unknown / closed sessions.
+    """
+    if not server.state.initialized:
+        raise JsonRpcHandlerError(
+            code=SERVER_NOT_INITIALIZED,
+            message=f"{method} called before initialize handshake",
+        )
+
+    if not isinstance(params, dict):
+        raise TypeError(f"{method} params must be a JSON object")
+
+    session_id = params.get("sessionId")
+    if not isinstance(session_id, str) or not session_id:
+        raise TypeError(f"{method}.sessionId must be a non-empty string")
+
+    try:
+        session = server.sessions.require(session_id)
+    except SessionNotFoundError:
+        raise JsonRpcHandlerError(
+            code=INVALID_REQUEST,
+            message=f"unknown sessionId: {session_id}",
+        )
+
+    if session.closed or session.agent is None:
+        raise JsonRpcHandlerError(
+            code=INVALID_REQUEST,
+            message=f"session {session_id} is not active",
+        )
+
+    return session
+
+
+@contextlib.contextmanager
+def hold_idle_turn_lock(session: AcpSessionState, method: str) -> Iterator[None]:
+    """Hold ``session.turn_lock`` for the duration of a state mutation.
+
+    The ACP dispatcher runs requests on a worker pool, so a model/mode
+    update racing an in-flight ``session/prompt`` would let the active
+    turn observe runtime changes mid-stream while the client is told the
+    switch already landed. Non-blocking acquire mirrors ``session_prompt``
+    (see ``session_prompt.py:182``) — we never queue dispatcher workers
+    behind a long-running turn; the client gets a clear error instead.
+    """
+    if not session.turn_lock.acquire(blocking=False):
+        raise JsonRpcHandlerError(
+            code=INVALID_REQUEST,
+            message=(
+                f"{method} rejected: session {session.session_id} has an "
+                "active turn; retry after it completes"
+            ),
+        )
+    try:
+        yield
+    finally:
+        session.turn_lock.release()

--- a/agentao/acp/models.py
+++ b/agentao/acp/models.py
@@ -14,7 +14,7 @@ import logging
 import threading
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Dict, Optional, Union
+from typing import TYPE_CHECKING, Any, Dict, List, Optional, Union
 
 from agentao.cancellation import CancellationToken
 
@@ -200,6 +200,7 @@ class AcpSessionState:
     turn_lock: threading.Lock = field(default_factory=threading.Lock)
     permission_overrides: Dict[str, bool] = field(default_factory=dict)
     permission_lock: threading.Lock = field(default_factory=threading.Lock)
+    last_known_models: Optional[List[str]] = None
     closed: bool = False
 
     def close(self) -> None:

--- a/agentao/acp/protocol.py
+++ b/agentao/acp/protocol.py
@@ -49,6 +49,9 @@ METHOD_SESSION_NEW = "session/new"
 METHOD_SESSION_PROMPT = "session/prompt"
 METHOD_SESSION_CANCEL = "session/cancel"
 METHOD_SESSION_LOAD = "session/load"
+METHOD_SESSION_SET_MODEL = "session/set_model"
+METHOD_SESSION_SET_MODE = "session/set_mode"
+METHOD_SESSION_LIST_MODELS = "session/list_models"
 
 # Server → client notifications
 METHOD_SESSION_UPDATE = "session/update"

--- a/agentao/acp/session_list_models.py
+++ b/agentao/acp/session_list_models.py
@@ -1,0 +1,49 @@
+"""ACP ``session/list_models`` handler.
+
+Lets the front end refresh the available-models catalog after the
+``initialize`` handshake. Reuses ``agent.list_available_models()``.
+
+Failure mode: on provider lookup failure the handler returns the cached
+list (or empty) plus a ``warning`` field, rather than a JSON-RPC error.
+A transient provider outage should not block the UI from rendering the
+last-known list. The cache lives on ``AcpSessionState.last_known_models``
+so it dies with the session — no module-level dict, no cross-session
+leakage, no manual eviction.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Dict
+
+from ._handler_utils import require_active_session
+from .protocol import METHOD_SESSION_LIST_MODELS
+
+if TYPE_CHECKING:
+    from .server import AcpServer
+
+logger = logging.getLogger(__name__)
+
+
+def handle_session_list_models(server: "AcpServer", params: Any) -> Dict[str, Any]:
+    session = require_active_session(server, params, METHOD_SESSION_LIST_MODELS)
+
+    try:
+        models = list(session.agent.list_available_models())
+        session.last_known_models = models
+        return {"models": models}
+    except Exception as e:
+        logger.warning(
+            "acp: session/list_models for %s failed: %s — returning cached list",
+            session.session_id,
+            e,
+        )
+        cached = session.last_known_models or []
+        return {"models": list(cached), "warning": f"Could not fetch model list: {e}"}
+
+
+def register(server: "AcpServer") -> None:
+    server.register(
+        METHOD_SESSION_LIST_MODELS,
+        lambda params: handle_session_list_models(server, params),
+    )

--- a/agentao/acp/session_set_mode.py
+++ b/agentao/acp/session_set_mode.py
@@ -1,0 +1,57 @@
+"""ACP ``session/set_mode`` handler.
+
+Updates a session's permission preset by calling
+``agent.permission_engine.set_mode(...)``. Per-session — each session owns
+its own ``PermissionEngine``, so a mode change on session A never affects
+session B.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Dict
+
+from agentao.permissions import PermissionMode
+
+from ._handler_utils import hold_idle_turn_lock, require_active_session
+from .protocol import INVALID_REQUEST, METHOD_SESSION_SET_MODE
+from .server import JsonRpcHandlerError
+
+if TYPE_CHECKING:
+    from .server import AcpServer
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_mode(value: Any) -> PermissionMode:
+    if not isinstance(value, str) or not value:
+        raise TypeError("session/set_mode.mode must be a non-empty string")
+    try:
+        return PermissionMode(value)
+    except ValueError:
+        valid = ", ".join(sorted(m.value for m in PermissionMode))
+        raise TypeError(f"session/set_mode.mode must be one of: {valid}")
+
+
+def handle_session_set_mode(server: "AcpServer", params: Any) -> Dict[str, Any]:
+    session = require_active_session(server, params, METHOD_SESSION_SET_MODE)
+    mode = _parse_mode(params.get("mode"))
+
+    if session.agent.permission_engine is None:
+        raise JsonRpcHandlerError(
+            code=INVALID_REQUEST,
+            message=f"session {session.session_id} has no permission engine to update",
+        )
+
+    # Hold turn_lock so an in-flight tool call cannot consult the engine
+    # mid-decision while we swap the active preset.
+    with hold_idle_turn_lock(session, METHOD_SESSION_SET_MODE):
+        session.agent.permission_engine.set_mode(mode)
+        return {"mode": session.agent.permission_engine.active_mode.value}
+
+
+def register(server: "AcpServer") -> None:
+    server.register(
+        METHOD_SESSION_SET_MODE,
+        lambda params: handle_session_set_mode(server, params),
+    )

--- a/agentao/acp/session_set_model.py
+++ b/agentao/acp/session_set_model.py
@@ -1,0 +1,84 @@
+"""ACP ``session/set_model`` handler.
+
+Three knobs, kept strictly separate. Wiring ``maxTokens`` to the context
+window would collapse the compression threshold (200K → a few K) and
+trigger runaway compression — that is the load-bearing reason this
+handler exists rather than a single overloaded "max_tokens" field::
+
+    model          -> agent.set_model()                 (active model id)
+    contextLength  -> agent.context_manager.max_tokens  (compression window)
+    maxTokens      -> agent.llm.max_tokens              (per-request cap)
+
+Returns the post-update values so the front end can confirm what landed
+when only a subset of fields was sent.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Dict
+
+from ._handler_utils import hold_idle_turn_lock, require_active_session
+from .protocol import METHOD_SESSION_SET_MODEL
+
+if TYPE_CHECKING:
+    from .server import AcpServer
+
+logger = logging.getLogger(__name__)
+
+
+def _parse_positive_int(value: Any, field: str) -> int:
+    # ``bool`` is a subclass of ``int`` in Python — reject explicitly so
+    # ``True`` / ``False`` don't slip through as 1 / 0.
+    if isinstance(value, bool) or not isinstance(value, int):
+        raise TypeError(f"session/set_model.{field} must be an integer")
+    if value <= 0:
+        raise TypeError(f"session/set_model.{field} must be > 0")
+    return value
+
+
+def handle_session_set_model(server: "AcpServer", params: Any) -> Dict[str, Any]:
+    session = require_active_session(server, params, METHOD_SESSION_SET_MODEL)
+
+    model = params.get("model")
+    context_length = params.get("contextLength")
+    max_tokens = params.get("maxTokens")
+
+    if model is None and context_length is None and max_tokens is None:
+        raise TypeError(
+            "session/set_model requires at least one of model / contextLength / maxTokens"
+        )
+
+    if model is not None and (not isinstance(model, str) or not model):
+        raise TypeError("session/set_model.model must be a non-empty string")
+    if context_length is not None:
+        context_length = _parse_positive_int(context_length, "contextLength")
+    if max_tokens is not None:
+        max_tokens = _parse_positive_int(max_tokens, "maxTokens")
+
+    agent = session.agent
+
+    # Apply each knob independently — a request carrying only ``model``
+    # must not reset the caller's existing contextLength / maxTokens.
+    # Holding turn_lock prevents an in-flight session/prompt from
+    # observing a model/window/cap change mid-stream.
+    with hold_idle_turn_lock(session, METHOD_SESSION_SET_MODEL):
+        if model is not None:
+            agent.set_model(model)
+        if context_length is not None:
+            agent.context_manager.max_tokens = context_length
+        if max_tokens is not None:
+            agent.llm.max_tokens = max_tokens
+
+        return {
+            "model": agent.llm.model,
+            "contextLength": agent.context_manager.max_tokens,
+            "maxTokens": agent.llm.max_tokens,
+        }
+
+
+def register(server: "AcpServer") -> None:
+    server.register(
+        METHOD_SESSION_SET_MODEL,
+        lambda params: handle_session_set_model(server, params),
+    )

--- a/agentao/llm/client.py
+++ b/agentao/llm/client.py
@@ -33,10 +33,14 @@ class _StreamToolCall:
 
 
 class _StreamMessage:
-    def __init__(self, content, tool_calls):
+    def __init__(self, content, tool_calls, reasoning_content: Optional[str] = None):
         self.content = content
         self.tool_calls = tool_calls
         self.role = "assistant"
+        # Mirrors the non-streaming `message.reasoning_content` attribute so
+        # chat_loop / context_manager / sanitize all see thinking-model output
+        # the same way regardless of streaming mode.
+        self.reasoning_content = reasoning_content
 
 
 class _StreamChoice:
@@ -55,6 +59,7 @@ class _StreamResponse:
         tool_calls_data: Dict[int, Dict[str, str]],
         finish_reason: str,
         usage: Any = None,
+        reasoning_content: Optional[str] = None,
     ):
         self.model = model
         self.usage = usage  # populated when provider supports stream_options include_usage
@@ -73,7 +78,11 @@ class _StreamResponse:
                 for idx in sorted(tool_calls_data)
             ]
 
-        message = _StreamMessage(content=content, tool_calls=tool_calls)
+        message = _StreamMessage(
+            content=content,
+            tool_calls=tool_calls,
+            reasoning_content=reasoning_content,
+        )
         self.choices = [_StreamChoice(message=message, finish_reason=finish_reason)]
 
 
@@ -134,8 +143,17 @@ class LLMClient:
         pkg_logger = logging.getLogger("agentao")
         pkg_logger.setLevel(logging.DEBUG)
 
-        # Remove existing handlers to avoid duplicates on hot-reload
-        pkg_logger.handlers.clear()
+        # Don't drop handlers we don't own (e.g. AcpServer's stderr guard).
+        # Tag our own and evict only the marked ones to avoid duplicates
+        # when LLMClient is reconstructed (which happens on every model
+        # switch in ACP mode).
+        for h in list(pkg_logger.handlers):
+            if getattr(h, "_agentao_llm_file_handler", False):
+                pkg_logger.removeHandler(h)
+                try:
+                    h.close()
+                except Exception:
+                    pass
 
         # File handler for detailed logs.
         #
@@ -158,6 +176,7 @@ class LLMClient:
         if file_handler is not None:
             file_handler.setLevel(logging.DEBUG)
             file_handler.setFormatter(file_formatter)
+            file_handler._agentao_llm_file_handler = True  # type: ignore[attr-defined]
             pkg_logger.addHandler(file_handler)
 
         # Request counter for tracking
@@ -516,6 +535,7 @@ class LLMClient:
             stream = self.client.chat.completions.create(**kwargs)
 
             content_parts: List[str] = []
+            reasoning_parts: List[str] = []
             tool_calls_data: Dict[int, Dict[str, str]] = {}
             finish_reason = "stop"
             response_model = self.model
@@ -537,6 +557,12 @@ class LLMClient:
                     content_parts.append(delta.content)
                     if on_text_chunk:
                         on_text_chunk(delta.content)
+
+                # Accumulate reasoning_content (DeepSeek/MiniMax/Kimi-style thinking
+                # field). Non-streaming exposes it on message.reasoning_content;
+                # without this branch the streaming path would silently drop it.
+                if delta and getattr(delta, "reasoning_content", None):
+                    reasoning_parts.append(delta.reasoning_content)
 
                 # Accumulate tool call deltas
                 if delta and delta.tool_calls:
@@ -574,6 +600,7 @@ class LLMClient:
                 tool_calls_data=tool_calls_data,
                 finish_reason=finish_reason,
                 usage=usage_data,
+                reasoning_content="".join(reasoning_parts) if reasoning_parts else None,
             )
 
             self._log_response(request_id, response)
@@ -590,6 +617,7 @@ class LLMClient:
                 try:
                     stream = self.client.chat.completions.create(**kwargs)
                     content_parts2: List[str] = []
+                    reasoning_parts2: List[str] = []
                     tool_calls_data2: Dict[int, Dict[str, str]] = {}
                     finish_reason2 = "stop"
                     response_model2 = self.model
@@ -605,6 +633,8 @@ class LLMClient:
                             content_parts2.append(delta.content)
                             if on_text_chunk:
                                 on_text_chunk(delta.content)
+                        if delta and getattr(delta, "reasoning_content", None):
+                            reasoning_parts2.append(delta.reasoning_content)
                         if delta and delta.tool_calls:
                             for tc_delta in delta.tool_calls:
                                 idx = tc_delta.index
@@ -630,6 +660,7 @@ class LLMClient:
                         tool_calls_data=tool_calls_data2,
                         finish_reason=finish_reason2,
                         usage=usage_data2,
+                        reasoning_content="".join(reasoning_parts2) if reasoning_parts2 else None,
                     )
                     self._log_response(request_id, response)
                     return response

--- a/agentao/tools/shell.py
+++ b/agentao/tools/shell.py
@@ -273,6 +273,11 @@ class ShellTool(Tool):
                     command,
                     shell=True,
                     cwd=cwd,
+                    # Detach stdin so we never inherit the parent's stdin —
+                    # under the ACP stdio transport the parent stdin is the
+                    # JSON-RPC channel, and a shell=True child inheriting it
+                    # can corrupt framing or deadlock.
+                    stdin=subprocess.DEVNULL,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
                     creationflags=subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS,
@@ -289,6 +294,7 @@ class ShellTool(Tool):
                     command,
                     shell=True,
                     cwd=cwd,
+                    stdin=subprocess.DEVNULL,
                     stdout=subprocess.DEVNULL,
                     stderr=subprocess.DEVNULL,
                     start_new_session=True,  # equivalent to preexec_fn=os.setsid
@@ -314,6 +320,9 @@ class ShellTool(Tool):
         popen_kwargs: Dict[str, Any] = dict(
             shell=True,
             cwd=cwd,
+            # See _run_background: never inherit parent stdin (JSON-RPC channel
+            # under ACP stdio).
+            stdin=subprocess.DEVNULL,
             stdout=subprocess.PIPE,
             stderr=subprocess.PIPE,
         )
@@ -356,6 +365,7 @@ class ShellTool(Tool):
                         # terminate the wrapper and leave children running.
                         subprocess.run(
                             ["taskkill", "/T", "/F", "/PID", str(proc.pid)],
+                            stdin=subprocess.DEVNULL,
                             capture_output=True,
                         )
                     else:

--- a/docs/implementation/ACP_STDIO_AUTH_FIX_PLAN.md
+++ b/docs/implementation/ACP_STDIO_AUTH_FIX_PLAN.md
@@ -1,0 +1,158 @@
+# ACP Stdio & Authorization Flow — Fix Plan (v2)
+
+Consolidated review of three issues found while debugging dynamic model
+configuration and the authorization flow under the ACP (Agent Communication
+Protocol) stdio transport. All three findings were independently verified
+against the current code on `chore/bump-0.2.15-dev`.
+
+## Fix order
+
+1. **P2 first** — restore reliable diagnostics; otherwise debugging signal
+   itself is unreliable and the file-handler pile-up amplifies log noise.
+2. **P1 next** — close the stdio-inheritance hole so authorization flows no
+   longer hang.
+3. **P3 / P3+ last** — on top of stable diagnostics + transport, add model
+   switching, context parameter sync, and the model-list interface.
+
+---
+
+## P1 — Shell subprocess inherits stdin (Critical)
+
+### Symptom
+`agentao/tools/shell.py:272` (Windows background), `agentao/tools/shell.py:288`
+(POSIX background), and `agentao/tools/shell.py:323` (foreground) all call
+`subprocess.Popen` without passing `stdin`. Under the ACP stdio transport the
+parent process's `sys.stdin` is the JSON-RPC channel; a `shell=True` child
+inherits that handle, and even incidental reads by the shell wrapper or by a
+`tee`/`cat`/`git`-like child can corrupt JSON-RPC framing — manifesting as
+hangs in tool calls (especially those that go through the authorization path).
+
+### Fix
+Pass `stdin=subprocess.DEVNULL` to every `Popen` in `shell.py`:
+
+- foreground execution
+- background execution (Windows + POSIX branches)
+- `taskkill` invocation in the timeout path (for consistency)
+
+Not Windows-only — POSIX is equally affected.
+
+### Acceptance
+- Foreground and background `ShellTool` `Popen` calls include
+  `stdin=subprocess.DEVNULL`.
+- Under ACP stdio, a tool call that requires authorization completes the
+  confirm/cancel round-trip without the child stealing stdin bytes.
+
+---
+
+## P2 — LLMClient log-handler dual constraint (High)
+
+### Symptom
+`agentao/acp/server.py:252-258` installs a stderr `StreamHandler` on the
+`agentao` package logger so ACP-mode diagnostics reach the host. Then
+`agentao/llm/client.py:147` calls `pkg_logger.handlers.clear()`, which
+removes that stderr handler. Conversely, removing the `clear()` naively
+would let repeated `LLMClient` construction (each model switch in ACP mode
+re-constructs the client) accumulate multiple `RotatingFileHandler`s — log
+lines would be written N times.
+
+Both constraints must hold:
+
+1. **Preserve handlers we don't own** (stderr handler installed by ACP, or
+   anything the host injected).
+2. **Avoid duplicate file handlers** across LLMClient reconstruction.
+
+### Fix
+Replace `pkg_logger.handlers.clear()` with marker-based selective cleanup:
+
+- Tag the file handler that LLMClient creates, e.g.
+  `handler._agentao_llm_file_handler = True`.
+- On (re)initialization, iterate `pkg_logger.handlers`, `removeHandler` +
+  `close()` only handlers carrying that marker, then `addHandler` the new
+  file handler.
+- Never call `handlers.clear()`.
+
+### Acceptance
+- After ACP installs its stderr handler, constructing `LLMClient` leaves
+  the stderr `StreamHandler` in place.
+- Constructing `LLMClient` N times in a row leaves at most one handler with
+  `_agentao_llm_file_handler = True` on the `agentao` logger; the log file
+  does not contain N-fold duplicate lines.
+
+---
+
+## P3 — ACP missing `set_model` / `set_mode` / `list_models` (Medium)
+
+### Symptom
+`agentao/acp/__main__.py:67-71` only registers `initialize`, `session/new`,
+`session/prompt`, `session/cancel`, and `session/load`.
+`agentao/acp/protocol.py` defines no `session/set_model`,
+`session/set_mode`, or `session/list_models` constants. Consequence:
+
+1. UI model switching returns `Method not found`.
+2. There is no way to push `contextLength` / `maxTokens` from the front end,
+   so the agent's context window is mis-configured and triggers improper
+   compression.
+3. The front end has no way to refresh the model list after `initialize`.
+
+### Interface contract — strict separation of three knobs
+The two `max_tokens` fields in the codebase are **not interchangeable**:
+
+| Frontend field   | Target attribute                           | Meaning                              |
+|------------------|--------------------------------------------|--------------------------------------|
+| `model`          | `agent.set_model()` (`runtime/model.py:51`)| Active model id                      |
+| `contextLength`  | `agent.context_manager.max_tokens`         | Context window — drives compression  |
+| `maxTokens`      | `agent.llm.max_tokens`                     | Per-request completion cap           |
+
+Rules:
+
+- The three knobs **never overwrite each other**.
+- A request that only carries `model` must not silently reset existing
+  `contextLength` / `maxTokens`.
+- Wiring `maxTokens` to `ContextManager.max_tokens` would collapse the
+  compression threshold (default 200K → small number) and cause runaway
+  compression — explicitly forbidden.
+
+### `session/set_mode`
+Updates the corresponding session's `permission_engine.active_mode` (see
+`agentao/permissions.py:208`). Per-session — must not affect other sessions.
+
+### `session/list_models` (P3+)
+Front end needs a way to refresh available models after `initialize`:
+
+- Implement `session/list_models`, reusing `agent.list_available_models()` or
+  the equivalent runtime helper.
+- Response schema must match `initialize.availableModels` so the front end
+  maintains a single schema.
+- **Failure behavior must be pinned down** — when the remote provider lookup
+  fails, choose **one** and document it:
+  - return a JSON-RPC error, or
+  - return cached / empty list with a warning field.
+
+### Acceptance
+- Before registration, `session/set_model` returns `Method not found`.
+- After implementation, `session/set_model` updates model + encoding cache +
+  context window correctly.
+- A single `session/set_model` call carrying both `contextLength` and
+  `maxTokens` writes them to `ContextManager.max_tokens` and
+  `LLMClient.max_tokens` respectively, with no cross-pollination.
+- A `session/set_model` call carrying only `model` does not reset existing
+  token configuration.
+- `session/set_mode` on session A does not change session B's `active_mode`.
+- `session/list_models` returns a payload whose schema matches
+  `initialize.availableModels`; simulated provider failure follows the
+  documented behavior (error vs. cached/empty + warning).
+
+---
+
+## File reference
+
+- `agentao/tools/shell.py:272` — Windows background `Popen`
+- `agentao/tools/shell.py:288` — POSIX background `Popen`
+- `agentao/tools/shell.py:323` — foreground `Popen`
+- `agentao/llm/client.py:147` — offending `pkg_logger.handlers.clear()`
+- `agentao/acp/server.py:252-258` — stderr `StreamHandler` install
+- `agentao/acp/__main__.py:67-71` — current handler registration list
+- `agentao/acp/protocol.py:48-54` — current `METHOD_*` constants
+- `agentao/runtime/model.py:51` — `set_model` runtime helper
+- `agentao/context_manager.py:78` — `ContextManager.max_tokens` (window)
+- `agentao/permissions.py:208` — `active_mode` for `set_mode`

--- a/tests/test_acp_session_set_model.py
+++ b/tests/test_acp_session_set_model.py
@@ -1,0 +1,484 @@
+"""Tests for P3 of ACP_STDIO_AUTH_FIX_PLAN.
+
+Covers ``session/set_model``, ``session/set_mode``, and
+``session/list_models``. Uses lightweight fakes rather than a real
+``Agentao`` runtime — the handlers only duck-type the agent.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Optional
+
+import pytest
+
+from agentao.acp import session_list_models as acp_list_models
+from agentao.acp import session_set_mode as acp_set_mode
+from agentao.acp import session_set_model as acp_set_model
+from agentao.acp.models import AcpSessionState
+from agentao.acp.protocol import (
+    INVALID_PARAMS,
+    INVALID_REQUEST,
+    METHOD_SESSION_LIST_MODELS,
+    METHOD_SESSION_SET_MODE,
+    METHOD_SESSION_SET_MODEL,
+    SERVER_NOT_INITIALIZED,
+)
+from agentao.acp.server import JsonRpcHandlerError
+from agentao.permissions import PermissionEngine, PermissionMode
+
+from .support.acp_server import make_initialized_server, make_server
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeLLM:
+    def __init__(self, model: str = "gpt-init", max_tokens: int = 4096):
+        self.model = model
+        self.max_tokens = max_tokens
+
+
+class _FakeContextManager:
+    def __init__(self, max_tokens: int = 200_000):
+        self.max_tokens = max_tokens
+        self._encoding = None
+        self._last_api_prompt_tokens = None
+
+
+class _FakeAgent:
+    def __init__(
+        self,
+        *,
+        model: str = "gpt-init",
+        llm_max_tokens: int = 4096,
+        ctx_max_tokens: int = 200_000,
+        models: Optional[List[str]] = None,
+        list_error: Optional[Exception] = None,
+        permission_engine: Optional[PermissionEngine] = None,
+    ):
+        self.llm = _FakeLLM(model=model, max_tokens=llm_max_tokens)
+        self.context_manager = _FakeContextManager(max_tokens=ctx_max_tokens)
+        self.permission_engine = permission_engine
+        self._models = models if models is not None else ["a", "b", "c"]
+        self._list_error = list_error
+        self.set_model_calls: List[str] = []
+
+    # API surface used by the handlers
+    def set_model(self, model: str) -> str:
+        self.set_model_calls.append(model)
+        self.llm.model = model
+        return f"changed to {model}"
+
+    def list_available_models(self) -> List[str]:
+        if self._list_error is not None:
+            raise self._list_error
+        return list(self._models)
+
+
+def _register_session(server, session_id: str, agent: _FakeAgent) -> AcpSessionState:
+    state = AcpSessionState(session_id=session_id)
+    state.agent = agent  # type: ignore[assignment]
+    server.sessions.create(state)
+    return state
+
+
+# ===========================================================================
+# session/set_model
+# ===========================================================================
+
+
+class TestSetModelGuards:
+    def test_pre_initialize_raises(self):
+        server = make_server()
+        with pytest.raises(JsonRpcHandlerError) as exc:
+            acp_set_model.handle_session_set_model(server, {"sessionId": "s", "model": "x"})
+        assert exc.value.code == SERVER_NOT_INITIALIZED
+
+    def test_params_must_be_dict(self):
+        server = make_initialized_server()
+        with pytest.raises(TypeError):
+            acp_set_model.handle_session_set_model(server, [])
+
+    def test_missing_session_id(self):
+        server = make_initialized_server()
+        with pytest.raises(TypeError):
+            acp_set_model.handle_session_set_model(server, {"model": "x"})
+
+    def test_unknown_session(self):
+        server = make_initialized_server()
+        with pytest.raises(JsonRpcHandlerError) as exc:
+            acp_set_model.handle_session_set_model(
+                server, {"sessionId": "nope", "model": "x"}
+            )
+        assert exc.value.code == INVALID_REQUEST
+
+    def test_no_fields_raises(self):
+        server = make_initialized_server()
+        _register_session(server, "s", _FakeAgent())
+        with pytest.raises(TypeError, match="at least one"):
+            acp_set_model.handle_session_set_model(server, {"sessionId": "s"})
+
+    def test_negative_context_length_rejected(self):
+        server = make_initialized_server()
+        _register_session(server, "s", _FakeAgent())
+        with pytest.raises(TypeError):
+            acp_set_model.handle_session_set_model(
+                server, {"sessionId": "s", "contextLength": 0}
+            )
+
+    def test_bool_max_tokens_rejected(self):
+        server = make_initialized_server()
+        _register_session(server, "s", _FakeAgent())
+        with pytest.raises(TypeError):
+            acp_set_model.handle_session_set_model(
+                server, {"sessionId": "s", "maxTokens": True}
+            )
+
+
+class TestSetModelKnobsAreIndependent:
+    def test_only_model_does_not_reset_token_caps(self):
+        server = make_initialized_server()
+        agent = _FakeAgent(llm_max_tokens=1234, ctx_max_tokens=99_999)
+        _register_session(server, "s", agent)
+
+        result = acp_set_model.handle_session_set_model(
+            server, {"sessionId": "s", "model": "gpt-new"}
+        )
+        assert agent.llm.model == "gpt-new"
+        assert agent.llm.max_tokens == 1234, "maxTokens must not be touched"
+        assert agent.context_manager.max_tokens == 99_999, (
+            "contextLength must not be touched"
+        )
+        assert result == {
+            "model": "gpt-new",
+            "contextLength": 99_999,
+            "maxTokens": 1234,
+        }
+
+    def test_context_length_only_writes_to_context_manager(self):
+        server = make_initialized_server()
+        agent = _FakeAgent(llm_max_tokens=5000, ctx_max_tokens=200_000)
+        _register_session(server, "s", agent)
+
+        acp_set_model.handle_session_set_model(
+            server, {"sessionId": "s", "contextLength": 500_000}
+        )
+        assert agent.context_manager.max_tokens == 500_000
+        assert agent.llm.max_tokens == 5000, (
+            "contextLength must NOT collapse the per-request completion cap"
+        )
+
+    def test_max_tokens_only_writes_to_llm(self):
+        server = make_initialized_server()
+        agent = _FakeAgent(llm_max_tokens=4096, ctx_max_tokens=200_000)
+        _register_session(server, "s", agent)
+
+        acp_set_model.handle_session_set_model(
+            server, {"sessionId": "s", "maxTokens": 8192}
+        )
+        assert agent.llm.max_tokens == 8192
+        assert agent.context_manager.max_tokens == 200_000, (
+            "maxTokens must NOT touch the context window"
+        )
+
+    def test_all_three_together_apply_separately(self):
+        """The critical anti-regression: a single request carrying all
+        three fields lands them on three distinct attributes — never
+        cross-pollinating maxTokens into the context window."""
+        server = make_initialized_server()
+        agent = _FakeAgent(
+            model="gpt-init", llm_max_tokens=4096, ctx_max_tokens=200_000
+        )
+        _register_session(server, "s", agent)
+
+        result = acp_set_model.handle_session_set_model(
+            server,
+            {
+                "sessionId": "s",
+                "model": "gpt-new",
+                "contextLength": 1_000_000,
+                "maxTokens": 16_000,
+            },
+        )
+        assert agent.llm.model == "gpt-new"
+        assert agent.context_manager.max_tokens == 1_000_000
+        assert agent.llm.max_tokens == 16_000
+        assert result == {
+            "model": "gpt-new",
+            "contextLength": 1_000_000,
+            "maxTokens": 16_000,
+        }
+
+
+# ===========================================================================
+# session/set_mode
+# ===========================================================================
+
+
+class TestSetMode:
+    def test_pre_initialize_raises(self):
+        server = make_server()
+        with pytest.raises(JsonRpcHandlerError) as exc:
+            acp_set_mode.handle_session_set_mode(
+                server, {"sessionId": "s", "mode": "read-only"}
+            )
+        assert exc.value.code == SERVER_NOT_INITIALIZED
+
+    def test_unknown_mode_rejected(self):
+        server = make_initialized_server()
+        agent = _FakeAgent(permission_engine=PermissionEngine())
+        _register_session(server, "s", agent)
+        with pytest.raises(TypeError):
+            acp_set_mode.handle_session_set_mode(
+                server, {"sessionId": "s", "mode": "yolo"}
+            )
+
+    def test_unknown_session(self):
+        server = make_initialized_server()
+        with pytest.raises(JsonRpcHandlerError) as exc:
+            acp_set_mode.handle_session_set_mode(
+                server, {"sessionId": "nope", "mode": "read-only"}
+            )
+        assert exc.value.code == INVALID_REQUEST
+
+    def test_applies_mode_to_session_engine(self):
+        server = make_initialized_server()
+        engine = PermissionEngine()
+        agent = _FakeAgent(permission_engine=engine)
+        _register_session(server, "s", agent)
+
+        result = acp_set_mode.handle_session_set_mode(
+            server, {"sessionId": "s", "mode": "read-only"}
+        )
+        assert result == {"mode": "read-only"}
+        assert engine.active_mode == PermissionMode.READ_ONLY
+
+    def test_does_not_affect_other_session(self):
+        """Critical isolation guarantee: each session owns its own
+        PermissionEngine; updating session A must not change session B."""
+        server = make_initialized_server()
+        engine_a = PermissionEngine()
+        engine_b = PermissionEngine()
+        _register_session(server, "a", _FakeAgent(permission_engine=engine_a))
+        _register_session(server, "b", _FakeAgent(permission_engine=engine_b))
+
+        acp_set_mode.handle_session_set_mode(
+            server, {"sessionId": "a", "mode": "read-only"}
+        )
+        assert engine_a.active_mode == PermissionMode.READ_ONLY
+        assert engine_b.active_mode == PermissionMode.WORKSPACE_WRITE
+
+
+# ===========================================================================
+# session/list_models
+# ===========================================================================
+
+
+class TestListModels:
+    def test_pre_initialize_raises(self):
+        server = make_server()
+        with pytest.raises(JsonRpcHandlerError) as exc:
+            acp_list_models.handle_session_list_models(server, {"sessionId": "s"})
+        assert exc.value.code == SERVER_NOT_INITIALIZED
+
+    def test_unknown_session(self):
+        server = make_initialized_server()
+        with pytest.raises(JsonRpcHandlerError) as exc:
+            acp_list_models.handle_session_list_models(server, {"sessionId": "nope"})
+        assert exc.value.code == INVALID_REQUEST
+
+    def test_returns_models_on_success(self):
+        server = make_initialized_server()
+        agent = _FakeAgent(models=["m1", "m2", "m3"])
+        _register_session(server, "s", agent)
+
+        result = acp_list_models.handle_session_list_models(
+            server, {"sessionId": "s"}
+        )
+        assert result == {"models": ["m1", "m2", "m3"]}
+
+    def test_failure_returns_empty_with_warning_when_no_cache(self):
+        server = make_initialized_server()
+        agent = _FakeAgent(list_error=RuntimeError("provider down"))
+        _register_session(server, "s", agent)
+
+        result = acp_list_models.handle_session_list_models(
+            server, {"sessionId": "s"}
+        )
+        assert result["models"] == []
+        assert "warning" in result
+        assert "provider down" in result["warning"]
+
+    def test_failure_returns_cached_list_with_warning(self):
+        server = make_initialized_server()
+        agent = _FakeAgent(models=["m1", "m2"])
+        _register_session(server, "s", agent)
+
+        # First call populates the cache.
+        first = acp_list_models.handle_session_list_models(
+            server, {"sessionId": "s"}
+        )
+        assert first["models"] == ["m1", "m2"]
+
+        # Now break the provider.
+        agent._list_error = RuntimeError("network error")
+        second = acp_list_models.handle_session_list_models(
+            server, {"sessionId": "s"}
+        )
+        assert second["models"] == ["m1", "m2"]
+        assert "warning" in second
+
+    def test_cache_is_per_session(self):
+        server = make_initialized_server()
+        agent_a = _FakeAgent(models=["a1", "a2"])
+        agent_b = _FakeAgent(models=["b1"])
+        _register_session(server, "a", agent_a)
+        _register_session(server, "b", agent_b)
+
+        ra = acp_list_models.handle_session_list_models(server, {"sessionId": "a"})
+        rb = acp_list_models.handle_session_list_models(server, {"sessionId": "b"})
+        assert ra == {"models": ["a1", "a2"]}
+        assert rb == {"models": ["b1"]}
+
+        # Break only B; A's cache should be untouched and still served.
+        agent_a._list_error = RuntimeError("a-down")
+        agent_b._list_error = RuntimeError("b-down")
+        ra2 = acp_list_models.handle_session_list_models(server, {"sessionId": "a"})
+        rb2 = acp_list_models.handle_session_list_models(server, {"sessionId": "b"})
+        assert ra2["models"] == ["a1", "a2"]
+        assert rb2["models"] == ["b1"]
+
+
+# ===========================================================================
+# Registration smoke tests
+# ===========================================================================
+
+
+def test_register_set_model():
+    server = make_initialized_server()
+    acp_set_model.register(server)
+    assert METHOD_SESSION_SET_MODEL in server._handlers
+
+
+def test_register_set_mode():
+    server = make_initialized_server()
+    acp_set_mode.register(server)
+    assert METHOD_SESSION_SET_MODE in server._handlers
+
+
+def test_register_list_models():
+    server = make_initialized_server()
+    acp_list_models.register(server)
+    assert METHOD_SESSION_LIST_MODELS in server._handlers
+
+
+def test_unregistered_methods_return_method_not_found():
+    """Sanity: before registration, set_model is genuinely missing — this
+    is the symptom users hit before the fix."""
+    server = make_initialized_server()
+    assert METHOD_SESSION_SET_MODEL not in server._handlers
+    assert METHOD_SESSION_SET_MODE not in server._handlers
+    assert METHOD_SESSION_LIST_MODELS not in server._handlers
+
+
+# ===========================================================================
+# Concurrency guard — set_model / set_mode reject during an active turn
+# ===========================================================================
+
+
+class TestActiveTurnGuard:
+    """Mutating handlers must not race an in-flight session/prompt.
+
+    The ACP dispatcher runs requests on a worker pool, so without a guard
+    a model swap could land mid-stream. ``hold_idle_turn_lock`` mirrors
+    the pattern from ``session_prompt.py:182``: non-blocking acquire,
+    reject with ``INVALID_REQUEST`` if the lock is held.
+    """
+
+    def test_set_model_rejected_while_turn_active(self):
+        server = make_initialized_server()
+        agent = _FakeAgent()
+        state = _register_session(server, "s", agent)
+        # Simulate session_prompt holding the lock for an in-flight turn.
+        assert state.turn_lock.acquire(blocking=False)
+        try:
+            with pytest.raises(JsonRpcHandlerError) as exc:
+                acp_set_model.handle_session_set_model(
+                    server, {"sessionId": "s", "model": "gpt-new"}
+                )
+            assert exc.value.code == INVALID_REQUEST
+            assert "active turn" in exc.value.message
+            # Critical: the rejected call must not have mutated anything.
+            assert agent.set_model_calls == []
+            assert agent.llm.model == "gpt-init"
+        finally:
+            state.turn_lock.release()
+
+    def test_set_model_succeeds_after_turn_releases(self):
+        server = make_initialized_server()
+        agent = _FakeAgent()
+        state = _register_session(server, "s", agent)
+        assert state.turn_lock.acquire(blocking=False)
+        state.turn_lock.release()  # turn ended
+
+        result = acp_set_model.handle_session_set_model(
+            server, {"sessionId": "s", "model": "gpt-new"}
+        )
+        assert result["model"] == "gpt-new"
+        # Lock is released after a successful update — next turn can run.
+        assert state.turn_lock.acquire(blocking=False)
+        state.turn_lock.release()
+
+    def test_set_mode_rejected_while_turn_active(self):
+        server = make_initialized_server()
+        engine = PermissionEngine()
+        state = _register_session(server, "s", _FakeAgent(permission_engine=engine))
+        assert state.turn_lock.acquire(blocking=False)
+        try:
+            with pytest.raises(JsonRpcHandlerError) as exc:
+                acp_set_mode.handle_session_set_mode(
+                    server, {"sessionId": "s", "mode": "read-only"}
+                )
+            assert exc.value.code == INVALID_REQUEST
+            assert "active turn" in exc.value.message
+            # Mode unchanged.
+            assert engine.active_mode == PermissionMode.WORKSPACE_WRITE
+        finally:
+            state.turn_lock.release()
+
+    def test_list_models_runs_during_active_turn(self):
+        """list_models is read-only — no lock required, so an in-flight
+        turn must not block catalog refreshes."""
+        server = make_initialized_server()
+        agent = _FakeAgent(models=["m1", "m2"])
+        state = _register_session(server, "s", agent)
+        assert state.turn_lock.acquire(blocking=False)
+        try:
+            result = acp_list_models.handle_session_list_models(
+                server, {"sessionId": "s"}
+            )
+            assert result == {"models": ["m1", "m2"]}
+        finally:
+            state.turn_lock.release()
+
+    def test_lock_released_on_handler_failure(self):
+        """If the mutation block raises, the lock must still release so a
+        retry — or the next session/prompt — can proceed."""
+        server = make_initialized_server()
+        agent = _FakeAgent()
+        # Make set_model raise mid-update.
+        def boom(_model):
+            raise RuntimeError("simulated failure")
+        agent.set_model = boom  # type: ignore[assignment]
+        state = _register_session(server, "s", agent)
+
+        with pytest.raises(RuntimeError, match="simulated failure"):
+            acp_set_model.handle_session_set_model(
+                server, {"sessionId": "s", "model": "gpt-new"}
+            )
+
+        # Lock must be free again.
+        assert state.turn_lock.acquire(blocking=False)
+        state.turn_lock.release()

--- a/tests/test_chat_stream_reasoning.py
+++ b/tests/test_chat_stream_reasoning.py
@@ -1,0 +1,166 @@
+"""Streaming path must accumulate ``delta.reasoning_content``.
+
+DeepSeek / MiniMax / Kimi / OpenAI o-series style endpoints emit
+``reasoning_content`` chunks alongside the regular ``content`` deltas. The
+non-streaming path already exposes them on ``message.reasoning_content``;
+this test pins down that ``chat_stream()`` does the same so thinking-model
+output is not silently dropped on streaming providers.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+
+def _chunk(content=None, reasoning=None, finish=None):
+    """Build a single SSE chunk with the fields chat_stream actually reads."""
+    delta = SimpleNamespace(
+        content=content,
+        tool_calls=None,
+        reasoning_content=reasoning,
+    )
+    choice = SimpleNamespace(delta=delta, finish_reason=finish)
+    return SimpleNamespace(
+        choices=[choice],
+        usage=None,
+        model="test-thinking-model",
+    )
+
+
+def _usage_only_chunk(prompt=10, completion=5):
+    return SimpleNamespace(
+        choices=[],
+        usage=SimpleNamespace(
+            prompt_tokens=prompt,
+            completion_tokens=completion,
+            total_tokens=prompt + completion,
+        ),
+        model="test-thinking-model",
+    )
+
+
+def _make_client():
+    """Construct a real LLMClient with the OpenAI SDK swapped for a Mock."""
+    with patch("agentao.llm.client.OpenAI") as openai_cls:
+        openai_cls.return_value = MagicMock()
+        from agentao.llm.client import LLMClient
+        client = LLMClient(
+            api_key="test-key",
+            base_url="https://example.test/v1",
+            model="test-thinking-model",
+        )
+    return client
+
+
+def test_chat_stream_accumulates_reasoning_content():
+    client = _make_client()
+
+    chunks = [
+        _chunk(reasoning="Let me "),
+        _chunk(reasoning="think step "),
+        _chunk(reasoning="by step.\n"),
+        _chunk(content="The answer is "),
+        _chunk(content="42.", finish="stop"),
+        _usage_only_chunk(),
+    ]
+    client.client.chat.completions.create = MagicMock(return_value=iter(chunks))
+
+    response = client.chat_stream(
+        messages=[{"role": "user", "content": "What is 6 * 7?"}],
+        tools=None,
+        max_tokens=128,
+    )
+
+    msg = response.choices[0].message
+    assert msg.content == "The answer is 42."
+    assert msg.reasoning_content == "Let me think step by step.\n"
+    assert response.choices[0].finish_reason == "stop"
+
+
+def test_chat_stream_reasoning_none_when_absent():
+    """Providers that don't emit reasoning_content must yield None, not ''."""
+    client = _make_client()
+
+    chunks = [
+        _chunk(content="hello"),
+        _chunk(content=" world", finish="stop"),
+        _usage_only_chunk(),
+    ]
+    client.client.chat.completions.create = MagicMock(return_value=iter(chunks))
+
+    response = client.chat_stream(
+        messages=[{"role": "user", "content": "hi"}],
+        tools=None,
+        max_tokens=64,
+    )
+
+    msg = response.choices[0].message
+    assert msg.content == "hello world"
+    assert msg.reasoning_content is None
+
+
+def test_chat_stream_reasoning_with_tool_calls():
+    """reasoning_content must coexist with tool_calls in the same response."""
+    client = _make_client()
+
+    tc_delta_open = SimpleNamespace(
+        index=0,
+        id="call_1",
+        function=SimpleNamespace(name="get_weather", arguments=""),
+    )
+    tc_delta_args = SimpleNamespace(
+        index=0,
+        id=None,
+        function=SimpleNamespace(name=None, arguments='{"city":"SF"}'),
+    )
+
+    chunks = [
+        _chunk(reasoning="I should check the weather."),
+        SimpleNamespace(
+            choices=[SimpleNamespace(
+                delta=SimpleNamespace(
+                    content=None,
+                    tool_calls=[tc_delta_open],
+                    reasoning_content=None,
+                ),
+                finish_reason=None,
+            )],
+            usage=None,
+            model="test-thinking-model",
+        ),
+        SimpleNamespace(
+            choices=[SimpleNamespace(
+                delta=SimpleNamespace(
+                    content=None,
+                    tool_calls=[tc_delta_args],
+                    reasoning_content=None,
+                ),
+                finish_reason="tool_calls",
+            )],
+            usage=None,
+            model="test-thinking-model",
+        ),
+        _usage_only_chunk(),
+    ]
+    client.client.chat.completions.create = MagicMock(return_value=iter(chunks))
+
+    response = client.chat_stream(
+        messages=[{"role": "user", "content": "weather?"}],
+        tools=[{"type": "function", "function": {"name": "get_weather"}}],
+        max_tokens=64,
+    )
+
+    msg = response.choices[0].message
+    assert msg.reasoning_content == "I should check the weather."
+    assert msg.tool_calls is not None
+    assert len(msg.tool_calls) == 1
+    assert msg.tool_calls[0].function.name == "get_weather"
+    assert msg.tool_calls[0].function.arguments == '{"city":"SF"}'
+
+
+if __name__ == "__main__":
+    test_chat_stream_accumulates_reasoning_content()
+    print("✓ accumulates reasoning_content")
+    test_chat_stream_reasoning_none_when_absent()
+    print("✓ reasoning is None when absent")
+    test_chat_stream_reasoning_with_tool_calls()
+    print("✓ reasoning coexists with tool_calls")

--- a/tests/test_llm_handler_marker.py
+++ b/tests/test_llm_handler_marker.py
@@ -1,0 +1,131 @@
+"""Tests for P2 of ACP_STDIO_AUTH_FIX_PLAN.
+
+The fix replaces ``pkg_logger.handlers.clear()`` with marker-based
+selective cleanup. Two invariants:
+
+1. Handlers we don't own (e.g. the stderr StreamHandler installed by
+   ``AcpServer._install_log_guard``) are preserved across LLMClient
+   construction.
+2. LLMClient-owned RotatingFileHandlers do not pile up across repeated
+   construction — only one carries the marker at any time.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+import pytest
+
+from agentao.llm.client import LLMClient
+
+
+@pytest.fixture(autouse=True)
+def _reset_pkg_logger():
+    pkg = logging.getLogger("agentao")
+    saved = list(pkg.handlers)
+    pkg.handlers = []
+    yield pkg
+    for h in pkg.handlers:
+        try:
+            h.close()
+        except Exception:
+            pass
+    pkg.handlers = saved
+
+
+def _marker_handlers(pkg):
+    return [h for h in pkg.handlers if getattr(h, "_agentao_llm_file_handler", False)]
+
+
+def test_external_stderr_handler_preserved(_reset_pkg_logger, tmp_path):
+    pkg = _reset_pkg_logger
+    # Mimic what AcpServer._install_log_guard does before LLMClient lands.
+    external = logging.StreamHandler(sys.stderr)
+    external.setLevel(logging.INFO)
+    pkg.addHandler(external)
+
+    LLMClient(
+        api_key="test-key",
+        base_url="https://api.example.com/v1",
+        model="gpt-test",
+        log_file=str(tmp_path / "agentao.log"),
+    )
+
+    assert external in pkg.handlers, (
+        "external stderr StreamHandler must survive LLMClient construction"
+    )
+
+
+def test_repeated_construction_yields_single_file_handler(_reset_pkg_logger, tmp_path):
+    pkg = _reset_pkg_logger
+    log_path = str(tmp_path / "agentao.log")
+
+    for _ in range(5):
+        LLMClient(
+            api_key="test-key",
+            base_url="https://api.example.com/v1",
+            model="gpt-test",
+            log_file=log_path,
+        )
+
+    marked = _marker_handlers(pkg)
+    assert len(marked) == 1, (
+        f"expected exactly one LLMClient-owned file handler, found {len(marked)}"
+    )
+
+
+def test_external_handler_count_unchanged_across_reconstruction(
+    _reset_pkg_logger, tmp_path
+):
+    pkg = _reset_pkg_logger
+    external_a = logging.StreamHandler(sys.stderr)
+    external_b = logging.StreamHandler(sys.stderr)
+    pkg.addHandler(external_a)
+    pkg.addHandler(external_b)
+    pre_external_count = sum(
+        1 for h in pkg.handlers
+        if h in (external_a, external_b)
+    )
+
+    log_path = str(tmp_path / "agentao.log")
+    for _ in range(3):
+        LLMClient(
+            api_key="test-key",
+            base_url="https://api.example.com/v1",
+            model="gpt-test",
+            log_file=log_path,
+        )
+
+    post_external_count = sum(
+        1 for h in pkg.handlers
+        if h in (external_a, external_b)
+    )
+    assert post_external_count == pre_external_count, (
+        "external handlers should be preserved 1:1"
+    )
+
+    marked = _marker_handlers(pkg)
+    assert len(marked) == 1
+
+
+def test_log_file_writes_only_once_per_message(_reset_pkg_logger, tmp_path):
+    """Constructing LLMClient N times must not cause N-fold duplicate
+    lines in the log file (the regression that an unguarded fix would
+    introduce)."""
+    log_path = tmp_path / "agentao.log"
+    for _ in range(4):
+        LLMClient(
+            api_key="test-key",
+            base_url="https://api.example.com/v1",
+            model="gpt-test",
+            log_file=str(log_path),
+        )
+
+    # Each LLMClient init logs "LLMClient initialized with model: gpt-test".
+    # Four constructions → exactly four such lines, not 1+2+3+4=10.
+    contents = log_path.read_text(encoding="utf-8")
+    occurrences = contents.count("LLMClient initialized with model: gpt-test")
+    assert occurrences == 4, (
+        f"expected 4 init log lines, got {occurrences} — duplicate handlers regression?"
+    )

--- a/tests/test_shell_stdin_devnull.py
+++ b/tests/test_shell_stdin_devnull.py
@@ -1,0 +1,105 @@
+"""Tests for P1 of ACP_STDIO_AUTH_FIX_PLAN.
+
+Verify ``ShellTool`` always passes ``stdin=subprocess.DEVNULL`` to its
+subprocesses. Under the ACP stdio transport the parent's stdin is the
+JSON-RPC channel; a ``shell=True`` child inheriting that handle can
+corrupt framing or deadlock the protocol.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+
+import pytest
+
+from agentao.tools.shell import ShellTool
+
+
+class _PopenSpy:
+    """Records every Popen invocation and exits cleanly without real I/O."""
+
+    instances: list = []
+
+    def __init__(self, *args, **kwargs):
+        self.args = args
+        self.kwargs = kwargs
+        self.pid = 4242
+        self.stdout = _DummyStream()
+        self.stderr = _DummyStream()
+        self.returncode = 0
+        _PopenSpy.instances.append(self)
+
+    def poll(self):
+        return 0
+
+    def wait(self, timeout=None):
+        return 0
+
+    def kill(self):
+        pass
+
+
+class _DummyStream:
+    def read(self, n=-1):
+        return b""
+
+    def close(self):
+        pass
+
+
+@pytest.fixture(autouse=True)
+def _reset_spy():
+    _PopenSpy.instances = []
+    yield
+    _PopenSpy.instances = []
+
+
+def _make_tool(tmp_path) -> ShellTool:
+    tool = ShellTool()
+    # Bind the tool's working directory so PathPolicy roots at tmp_path.
+    tool.working_directory = str(tmp_path)
+    return tool
+
+
+def test_foreground_popen_uses_devnull_stdin(monkeypatch, tmp_path):
+    monkeypatch.setattr(subprocess, "Popen", _PopenSpy)
+    tool = _make_tool(tmp_path)
+    tool.execute(command="echo hi", working_directory=".", timeout=1)
+    assert _PopenSpy.instances, "expected Popen to be invoked"
+    for inst in _PopenSpy.instances:
+        assert inst.kwargs.get("stdin") is subprocess.DEVNULL, (
+            f"foreground Popen missing stdin=DEVNULL: {inst.kwargs}"
+        )
+
+
+def test_background_popen_uses_devnull_stdin(monkeypatch, tmp_path):
+    monkeypatch.setattr(subprocess, "Popen", _PopenSpy)
+    # POSIX background path calls os.getpgid(proc.pid); _PopenSpy's pid
+    # isn't a real process, so stub getpgid to a no-op.
+    monkeypatch.setattr(os, "getpgid", lambda pid: pid)
+    tool = _make_tool(tmp_path)
+    tool.execute(
+        command="sleep 0.01",
+        working_directory=".",
+        timeout=1,
+        is_background=True,
+    )
+    assert _PopenSpy.instances, "expected Popen to be invoked"
+    for inst in _PopenSpy.instances:
+        assert inst.kwargs.get("stdin") is subprocess.DEVNULL, (
+            f"background Popen missing stdin=DEVNULL: {inst.kwargs}"
+        )
+
+
+def test_real_subprocess_sees_empty_stdin(tmp_path):
+    """End-to-end: spawn a real shell command that reads its own stdin and
+    print it. With stdin=DEVNULL the read returns empty; if we ever
+    regressed, the child would block on the test runner's stdin."""
+    tool = _make_tool(tmp_path)
+    out = tool.execute(
+        command='python -c "import sys; sys.stdout.write(repr(sys.stdin.read()))"',
+        working_directory=".",
+        timeout=5,
+    )
+    assert "''" in out, f"child should see empty stdin; got: {out!r}"


### PR DESCRIPTION
## Summary

Ship Agentao 0.2.15 — already tagged as [v0.2.15](https://github.com/jin-bo/agentao/releases/tag/v0.2.15) and live on PyPI.

- **ACP control-plane parity**: `session/set_model`, `session/set_mode`, `session/list_models` handlers + shared `_handler_utils.require_active_session`
- **LLMClient**: preserve outsider log handlers across reconstruction (only evict `_agentao_llm_file_handler`-tagged); capture `reasoning_content` in streaming mode
- **Shell tool**: `stdin=DEVNULL` so children cannot consume the ACP JSON-RPC stdin channel

Full breakdown: [`docs/releases/v0.2.15.md`](docs/releases/v0.2.15.md) · [CHANGELOG `[0.2.15]`](CHANGELOG.md)

Three commits:
- `9a100c3` chore: bump to 0.2.15.dev0
- `7f9404a` feat(acp): add set_model/set_mode/list_models + stdio safety fixes
- `309b6aa` chore(release): 0.2.15 — drop `.dev0`, add CHANGELOG + release notes

## Test plan

- [x] Local: `pytest tests/` — 2028 passed, 1 skipped
- [x] Local: `uv build` — 0.2.15 sdist + wheel
- [x] Local: `twine check dist/*` — PASSED
- [x] CI publish workflow `25004531966` — success (1m41s)
- [x] PyPI simple index — wheel + sdist + provenance live

🤖 Generated with [Claude Code](https://claude.com/claude-code)