### PR TITLE
chore(release): land 0.2.15 release files on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,76 @@ _No changes yet._
 
 ---
 
+## [0.2.15] — 2026-04-27
+
+Maintenance follow-up to `0.2.14`. Headline: **ACP control-plane
+parity** — `session/set_model`, `session/set_mode`, and
+`session/list_models` handlers land so ACP clients (Zed and others)
+can drive model switching, permission-mode toggles, and capability
+discovery on a live session. The same release fixes three
+correctness gaps around the ACP stdio channel and streaming
+`reasoning_content`.
+
+### Added
+
+- **`session/set_model` handler** (`agentao/acp/session_set_model.py`):
+  apply `model` / `contextLength` / `maxTokens` independently on a
+  running session via `agent.set_model()` and `agent.context_manager.max_tokens`
+  / `agent.llm.max_tokens`. Each knob is optional; partial requests
+  do not reset untouched fields. Holds the session's idle turn lock
+  so an in-flight `session/prompt` cannot observe a mid-stream
+  change. Conversation history and tool state are preserved.
+- **`session/set_mode` handler** (`agentao/acp/session_set_mode.py`):
+  toggle `PermissionEngine` mode (`default` / `acceptEdits` /
+  `bypassPermissions` / `plan`) per session via
+  `permission_engine.set_mode(...)`.
+- **`session/list_models` handler** (`agentao/acp/session_list_models.py`):
+  call `agent.list_available_models()` and cache the result on
+  `AcpSessionState.last_known_models`. On provider lookup failure,
+  returns the cached list plus a `warning` field instead of a
+  JSON-RPC error so transient provider outages don't blank the UI.
+- **Shared session-validation helper**
+  (`agentao/acp/_handler_utils.py`): single point for "does this
+  `session_id` exist, is it ours, did the client send a well-formed
+  request" so each new handler does not re-derive the contract.
+- **Streaming `reasoning_content` capture** (`agentao/llm/client.py`):
+  thinking-model output arriving on the streaming `delta` is now
+  forwarded the same way as the non-streaming
+  `message.reasoning_content` field, so transport `THINKING` events
+  no longer drop reasoning text from streaming backends.
+- **Test coverage** for all of the above:
+  `tests/test_acp_session_set_model.py` (484 lines, 31 cases),
+  `tests/test_chat_stream_reasoning.py`,
+  `tests/test_llm_handler_marker.py`,
+  `tests/test_shell_stdin_devnull.py`.
+
+### Fixed
+
+- **Outsider log handlers preserved across `LLMClient` reconstruction**
+  (`agentao/llm/client.py`): the package-root handler eviction now
+  only drops handlers tagged with `_agentao_llm_file_handler=True`.
+  Previously, every `LLMClient` rebuild (which `set_model` triggers,
+  and which the test suite triggers repeatedly) silently evicted
+  unrelated handlers — including the `AcpServer` stderr-guard handler
+  that protects the ACP JSON-RPC stdout/stdin channel.
+- **Shell subprocess no longer inherits parent stdin**
+  (`agentao/tools/shell.py`): `Popen(..., stdin=subprocess.DEVNULL)`.
+  Children that read from stdin (interactive prompts, `read`-style
+  tooling) can no longer consume bytes from the ACP JSON-RPC stdin
+  channel that the parent process owns.
+
+### Packaging
+
+- `.gitignore`: ignore rotated `*.log.*` files (avoid tracking the
+  bounded-rotation artifacts introduced in `0.2.14`).
+- `.github/workflows/ci.yml`: `actions/upload-artifact` pinned at v7
+  (v8 does not exist; resolved on-branch in `e84fc0b`).
+
+See [`docs/releases/v0.2.15.md`](docs/releases/v0.2.15.md) for the
+release summary and maintainer checklist.
+
+---
+
 ## [0.2.14] — 2026-04-25
 
 Maintenance follow-up to `0.2.13` GA. Headline: **tool-call resilience

--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.2.15.dev0"
+__version__ = "0.2.15"
 
 # Lazy exports via PEP 562 module __getattr__.
 #

--- a/docs/releases/v0.2.15.md
+++ b/docs/releases/v0.2.15.md
@@ -1,0 +1,109 @@
+# Agentao 0.2.15
+
+Maintenance follow-up to `0.2.14`. Headline: **ACP control-plane
+parity** — the missing `session/set_model`, `session/set_mode`, and
+`session/list_models` handlers land so Zed and other ACP clients can
+drive model switching, permission-mode toggles, and capability
+discovery without falling back to environment-restart workarounds.
+The same release also carries three correctness fixes around the ACP
+stdio channel and an LLM streaming gap that affected thinking-model
+backends.
+
+No breaking changes. The full Added / Fixed / Packaging breakdown is
+in the [CHANGELOG.md `[0.2.15]` entry](../../CHANGELOG.md).
+
+## Highlights
+
+- **Three new ACP session handlers** (`agentao/acp/session_set_model.py`,
+  `session_set_mode.py`, `session_list_models.py`):
+  - `session/set_model` — apply `model` / `contextLength` / `maxTokens`
+    independently on a running session via `agent.set_model()` and
+    `agent.context_manager.max_tokens` / `agent.llm.max_tokens`.
+    Each knob is optional; a request carrying only `model` does not
+    reset the caller's existing context/cap. The handler holds the
+    session's idle turn lock so an in-flight `session/prompt` cannot
+    observe a model/window/cap change mid-stream. Conversation
+    history and tool state are preserved.
+  - `session/set_mode` — toggle `PermissionEngine` permission mode
+    (`default` / `acceptEdits` / `bypassPermissions` / `plan`) per
+    session, matching ACP's permission-mode contract.
+  - `session/list_models` — call `agent.list_available_models()` and
+    cache the result on `AcpSessionState.last_known_models`. On
+    provider lookup failure, returns the cached list with a
+    `warning` field instead of a JSON-RPC error so a transient
+    outage doesn't blank the UI.
+  - Shared session-validation helper in `agentao/acp/_handler_utils.py`
+    (single point for "does this `session_id` exist, is it ours,
+    did the client send a well-formed request").
+- **Preserve outsider log handlers across `LLMClient` reconstruction**
+  (`agentao/llm/client.py`): the package-root logger eviction now only
+  drops handlers tagged with `_agentao_llm_file_handler=True`. The ACP
+  stderr-guard handler installed by `AcpServer` is no longer collateral
+  damage when `set_model` or repeated test reconstructions trigger a
+  new `LLMClient`.
+- **Capture `reasoning_content` in streaming mode** (`agentao/llm/client.py`):
+  thinking-model output that arrives on the streaming `delta` was
+  silently dropped while non-streaming `message.reasoning_content`
+  worked. Streaming now mirrors the non-streaming path so reasoning
+  text reaches the transport `THINKING` event without backend-shape
+  drift.
+- **Detach subprocess stdin in the shell tool** (`agentao/tools/shell.py`):
+  `subprocess.Popen(..., stdin=subprocess.DEVNULL)` so any child
+  process that reads stdin (e.g. an interactive prompt slipped into a
+  shell call) cannot consume — and corrupt — the ACP JSON-RPC stdin
+  channel that the parent process owns.
+
+## Tests
+
+- `tests/test_acp_session_set_model.py` — 484 lines / 31 cases covering
+  set_model, set_mode, list_models, including permission-engine
+  interaction, session-id validation, and error paths.
+- `tests/test_chat_stream_reasoning.py` — verifies the streaming
+  reasoning_content capture matches non-streaming behaviour.
+- `tests/test_llm_handler_marker.py` — asserts handler tagging and
+  preservation across repeated `LLMClient` reconstruction (the
+  scenario `set_model` triggers).
+- `tests/test_shell_stdin_devnull.py` — confirms subprocess `stdin` is
+  detached from the parent's stdin in the shell tool.
+
+## Packaging / CI
+
+- `.gitignore`: ignore rotated `*.log.*` files (avoid tracking the
+  bounded-rotation artifacts introduced in `0.2.14`).
+- `.github/workflows/ci.yml`: `actions/upload-artifact` pinned at v7
+  (v8 does not exist; resolved on-branch in commit `e84fc0b`).
+
+## Release Summary
+
+- **Version:** `0.2.15`
+- **Git tag:** `v0.2.15`
+- **GitHub release type:** regular release, **not** pre-release
+- **Publish workflow:** `.github/workflows/publish.yml`
+
+## Install
+
+```bash
+pip install -U agentao
+```
+
+## Maintainer Checklist
+
+1. Ensure `agentao/__init__.py` reports `0.2.15` (drop the `.dev0`
+   suffix from `0.2.15.dev0`).
+2. Run the smoke path:
+   `uv run python -m pytest tests/ && uv build && uv run twine check dist/*`.
+3. Push the tag:
+
+   ```bash
+   git push origin v0.2.15
+   ```
+
+4. Create the GitHub release for `v0.2.15`.
+5. Leave **Set as a pre-release** unchecked so
+   `.github/workflows/publish.yml` publishes to PyPI (the workflow's
+   tag-vs-package version consistency check will validate alignment
+   before upload).
+
+## Full Changelog
+
+See [CHANGELOG.md](../../CHANGELOG.md) for the `0.2.15` entry.


### PR DESCRIPTION
## Summary

Recover the `chore(release): 0.2.15` commit that was missing from #5.

The v0.2.15 tag and the GitHub Release point at the original commit `309b6aa` (which built and shipped to PyPI correctly), but that commit was never pushed to the PR branch — the branch on origin stopped at the `feat(acp)` commit, so #5 only contained 2 of the 3 release commits. As a result, `main` still reports `__version__ = "0.2.15.dev0"` and is missing the CHANGELOG entry and release notes.

This PR cherry-picks `309b6aa` onto `main` so the published version, the CHANGELOG, and the release notes file are all consistent again. No source / runtime changes — only:

- `agentao/__init__.py`: `0.2.15.dev0` → `0.2.15`
- `CHANGELOG.md`: add `[0.2.15] — 2026-04-27` block
- `docs/releases/v0.2.15.md`: new release notes (already linked from the GitHub Release page)

## Test plan

- [x] PyPI 0.2.15 already live (sdist + wheel + provenance, published from tag `v0.2.15`)
- [x] Cherry-pick applies cleanly onto `origin/main`
- [x] `agentao/__init__.py` reports `0.2.15`
- [x] `docs/releases/v0.2.15.md` matches the v0.2.14 convention

🤖 Generated with [Claude Code](https://claude.com/claude-code)