### PR TITLE
feat(harness): embedded-harness foundations (#9-#13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,43 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-_No changes yet._
+### Added
+
+- **Embedded harness foundations** (Issues #9-#13). Agentao is now
+  positioned as an embedded agent runtime that hosts can drop into
+  their own apps without the implicit cwd/env/.agentao/ side effects
+  the CLI relies on. Headline pieces:
+  - `agentao.capabilities.FileSystem` / `ShellExecutor` protocols
+    plus `LocalFileSystem` / `LocalShellExecutor` defaults. File,
+    search, and shell tools route through them, so embedded hosts
+    can swap in Docker exec, virtual filesystems, or remote runners
+    without monkey-patching `subprocess` / `pathlib`.
+  - `agentao.embedding.build_from_environment(...)` factory that
+    captures every implicit `.env` / `.agentao/permissions.json` /
+    `.agentao/mcp.json` / cwd read in one place. CLI and ACP route
+    through it so subsystem fallbacks become dead code from their
+    perspective.
+  - `Agentao.__init__` accepts explicit injections for
+    `llm_client`, `logger`, `memory_manager`, `skill_manager`,
+    `project_instructions`, `mcp_manager`, `filesystem`, and
+    `shell`. When `skill_manager` or `project_instructions` is
+    injected, the auto-discovery / disk-read paths are skipped.
+  - `Agentao.arun(...)` async surface that bridges sync chat
+    internals through `loop.run_in_executor`. Async hosts can
+    `await agent.arun(...)` without rolling their own thread
+    bridge; cancellation, replay, and `max_iterations` behave
+    identically across `chat()` and `arun()`.
+- Sub-agent construction in `agentao/agents/tools.py` no longer
+  re-reads provider env vars (`{PROVIDER}_API_KEY` / `_BASE_URL`).
+  Children inherit the parent's already-resolved LLM config so a
+  mid-run env mutation cannot create a credential split.
+
+### Deprecated
+
+- `Agentao()` without `working_directory=` emits a `DeprecationWarning`
+  and will become a `TypeError` in 0.3.0. Pass an explicit `Path` —
+  or use `agentao.embedding.build_from_environment()` for CLI-style
+  cwd / `.env` / `.agentao/` auto-discovery.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -744,13 +744,13 @@ transport = SdkTransport(
     on_event=events.append,           # receive typed AgentEvents
     confirm_tool=lambda n, d, a: True,  # auto-approve all tools
 )
-agent = Agentao(transport=transport)
+agent = Agentao(transport=transport, working_directory=Path.cwd())
 response = agent.chat("Summarize the current directory")
 ```
 
 `SdkTransport` accepts four optional callbacks: `on_event`, `confirm_tool`, `ask_user`, `on_max_iterations`. Omit any you don't need — unset ones fall back to safe defaults (auto-approve, sentinel for ask_user, stop on max iterations).
 
-For fully silent headless use with no callbacks, just `Agentao()` — it uses `NullTransport` automatically.
+For fully silent headless use with no callbacks, use `Agentao(working_directory=Path.cwd())` — it uses `NullTransport` automatically. Embedded hosts that want CLI-style auto-discovery of `.env` and `.agentao/` can route through `agentao.embedding.build_from_environment()` instead.
 
 ### ACP (Agent Client Protocol) Mode
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -736,13 +736,13 @@ transport = SdkTransport(
     on_event=events.append,              # 接收类型化的 AgentEvent
     confirm_tool=lambda n, d, a: True,   # 自动允许所有工具
 )
-agent = Agentao(transport=transport)
+agent = Agentao(transport=transport, working_directory=Path.cwd())
 response = agent.chat("总结当前目录")
 ```
 
 `SdkTransport` 接受四个可选回调：`on_event`、`confirm_tool`、`ask_user`、`on_max_iterations`。未设置的回调使用安全默认值（自动允许、ask_user 返回提示信息、超出最大迭代次数时停止）。
 
-如需完全静默的无头模式，直接 `Agentao()` 即可——自动使用 `NullTransport`。
+如需完全静默的无头模式，使用 `Agentao(working_directory=Path.cwd())` 即可——自动使用 `NullTransport`。需要 CLI 风格的 `.env` / `.agentao/` 自动发现时，请改用 `agentao.embedding.build_from_environment()`。
 
 ### ACP（Agent Client Protocol）模式
 

--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.2.15"
+__version__ = "0.2.16.dev0"
 
 # Lazy exports via PEP 562 module __getattr__.
 #

--- a/agentao/acp/session_new.py
+++ b/agentao/acp/session_new.py
@@ -104,15 +104,17 @@ def default_agent_factory(
     """
     # Local import avoids pulling openai/tools/llm into the ACP package
     # at import time — handler modules stay lightweight for testing.
-    from agentao.agent import Agentao
+    from agentao.embedding import build_from_environment
 
-    return Agentao(
-        model=model or None,  # empty string from missing field → default
-        permission_engine=permission_engine,
-        transport=transport,
-        working_directory=cwd,
-        extra_mcp_servers=mcp_servers,
-    )
+    overrides: Dict[str, Any] = {
+        "permission_engine": permission_engine,
+        "transport": transport,
+        "extra_mcp_servers": mcp_servers,
+    }
+    if model:  # empty string / None → use default discovered by factory
+        overrides["model"] = model
+
+    return build_from_environment(working_directory=cwd, **overrides)
 
 
 # ---------------------------------------------------------------------------

--- a/agentao/acp/transport.py
+++ b/agentao/acp/transport.py
@@ -277,6 +277,8 @@ class ACPTransport:
             update = self._build_update(event)
             if update is None:
                 return  # silent event (e.g. TURN_START)
+            # Stamp the runtime payload version (independent of ACP_PROTOCOL_VERSION).
+            update["schema_version"] = event.schema_version
             self._server.write_notification(
                 METHOD_SESSION_UPDATE,
                 {"sessionId": self._session_id, "update": update},

--- a/agentao/agent.py
+++ b/agentao/agent.py
@@ -1,7 +1,10 @@
 """Main agent logic for Agentao."""
 
+import asyncio
+import logging
+import warnings
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
 
 from .llm import LLMClient
 from .permissions import PermissionEngine
@@ -39,6 +42,10 @@ from .replay.observability import (
 from .sandbox import SandboxPolicy
 from .transport import NullTransport, build_compat_transport
 
+if TYPE_CHECKING:
+    from .capabilities import FileSystem, ShellExecutor
+    from .memory import MemoryManager  # noqa: F401
+
 
 class Agentao:
     """Agentao agent with tool, skill, and MCP support."""
@@ -65,6 +72,15 @@ class Agentao:
         *,
         working_directory: Optional[Path] = None,
         extra_mcp_servers: Optional[Dict[str, Dict[str, Any]]] = None,
+        # Embedded-harness explicit-injection kwargs.
+        llm_client: Optional[LLMClient] = None,
+        logger: Optional[logging.Logger] = None,
+        memory_manager: Optional["MemoryManager"] = None,
+        skill_manager: Optional[SkillManager] = None,
+        project_instructions: Optional[str] = None,
+        mcp_manager: Optional[McpClientManager] = None,
+        filesystem: Optional["FileSystem"] = None,
+        shell: Optional["ShellExecutor"] = None,
     ):
         """Initialize Agentao agent.
 
@@ -103,6 +119,31 @@ class Agentao:
             output_callback, tool_complete_callback, llm_text_callback,
             on_max_iterations_callback.
         """
+        # A fully-constructed object always wins over its raw-config
+        # sibling; supplying both is a programmer error.
+        if llm_client is not None and any(
+            v is not None for v in (api_key, base_url, model, temperature)
+        ):
+            raise ValueError(
+                "Agentao(): pass either llm_client= or "
+                "api_key/base_url/model/temperature, not both."
+            )
+        if mcp_manager is not None and extra_mcp_servers is not None:
+            raise ValueError(
+                "Agentao(): pass either mcp_manager= or extra_mcp_servers=, "
+                "not both."
+            )
+
+        if working_directory is None:
+            warnings.warn(
+                "Agentao() without working_directory= is deprecated and "
+                "will be required in 0.3.0. Pass an explicit Path, or use "
+                "agentao.embedding.build_from_environment() for CLI-style "
+                "auto-detection of cwd/.env/.agentao/.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+
         # Freeze working directory to an absolute path if one was supplied.
         # Resolve once so subsequent accesses are cheap and consistent.
         self._explicit_working_directory: Optional[Path] = (
@@ -110,6 +151,11 @@ class Agentao:
             if working_directory is not None
             else None
         )
+
+        # When ``None``, file/search/shell tools fall back to
+        # ``LocalFileSystem`` / ``LocalShellExecutor`` at first use.
+        self.filesystem = filesystem
+        self.shell = shell
 
         # Snapshot of session-scoped MCP server configs (Issue 11). Stored
         # privately so a caller can't mutate it after construction. ``None``
@@ -128,26 +174,34 @@ class Agentao:
         # falls back to Path.cwd()); ACP sessions land it under the frozen,
         # client-supplied project cwd instead of the subprocess's cwd — which
         # for ACP launches is often "/" and read-only.
-        self.llm = LLMClient(
-            api_key=api_key,
-            base_url=base_url,
-            model=model,
-            temperature=temperature,
-            log_file=str(self.working_directory / "agentao.log"),
-        )
-        # Pass the explicit working_directory through (or None for the CLI
-        # default — SkillManager will fall back to Path.cwd() at construction
-        # time, matching the legacy behavior). ACP sessions targeting different
-        # repos must see independent project skills + disabled-skill state.
-        self.skill_manager = SkillManager(
-            working_directory=self._explicit_working_directory,
-        )
+        if llm_client is not None:
+            self.llm = llm_client
+        else:
+            self.llm = LLMClient(
+                api_key=api_key,
+                base_url=base_url,
+                model=model,
+                temperature=temperature,
+                log_file=str(self.working_directory / "agentao.log"),
+                logger=logger,
+            )
+        # When the host has constructed and pre-loaded its own
+        # ``SkillManager``, skip the auto-discovery scan entirely.
+        if skill_manager is not None:
+            self.skill_manager = skill_manager
+        else:
+            self.skill_manager = SkillManager(
+                working_directory=self._explicit_working_directory,
+            )
         from .memory import MemoryManager, MemoryRetriever
         from .memory.render import MemoryPromptRenderer
-        self._memory_manager = MemoryManager(
-            project_root=self.working_directory / ".agentao",
-            global_root=Path.home() / ".agentao",
-        )
+        if memory_manager is not None:
+            self._memory_manager = memory_manager
+        else:
+            self._memory_manager = MemoryManager(
+                project_root=self.working_directory / ".agentao",
+                global_root=Path.home() / ".agentao",
+            )
         self.memory_tool = SaveMemoryTool(memory_manager=self._memory_manager)
         self.memory_retriever = MemoryRetriever(self._memory_manager)
         self.memory_renderer = MemoryPromptRenderer()
@@ -191,12 +245,14 @@ class Agentao:
         # Reasoning prompt is shown only when a dedicated thinking callback is registered
         self._has_thinking_handler = thinking_callback is not None
 
-        # Save LLM config for sub-agent creation
+        # Resolved values on the LLM client itself — covers both the
+        # raw-kwargs path and the injected ``llm_client`` path so
+        # sub-agents always see the parent's effective provider config.
         self._llm_config = {
-            "api_key": api_key,
-            "base_url": base_url,
-            "model": model,
-            "temperature": self.llm.temperature,  # resolved value (explicit or from env)
+            "api_key": self.llm.api_key,
+            "base_url": self.llm.base_url,
+            "model": self.llm.model,
+            "temperature": self.llm.temperature,
         }
 
         # Initialize context manager
@@ -227,8 +283,12 @@ class Agentao:
         self.tools = ToolRegistry()
         self._register_tools()
 
-        # Initialize MCP (Model Context Protocol) support
-        self.mcp_manager = self._init_mcp()
+        # When an already-built manager is injected, skip the file
+        # discovery pass entirely; the host owns the lifecycle.
+        if mcp_manager is not None:
+            self.mcp_manager = mcp_manager
+        else:
+            self.mcp_manager = self._init_mcp()
 
         # Initialize agent manager and register agent tools
         self.agent_manager = AgentManager()
@@ -251,8 +311,12 @@ class Agentao:
         # Plan session (shared with CLI; Agent reads via _plan_mode property)
         self._plan_session: PlanSession = plan_session or PlanSession()
 
-        # Load project instructions if available
-        self.project_instructions = self._load_project_instructions()
+        # When the host injects a ``project_instructions`` string,
+        # skip the AGENTAO.md disk read and use the override verbatim.
+        if project_instructions is not None:
+            self.project_instructions = project_instructions
+        else:
+            self.project_instructions = self._load_project_instructions()
 
         # Initialize sandbox policy (macOS sandbox-exec wrapper for shell
         # commands). Silently disabled on non-macOS or when config absent.
@@ -475,6 +539,29 @@ class Agentao:
         # :mod:`agentao.runtime.turn`; this method stays as a thin facade
         # so external callers and tests keep using ``Agentao.chat``.
         return run_turn(self, user_message, max_iterations, cancellation_token)
+
+    async def arun(
+        self,
+        user_message: str,
+        max_iterations: int = 100,
+        cancellation_token: Optional[CancellationToken] = None,
+    ) -> str:
+        """Async wrapper around :meth:`chat` for embedded async hosts.
+
+        Runtime internals stay sync (the chat loop, tool execution,
+        permission, and replay surfaces are all sequential I/O). This
+        method bridges through ``run_in_executor`` so async hosts can
+        ``await agent.arun(...)`` without their own thread bridge while
+        the same turn lifecycle from :meth:`chat` runs unchanged.
+
+        Cancellation, replay, and ``max_iterations`` behave identically
+        across both surfaces; the executor thread reads the same
+        cancellation token.
+        """
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None, self.chat, user_message, max_iterations, cancellation_token
+        )
 
     def _chat_inner(self, user_message: str, max_iterations: int,
                     token: CancellationToken) -> str:

--- a/agentao/agent.py
+++ b/agentao/agent.py
@@ -11,7 +11,7 @@ from .permissions import PermissionEngine
 from .runtime import ChatLoopRunner, ToolRunner, run_llm_call, run_turn
 from .runtime import model as _runtime_model
 from .tools import ToolRegistry, SaveMemoryTool, TodoWriteTool
-from .tooling import init_mcp, register_agent_tools, register_builtin_tools
+from .tooling import init_mcp, register_agent_tools, register_builtin_tools, register_mcp_tools
 from .agents import AgentManager
 from .cancellation import CancellationToken
 from .plan import PlanSession
@@ -284,9 +284,12 @@ class Agentao:
         self._register_tools()
 
         # When an already-built manager is injected, skip the file
-        # discovery pass entirely; the host owns the lifecycle.
+        # discovery pass entirely; the host owns the lifecycle. We still
+        # have to wrap and register every tool the manager exposes, or
+        # the model can't see any of them.
         if mcp_manager is not None:
             self.mcp_manager = mcp_manager
+            register_mcp_tools(self, mcp_manager)
         else:
             self.mcp_manager = self._init_mcp()
 
@@ -556,12 +559,22 @@ class Agentao:
 
         Cancellation, replay, and ``max_iterations`` behave identically
         across both surfaces; the executor thread reads the same
-        cancellation token.
+        cancellation token. If the awaiting task is cancelled (e.g.
+        ``asyncio.wait_for`` timeout, client disconnect) we forward the
+        signal to the in-flight ``chat()`` call so the executor thread
+        actually winds down instead of running to completion against
+        the now-detached host.
         """
         loop = asyncio.get_running_loop()
-        return await loop.run_in_executor(
-            None, self.chat, user_message, max_iterations, cancellation_token
+        token = cancellation_token if cancellation_token is not None else CancellationToken()
+        future = loop.run_in_executor(
+            None, self.chat, user_message, max_iterations, token
         )
+        try:
+            return await future
+        except asyncio.CancelledError:
+            token.cancel("async-cancel")
+            raise
 
     def _chat_inner(self, user_message: str, max_iterations: int,
                     token: CancellationToken) -> str:

--- a/agentao/agents/tools.py
+++ b/agentao/agents/tools.py
@@ -6,7 +6,6 @@ three tools here take a store reference at construction time and read
 or write through it.
 """
 
-import os
 import threading
 import time
 import uuid
@@ -423,15 +422,15 @@ class AgentToolWrapper(Tool):
         defn_model: Optional[str] = self._definition.get("model")
         defn_temperature: Optional[float] = self._definition.get("temperature")
 
+        # Sub-agents inherit the parent's resolved LLM config so a
+        # mid-run env mutation cannot give a child different credentials
+        # than its parent.
         if defn_model and "/" in defn_model:
-            provider, model_name = defn_model.split("/", 1)
-            provider = provider.strip().upper()
-            api_key = os.getenv(f"{provider}_API_KEY") or self._llm_config["api_key"]
-            base_url = os.getenv(f"{provider}_BASE_URL") or self._llm_config.get("base_url")
+            _, model_name = defn_model.split("/", 1)
         else:
             model_name = defn_model or self._llm_config.get("model")
-            api_key = self._llm_config["api_key"]
-            base_url = self._llm_config.get("base_url")
+        api_key = self._llm_config["api_key"]
+        base_url = self._llm_config.get("base_url")
 
         temperature = (
             defn_temperature if defn_temperature is not None

--- a/agentao/capabilities/__init__.py
+++ b/agentao/capabilities/__init__.py
@@ -1,0 +1,33 @@
+"""Capability protocols for embedded harness IO routing.
+
+Embedded hosts inject these protocols to redirect filesystem and shell
+IO through their own infrastructure (Docker exec, virtual FS, audit
+proxies, remote runners, …). When omitted, ``LocalFileSystem`` and
+``LocalShellExecutor`` provide byte-equivalent default behavior.
+"""
+
+from .filesystem import (
+    FileEntry,
+    FileStat,
+    FileSystem,
+    LocalFileSystem,
+)
+from .shell import (
+    BackgroundHandle,
+    LocalShellExecutor,
+    ShellExecutor,
+    ShellRequest,
+    ShellResult,
+)
+
+__all__ = [
+    "FileEntry",
+    "FileStat",
+    "FileSystem",
+    "LocalFileSystem",
+    "BackgroundHandle",
+    "ShellExecutor",
+    "ShellRequest",
+    "ShellResult",
+    "LocalShellExecutor",
+]

--- a/agentao/capabilities/filesystem.py
+++ b/agentao/capabilities/filesystem.py
@@ -1,0 +1,166 @@
+"""FileSystem capability protocol and local default.
+
+Defines a narrow IO contract that file/search tools route through. The
+default :class:`LocalFileSystem` keeps byte-equivalent behavior with
+the pre-capability code (``Path.glob``, ``os.scandir`` ordering,
+``open(...)``); embedded hosts can replace it with an in-memory or
+remote-backed implementation without monkey-patching.
+
+Only operations that file/search tools actually use are exposed.
+The shell tool keeps its own ``ShellExecutor`` so the two surfaces
+do not get tangled.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterator, List, Protocol, runtime_checkable
+
+
+@dataclass(frozen=True)
+class FileStat:
+    """Subset of ``os.stat_result`` exposed to tools."""
+
+    size: int
+    mtime: float
+    is_dir: bool
+    is_file: bool
+
+
+@dataclass(frozen=True)
+class FileEntry:
+    """Single directory entry returned by :meth:`FileSystem.list_dir`."""
+
+    name: str
+    is_dir: bool
+    is_file: bool
+    size: int
+
+
+@runtime_checkable
+class FileSystem(Protocol):
+    """IO contract used by file and search tools.
+
+    Implementations must accept absolute paths only — relative path
+    resolution is the tool's responsibility (see ``Tool._resolve_path``).
+    Methods raise the underlying ``OSError`` family on failure; tools
+    catch and turn them into user-facing error strings.
+    """
+
+    def read_bytes(self, path: Path) -> bytes:
+        ...
+
+    def read_partial(self, path: Path, n: int) -> bytes:
+        """Read up to ``n`` bytes from the start of ``path``.
+
+        Used for binary detection without materializing huge files.
+        Implementations should never read more than ``n`` bytes.
+        """
+        ...
+
+    def open_text(self, path: Path) -> Iterator[str]:
+        """Iterate ``path`` line by line as text.
+
+        Streaming primitive: tools that scan large files (search,
+        grep) should not materialize the whole content. Implementations
+        must yield lines including their trailing newline so callers
+        can preserve byte offsets if needed.
+        """
+        ...
+
+    def write_text(self, path: Path, data: str, *, append: bool = False) -> None:
+        ...
+
+    def list_dir(self, path: Path) -> List[FileEntry]:
+        ...
+
+    def glob(self, base: Path, pattern: str, *, recursive: bool) -> List[Path]:
+        ...
+
+    def stat(self, path: Path) -> FileStat:
+        ...
+
+    def exists(self, path: Path) -> bool:
+        ...
+
+    def is_dir(self, path: Path) -> bool:
+        ...
+
+    def is_file(self, path: Path) -> bool:
+        ...
+
+
+class LocalFileSystem:
+    """Default :class:`FileSystem` backed by ``pathlib`` / ``os``.
+
+    Behavior matches the pre-capability tool code so that the refactor
+    is byte-equivalent: ``Path.glob`` symlink semantics, ``os.scandir``
+    ordering, and the same set of stat fields. Tools that need
+    ordering or symlink follow-through behavior must rely on those same
+    semantics.
+    """
+
+    def read_bytes(self, path: Path) -> bytes:
+        with open(path, "rb") as f:
+            return f.read()
+
+    def read_partial(self, path: Path, n: int) -> bytes:
+        with open(path, "rb") as f:
+            return f.read(n)
+
+    def open_text(self, path: Path) -> Iterator[str]:
+        with open(path, "r", encoding="utf-8") as f:
+            yield from f
+
+    def write_text(self, path: Path, data: str, *, append: bool = False) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        mode = "a" if append else "w"
+        with open(path, mode, encoding="utf-8") as f:
+            f.write(data)
+
+    def list_dir(self, path: Path) -> List[FileEntry]:
+        entries: List[FileEntry] = []
+        with os.scandir(path) as it:
+            for de in it:
+                try:
+                    is_dir = de.is_dir()
+                    is_file = de.is_file()
+                    size = de.stat().st_size if is_file else 0
+                except OSError:
+                    is_dir = False
+                    is_file = False
+                    size = 0
+                entries.append(
+                    FileEntry(
+                        name=de.name,
+                        is_dir=is_dir,
+                        is_file=is_file,
+                        size=size,
+                    )
+                )
+        return entries
+
+    def glob(self, base: Path, pattern: str, *, recursive: bool) -> List[Path]:
+        if recursive:
+            return list(base.rglob(pattern))
+        return list(base.glob(pattern))
+
+    def stat(self, path: Path) -> FileStat:
+        st = path.stat()
+        return FileStat(
+            size=st.st_size,
+            mtime=st.st_mtime,
+            is_dir=path.is_dir(),
+            is_file=path.is_file(),
+        )
+
+    def exists(self, path: Path) -> bool:
+        return path.exists()
+
+    def is_dir(self, path: Path) -> bool:
+        return path.is_dir()
+
+    def is_file(self, path: Path) -> bool:
+        return path.is_file()

--- a/agentao/capabilities/shell.py
+++ b/agentao/capabilities/shell.py
@@ -1,0 +1,199 @@
+"""ShellExecutor capability protocol and local default.
+
+Wraps the foreground / background subprocess machinery used by
+:class:`agentao.tools.shell.ShellTool` so embedded hosts can route
+shell execution through Docker, a remote runner, or an audit proxy
+without monkey-patching subprocess.
+
+The default :class:`LocalShellExecutor` shells out via ``subprocess.Popen``
+with the same flags (process-group leadership, stdin detach,
+inactivity-timeout reads) as the pre-capability tool, so behavior is
+byte-equivalent.
+"""
+
+from __future__ import annotations
+
+import os
+import signal
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Protocol, runtime_checkable
+
+IS_WINDOWS = sys.platform == "win32"
+
+
+@dataclass(frozen=True)
+class ShellRequest:
+    """Single foreground shell command request."""
+
+    command: str
+    cwd: Path
+    timeout: float = 120.0
+    on_chunk: Optional[Callable[[str], None]] = None
+    env: Optional[Dict[str, str]] = None
+
+
+@dataclass
+class ShellResult:
+    """Result of a foreground shell run."""
+
+    returncode: int
+    stdout: bytes = b""
+    stderr: bytes = b""
+    timed_out: bool = False
+
+
+@dataclass
+class BackgroundHandle:
+    """Handle to a detached background process."""
+
+    pid: int
+    pgid: Optional[int] = None  # None on Windows
+    command: str = ""
+    cwd: Path = field(default_factory=lambda: Path("."))
+
+
+@runtime_checkable
+class ShellExecutor(Protocol):
+    """IO contract for shell execution.
+
+    Two operations: foreground ``run`` (caller waits for completion or
+    inactivity timeout) and ``run_background`` (caller gets a handle
+    immediately while the process continues detached). Hosts that
+    cannot support real backgrounding can raise ``NotImplementedError``
+    in ``run_background`` — :class:`agentao.tools.shell.ShellTool`
+    surfaces it as a normal tool error.
+    """
+
+    def run(self, request: ShellRequest) -> ShellResult:
+        ...
+
+    def run_background(self, request: ShellRequest) -> BackgroundHandle:
+        ...
+
+
+def _is_binary(data: bytes) -> bool:
+    return b"\x00" in data[:8192]
+
+
+class LocalShellExecutor:
+    """Default :class:`ShellExecutor` using ``subprocess.Popen``.
+
+    Mirrors :func:`agentao.tools.shell.ShellTool._run_foreground` /
+    ``_run_background`` exactly: shell=True wrapping, stdin detach
+    (so children never inherit the ACP JSON-RPC channel), process
+    group leadership for clean kill, inactivity-based timeout, and
+    ``taskkill`` / ``killpg`` teardown by platform.
+    """
+
+    def run(self, request: ShellRequest) -> ShellResult:
+        popen_kwargs: Dict[str, Any] = dict(
+            shell=True,
+            cwd=request.cwd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        if request.env is not None:
+            popen_kwargs["env"] = request.env
+        if not IS_WINDOWS:
+            popen_kwargs["start_new_session"] = True
+
+        try:
+            proc = subprocess.Popen(request.command, **popen_kwargs)
+        except Exception as e:
+            return ShellResult(
+                returncode=-1,
+                stdout=b"",
+                stderr=f"Error starting command: {e}".encode("utf-8"),
+                timed_out=False,
+            )
+
+        stdout_chunks: List[bytes] = []
+        stderr_chunks: List[bytes] = []
+        last_activity = [time.monotonic()]
+        timed_out = [False]
+        on_chunk = request.on_chunk
+
+        def _read(stream, chunks: List[bytes]) -> None:
+            for chunk in iter(lambda: stream.read(4096), b""):
+                chunks.append(chunk)
+                last_activity[0] = time.monotonic()
+                if on_chunk and not _is_binary(chunk):
+                    try:
+                        on_chunk(chunk.decode("utf-8", errors="replace"))
+                    except Exception:
+                        pass
+
+        t_out = threading.Thread(target=_read, args=(proc.stdout, stdout_chunks), daemon=True)
+        t_err = threading.Thread(target=_read, args=(proc.stderr, stderr_chunks), daemon=True)
+        t_out.start()
+        t_err.start()
+
+        timeout = request.timeout
+        while proc.poll() is None:
+            if time.monotonic() - last_activity[0] > timeout:
+                timed_out[0] = True
+                try:
+                    if IS_WINDOWS:
+                        subprocess.run(
+                            ["taskkill", "/T", "/F", "/PID", str(proc.pid)],
+                            stdin=subprocess.DEVNULL,
+                            capture_output=True,
+                        )
+                    else:
+                        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
+                except ProcessLookupError:
+                    proc.kill()
+                break
+            time.sleep(0.05)
+
+        t_out.join(timeout=2)
+        t_err.join(timeout=2)
+
+        return ShellResult(
+            returncode=proc.returncode if proc.returncode is not None else -1,
+            stdout=b"".join(stdout_chunks),
+            stderr=b"".join(stderr_chunks),
+            timed_out=timed_out[0],
+        )
+
+    def run_background(self, request: ShellRequest) -> BackgroundHandle:
+        popen_kwargs: Dict[str, Any] = dict(
+            shell=True,
+            cwd=request.cwd,
+            stdin=subprocess.DEVNULL,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        if request.env is not None:
+            popen_kwargs["env"] = request.env
+
+        if IS_WINDOWS:
+            popen_kwargs["creationflags"] = (
+                subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS  # type: ignore[attr-defined]
+            )
+            proc = subprocess.Popen(request.command, **popen_kwargs)
+            return BackgroundHandle(
+                pid=proc.pid,
+                pgid=None,
+                command=request.command,
+                cwd=request.cwd,
+            )
+
+        popen_kwargs["start_new_session"] = True
+        proc = subprocess.Popen(request.command, **popen_kwargs)
+        try:
+            pgid = os.getpgid(proc.pid)
+        except ProcessLookupError:
+            pgid = None
+        return BackgroundHandle(
+            pid=proc.pid,
+            pgid=pgid,
+            command=request.command,
+            cwd=request.cwd,
+        )

--- a/agentao/cli/app.py
+++ b/agentao/cli/app.py
@@ -29,6 +29,7 @@ from dotenv import load_dotenv
 
 from ..agent import Agentao
 from ..display import DisplayController
+from ..embedding import build_from_environment
 from ..transport import AgentEvent
 from ._globals import console
 from ._utils import _SlashCompleter
@@ -54,9 +55,6 @@ class AgentaoCLI:
 
         context_limit = int(os.getenv("AGENTAO_CONTEXT_TOKENS", "200000"))
 
-        from ..permissions import PermissionEngine, PermissionMode
-        self.permission_engine = PermissionEngine()
-
         self.allow_all_tools = False
         self.readonly_mode = False
         self._cached_ctx_pct: float = 0.0
@@ -65,19 +63,18 @@ class AgentaoCLI:
         from ..permissions import PermissionMode as _PM
         _saved = self._load_settings().get("mode", "workspace-write")
         try:
-            self.current_mode: PermissionMode = _PM(_saved)
+            self.current_mode: _PM = _PM(_saved)
         except ValueError:
             self.current_mode = _PM.WORKSPACE_WRITE
 
-        self.agent = Agentao(
-            api_key=os.getenv(f"{provider}_API_KEY"),
-            base_url=os.getenv(f"{provider}_BASE_URL"),
-            model=os.getenv(f"{provider}_MODEL"),
+        self.agent = build_from_environment(
             transport=self,
             max_context_tokens=context_limit,
-            permission_engine=self.permission_engine,
             plan_session=self._plan_session,
         )
+        # Hold a reference so the CLI can switch modes / inspect rules
+        # without going through the agent.
+        self.permission_engine = self.agent.permission_engine
 
         from ..plan import PlanController
         self._plan_controller = PlanController(

--- a/agentao/cli/entrypoints.py
+++ b/agentao/cli/entrypoints.py
@@ -18,11 +18,9 @@ from ._globals import console, _plugin_inline_dirs
 
 def run_print_mode(prompt: str) -> int:
     """Non-interactive print mode: send prompt, print response, exit. Returns exit code."""
-    from ..agent import Agentao
+    from ..embedding import build_from_environment
     from .subcommands import _load_and_register_plugins
 
-    load_dotenv()
-    provider = os.getenv("LLM_PROVIDER", "OPENAI").strip().upper()
     max_iterations_reached = [False]
 
     def _on_max_iterations(max_iterations: int, pending_tools: list) -> dict:
@@ -34,10 +32,7 @@ def run_print_mode(prompt: str) -> int:
         )
         return {"action": "stop"}
 
-    agent = Agentao(
-        api_key=os.getenv(f"{provider}_API_KEY"),
-        base_url=os.getenv(f"{provider}_BASE_URL"),
-        model=os.getenv(f"{provider}_MODEL"),
+    agent = build_from_environment(
         on_max_iterations_callback=_on_max_iterations,
     )
     agent._session_id = str(_uuid_mod.uuid4())

--- a/agentao/embedding/__init__.py
+++ b/agentao/embedding/__init__.py
@@ -1,0 +1,13 @@
+"""Embedded harness factory for :class:`agentao.agent.Agentao`.
+
+`build_from_environment()` captures every implicit env / dotenv / cwd /
+``.agentao/*.json`` read that the agent constructor would otherwise
+perform and routes them through explicit-injection kwargs. CLI and
+ACP entrypoints go through this single surface so embedded hosts that
+already have explicit config can construct :class:`Agentao` directly
+without any of the env-touching side effects.
+"""
+
+from .factory import build_from_environment
+
+__all__ = ["build_from_environment"]

--- a/agentao/embedding/factory.py
+++ b/agentao/embedding/factory.py
@@ -1,0 +1,100 @@
+"""``build_from_environment()`` — the CLI-style auto-discovery factory.
+
+Pulls in everything ``Agentao.__init__`` used to read implicitly:
+
+- ``.env`` via :func:`dotenv.load_dotenv`
+- ``LLM_PROVIDER`` and provider-prefixed env vars
+- ``working_directory or Path.cwd()`` resolved to absolute
+- ``<wd>/.agentao/permissions.json`` + ``~/.agentao/permissions.json``
+- ``<wd>/.agentao/mcp.json`` + ``~/.agentao/mcp.json``
+- memory roots (``<wd>/.agentao`` + ``~/.agentao``)
+
+Then constructs subsystems explicitly and forwards them to
+:class:`Agentao`. This factory is the single entry point that
+touches the surrounding environment, so embedded hosts can construct
+:class:`Agentao` directly with explicit injections instead.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Dict, Optional
+
+from dotenv import load_dotenv
+
+if TYPE_CHECKING:
+    from ..agent import Agentao
+
+
+def build_from_environment(
+    working_directory: Optional[Path] = None,
+    **overrides: Any,
+) -> "Agentao":
+    """Build an :class:`Agentao` instance from the surrounding environment.
+
+    Args:
+        working_directory: Project root used for ``.agentao/`` lookups.
+            When ``None``, falls back to ``Path.cwd()``. The result is
+            always resolved to an absolute path before forwarding to
+            ``Agentao(working_directory=...)`` so the runtime is frozen
+            (no later cwd-implicit reads).
+        **overrides: Any keyword accepted by ``Agentao.__init__`` —
+            takes priority over the values discovered from disk / env.
+            ``llm_client``, ``permission_engine``, ``memory_manager``,
+            ``skill_manager``, ``project_instructions``, ``mcp_manager``,
+            ``filesystem``, ``shell``, ``transport``, ``logger``,
+            ``temperature``, ``max_context_tokens``, ``plan_session``
+            are all valid here.
+
+    Returns:
+        A fully-constructed :class:`Agentao` instance bound to
+        ``working_directory``.
+    """
+    # Local imports keep the embedding package light — pulling
+    # ``Agentao`` (and through it the LLM stack) at module import time
+    # would defeat the point of having a thin entry surface.
+    from ..agent import Agentao
+    from ..memory import MemoryManager
+    from ..permissions import PermissionEngine
+
+    wd = (working_directory or Path.cwd()).expanduser().resolve()
+
+    dotenv_path = wd / ".env"
+    if dotenv_path.is_file():
+        load_dotenv(dotenv_path)
+    else:
+        load_dotenv()
+
+    provider = os.getenv("LLM_PROVIDER", "OPENAI").strip().upper()
+    discovered_api_key = os.getenv(f"{provider}_API_KEY")
+    discovered_base_url = os.getenv(f"{provider}_BASE_URL")
+    discovered_model = os.getenv(f"{provider}_MODEL")
+
+    permission_engine = overrides.pop("permission_engine", None)
+    if permission_engine is None:
+        permission_engine = PermissionEngine(project_root=wd)
+
+    memory_manager = overrides.pop("memory_manager", None)
+    if memory_manager is None:
+        memory_manager = MemoryManager(
+            project_root=wd / ".agentao",
+            global_root=Path.home() / ".agentao",
+        )
+
+    # When the caller supplied an ``llm_client``, do not surface the
+    # factory-discovered raw provider kwargs — the constructor would
+    # reject the combination as a programmer error.
+    kwargs: Dict[str, Any] = dict(
+        working_directory=wd,
+        permission_engine=permission_engine,
+        memory_manager=memory_manager,
+    )
+    if "llm_client" not in overrides:
+        kwargs["api_key"] = discovered_api_key
+        kwargs["base_url"] = discovered_base_url
+        kwargs["model"] = discovered_model
+    kwargs.update(overrides)
+
+    return Agentao(**kwargs)

--- a/agentao/llm/client.py
+++ b/agentao/llm/client.py
@@ -87,7 +87,12 @@ class _StreamResponse:
 
 
 class LLMClient:
-    """OpenAI-compatible LLM client with comprehensive logging."""
+    """OpenAI-compatible LLM client with comprehensive logging.
+
+    Pass ``logger=...`` to skip all ``agentao`` package-root mutation
+    (handler attach, level set, marker eviction) — embedded hosts own
+    their stack. Pass ``log_file=None`` to skip the file handler.
+    """
 
     def __init__(
         self,
@@ -95,7 +100,8 @@ class LLMClient:
         base_url: Optional[str] = None,
         model: Optional[str] = None,
         temperature: Optional[float] = None,
-        log_file: str = "agentao.log",
+        log_file: Optional[str] = "agentao.log",
+        logger: Optional[logging.Logger] = None,
     ):
         """Initialize LLM client.
 
@@ -103,7 +109,13 @@ class LLMClient:
             api_key: API key for the LLM service (overrides env)
             base_url: Base URL for the API endpoint (overrides env)
             model: Model name to use (overrides env; required if not set in env)
-            log_file: Path to log file for LLM interactions
+            log_file: Path to log file for LLM interactions. ``None`` skips
+                the file handler entirely.
+            logger: Optional injected logger. When provided, the client
+                uses it as ``self.logger`` and does not mutate
+                ``logging.getLogger("agentao")`` — no level set, no
+                handler attach, no marker eviction. Embedded hosts that
+                own their logging stack should pass this.
         """
         provider = os.getenv("LLM_PROVIDER", "OPENAI").strip().upper()
         self.api_key = api_key or os.getenv(f"{provider}_API_KEY")
@@ -137,47 +149,32 @@ class LLMClient:
             base_url=self.base_url,
         )
 
-        # Setup logging — attach FileHandler to the package root so all
-        # child loggers (agentao.llm, agentao.tools.web, etc.) inherit it.
-        self.logger = logging.getLogger("agentao.llm")
-        pkg_logger = logging.getLogger("agentao")
-        pkg_logger.setLevel(logging.DEBUG)
+        # Injected logger → host owns the stack; skip package-root mutation.
+        if logger is not None:
+            self.logger = logger
+        else:
+            self.logger = logging.getLogger("agentao.llm")
+            pkg_logger = logging.getLogger("agentao")
+            pkg_logger.setLevel(logging.DEBUG)
 
-        # Don't drop handlers we don't own (e.g. AcpServer's stderr guard).
-        # Tag our own and evict only the marked ones to avoid duplicates
-        # when LLMClient is reconstructed (which happens on every model
-        # switch in ACP mode).
-        for h in list(pkg_logger.handlers):
-            if getattr(h, "_agentao_llm_file_handler", False):
-                pkg_logger.removeHandler(h)
-                try:
-                    h.close()
-                except Exception:
-                    pass
+            # Evict only our marker-tagged handlers so AcpServer's stderr
+            # guard (and any other outsider handler) survives reconstruction.
+            for h in list(pkg_logger.handlers):
+                if getattr(h, "_agentao_llm_file_handler", False):
+                    pkg_logger.removeHandler(h)
+                    try:
+                        h.close()
+                    except Exception:
+                        pass
 
-        # File handler for detailed logs.
-        #
-        # We resolve the log file to an absolute path before opening it. The
-        # primary caller (Agentao) already passes an absolute path anchored to
-        # its working directory, but LLMClient is also constructed directly by
-        # tests and may be reused as a public-ish API, so we anchor any
-        # remaining relative path to the current cwd here as defense in depth.
-        # If the chosen path is unwritable (e.g. ACP launches with cwd="/" on
-        # macOS, or a sandboxed/read-only project dir), fall back to the
-        # user-scoped ~/.agentao/agentao.log so the agent can still start.
-        file_handler = self._build_file_handler(log_file)
-
-        # Concise format for file logs (no name/level noise in dedicated log file)
-        file_formatter = logging.Formatter(
-            "%(asctime)s %(message)s",
-            datefmt="%H:%M:%S",
-        )
-
-        if file_handler is not None:
-            file_handler.setLevel(logging.DEBUG)
-            file_handler.setFormatter(file_formatter)
-            file_handler._agentao_llm_file_handler = True  # type: ignore[attr-defined]
-            pkg_logger.addHandler(file_handler)
+            file_handler = self._build_file_handler(log_file) if log_file else None
+            if file_handler is not None:
+                file_handler.setLevel(logging.DEBUG)
+                file_handler.setFormatter(
+                    logging.Formatter("%(asctime)s %(message)s", datefmt="%H:%M:%S")
+                )
+                file_handler._agentao_llm_file_handler = True  # type: ignore[attr-defined]
+                pkg_logger.addHandler(file_handler)
 
         # Request counter for tracking
         self.request_count = 0

--- a/agentao/tooling/__init__.py
+++ b/agentao/tooling/__init__.py
@@ -13,11 +13,12 @@ Split by concern so each file is small and independently testable:
 """
 
 from .agent_tools import register_agent_tools
-from .mcp_tools import init_mcp
+from .mcp_tools import init_mcp, register_mcp_tools
 from .registry import register_builtin_tools
 
 __all__ = [
     "register_builtin_tools",
     "register_agent_tools",
     "init_mcp",
+    "register_mcp_tools",
 ]

--- a/agentao/tooling/mcp_tools.py
+++ b/agentao/tooling/mcp_tools.py
@@ -62,6 +62,19 @@ def init_mcp(agent: "Agentao") -> Optional[McpClientManager]:
     except Exception as e:
         agent.llm.logger.warning(f"MCP connection error: {e}")
 
+    register_mcp_tools(agent, manager)
+    return manager
+
+
+def register_mcp_tools(agent: "Agentao", manager: McpClientManager) -> None:
+    """Wrap every tool exposed by ``manager`` and register it on ``agent``.
+
+    Used by both ``init_mcp`` (for file/ACP-discovered managers) and
+    ``Agentao.__init__`` (for managers the embedded host injects directly).
+    The host owns connect/disconnect; this only handles tool wrapping so
+    the model sees the same surface regardless of how the manager was
+    created.
+    """
     for server_name, mcp_tool_def in manager.get_all_tools():
         client = manager.get_client(server_name)
         trusted = client.is_trusted if client else False
@@ -79,4 +92,3 @@ def init_mcp(agent: "Agentao") -> Optional[McpClientManager]:
         agent.llm.logger.info(
             f"MCP: {count} tools from {len(manager.clients)} server(s)"
         )
-    return manager

--- a/agentao/tooling/registry.py
+++ b/agentao/tooling/registry.py
@@ -58,4 +58,6 @@ def register_builtin_tools(agent: "Agentao") -> None:
     wd = agent._explicit_working_directory
     for tool in tools_to_register:
         tool.working_directory = wd
+        tool.filesystem = agent.filesystem
+        tool.shell = agent.shell
         agent.tools.register(tool)

--- a/agentao/tools/base.py
+++ b/agentao/tools/base.py
@@ -3,7 +3,10 @@
 import logging
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional
+from typing import TYPE_CHECKING, Any, Callable, Dict, List, Optional
+
+if TYPE_CHECKING:
+    from ..capabilities import FileSystem, ShellExecutor
 
 _logger = logging.getLogger(__name__)
 
@@ -13,12 +16,32 @@ class Tool(ABC):
 
     def __init__(self):
         self.output_callback: Optional[Callable[[str], None]] = None
-        # Per-session working directory bound by Agentao at registration time
-        # (Issue 05). ``None`` = legacy behavior: relative paths resolve
-        # against the process cwd at call time. A ``Path`` binds the tool
-        # to a specific session cwd so two ACP sessions with different cwd
-        # values do not leak state through relative file paths.
+        # Per-session working directory bound by Agentao at registration time.
+        # ``None`` = legacy behavior: relative paths resolve against the
+        # process cwd at call time. A ``Path`` binds the tool to a specific
+        # session cwd so two ACP sessions with different cwd values do not
+        # leak state through relative file paths.
         self.working_directory: Optional[Path] = None
+        # Capability injection. ``None`` means "construct a local default
+        # lazily at first use"; embedded hosts override at registration
+        # time to redirect IO through Docker exec, virtual FS, audit
+        # proxy, etc.
+        self.filesystem: Optional["FileSystem"] = None
+        self.shell: Optional["ShellExecutor"] = None
+
+    def _get_fs(self) -> "FileSystem":
+        """Lazy accessor — build a ``LocalFileSystem`` on first use."""
+        if self.filesystem is None:
+            from ..capabilities import LocalFileSystem
+            self.filesystem = LocalFileSystem()
+        return self.filesystem
+
+    def _get_shell(self) -> "ShellExecutor":
+        """Lazy accessor — build a ``LocalShellExecutor`` on first use."""
+        if self.shell is None:
+            from ..capabilities import LocalShellExecutor
+            self.shell = LocalShellExecutor()
+        return self.shell
 
     # ------------------------------------------------------------------
     # Path resolution helpers (Issue 05)

--- a/agentao/tools/file_ops.py
+++ b/agentao/tools/file_ops.py
@@ -57,22 +57,19 @@ class ReadFileTool(Tool):
         """Read file contents with line numbers and optional range."""
         try:
             path = self._resolve_path(file_path)
+            fs = self._get_fs()
 
-            if not path.exists():
+            if not fs.is_file(path):
                 return f"Error: File {file_path} does not exist"
 
-            if not path.is_file():
-                return f"Error: {file_path} is not a file"
+            sniff = fs.read_partial(path, BINARY_CHECK_SIZE)
+            if b"\x00" in sniff:
+                return f"Binary file: {file_path} ({fs.stat(path).size} bytes)"
 
-            # Binary detection: check first 8KB for null bytes
-            with open(path, "rb") as f:
-                chunk = f.read(BINARY_CHECK_SIZE)
-                if b"\x00" in chunk:
-                    size = path.stat().st_size
-                    return f"Binary file: {file_path} ({size} bytes)"
-
-            with open(path, "r", encoding="utf-8") as f:
-                all_lines = f.readlines()
+            try:
+                all_lines = list(fs.open_text(path))
+            except UnicodeDecodeError:
+                return f"Binary file: {file_path} ({fs.stat(path).size} bytes)"
 
             total_lines = len(all_lines)
 
@@ -118,9 +115,6 @@ class ReadFileTool(Tool):
                 result += f"\n[{long_lines} line(s) truncated to {MAX_LINE_LENGTH} chars per line]"
 
             return result
-        except UnicodeDecodeError:
-            size = path.stat().st_size
-            return f"Binary file: {file_path} ({size} bytes)"
         except Exception as e:
             return f"Error reading file: {str(e)}"
 
@@ -169,10 +163,7 @@ class WriteFileTool(Tool):
         except PathPolicyError as e:
             return f"Error: {e}"
         try:
-            path.parent.mkdir(parents=True, exist_ok=True)
-            mode = "a" if append else "w"
-            with open(path, mode, encoding="utf-8") as f:
-                f.write(content)
+            self._get_fs().write_text(path, content, append=append)
             action = "appended to" if append else "wrote to"
             return f"Successfully {action} {file_path}"
         except Exception as e:
@@ -282,9 +273,9 @@ class EditTool(Tool):
             path = PathPolicy.for_tool(self).contain_file(file_path)
         except PathPolicyError as e:
             return f"Error: {e}"
+        fs = self._get_fs()
         try:
-            with open(path, "r", encoding="utf-8") as f:
-                content = f.read()
+            content = fs.read_bytes(path).decode("utf-8")
 
             # 1. Exact match (original logic)
             if old_text in content:
@@ -295,8 +286,7 @@ class EditTool(Tool):
                     new_content = content.replace(old_text, new_text, 1)
                     count = 1
 
-                with open(path, "w", encoding="utf-8") as f:
-                    f.write(new_content)
+                fs.write_text(path, new_content)
                 return f"Replaced {count} occurrence(s) in {file_path}"
 
             # 2. Flexible match: whitespace-normalized comparison
@@ -316,8 +306,7 @@ class EditTool(Tool):
                     new_content = content[:start] + new_text + content[end:]
                     count = 1
 
-                with open(path, "w", encoding="utf-8") as f:
-                    f.write(new_content)
+                fs.write_text(path, new_content)
                 return f"Replaced {count} occurrence(s) in {file_path} (flexible whitespace match)"
 
             # 3. Not found — return hint with most similar snippet
@@ -363,31 +352,35 @@ class ReadFolderTool(Tool):
         """List directory contents."""
         try:
             path = self._resolve_path(directory_path)
-            if not path.exists():
+            fs = self._get_fs()
+            if not fs.exists(path):
                 return f"Error: Directory {directory_path} does not exist"
 
-            if not path.is_dir():
+            if not fs.is_dir(path):
                 return f"Error: {directory_path} is not a directory"
 
             results = []
             if recursive:
-                items = sorted(path.rglob("*"), key=lambda e: (not e.is_dir(), str(e).lower()))
+                items = sorted(fs.glob(path, "*", recursive=True),
+                               key=lambda e: (not fs.is_dir(e), str(e).lower()))
                 for item in items:
                     rel_path = item.relative_to(path)
-                    if item.is_dir():
+                    if fs.is_dir(item):
                         results.append(f"[DIR]  {rel_path}/")
                     else:
-                        size = item.stat().st_size
+                        try:
+                            size = fs.stat(item).size
+                        except OSError:
+                            size = 0
                         results.append(f"[FILE] {rel_path} ({size} bytes)")
             else:
-                # Sort: directories first, then alphabetical (case-insensitive)
-                items = sorted(path.iterdir(), key=lambda e: (not e.is_dir(), e.name.lower()))
+                entries = fs.list_dir(path)
+                items = sorted(entries, key=lambda e: (not e.is_dir, e.name.lower()))
                 for item in items:
-                    if item.is_dir():
+                    if item.is_dir:
                         results.append(f"[DIR]  {item.name}/")
                     else:
-                        size = item.stat().st_size
-                        results.append(f"[FILE] {item.name} ({size} bytes)")
+                        results.append(f"[FILE] {item.name} ({item.size} bytes)")
 
             return f"Directory: {directory_path}\n\n" + "\n".join(results)
         except Exception as e:

--- a/agentao/tools/search.py
+++ b/agentao/tools/search.py
@@ -8,7 +8,7 @@ import fnmatch
 import re
 
 from .base import Tool
-from ..capabilities import FileSystem
+from ..capabilities import FileSystem, LocalFileSystem
 
 # Files modified within this window are sorted by recency
 RECENCY_THRESHOLD = 86400  # 24 hours
@@ -227,8 +227,11 @@ class SearchTextTool(Tool):
             if not fs.exists(path):
                 return f"Error: Directory {directory} does not exist"
 
-            # Try git grep first (much faster in git repos)
-            if self._is_git_repo(path):
+            # Try git grep first (much faster in git repos), but only when the
+            # filesystem capability is the local default. An injected FileSystem
+            # may be virtual or remote, so the on-disk git repo at ``path``
+            # would return results unrelated to the injected view.
+            if isinstance(fs, LocalFileSystem) and self._is_git_repo(path):
                 result = self._git_grep(path, pattern, file_pattern, case_sensitive, regex)
                 if result is not None:
                     return result

--- a/agentao/tools/search.py
+++ b/agentao/tools/search.py
@@ -8,6 +8,7 @@ import fnmatch
 import re
 
 from .base import Tool
+from ..capabilities import FileSystem
 
 # Files modified within this window are sorted by recency
 RECENCY_THRESHOLD = 86400  # 24 hours
@@ -46,14 +47,14 @@ class FindFilesTool(Tool):
             "required": ["pattern"],
         }
 
-    def _sort_by_recency(self, base_path: Path, file_paths: List[str]) -> List[str]:
+    def _sort_by_recency(self, base_path: Path, file_paths: List[str], fs: FileSystem) -> List[str]:
         """Sort files: recently modified (24h) by mtime desc, then rest alphabetically."""
         now = time.time()
         recent = []
         older = []
         for f in file_paths:
             try:
-                mtime = (base_path / f).stat().st_mtime
+                mtime = fs.stat(base_path / f).mtime
                 if now - mtime < RECENCY_THRESHOLD:
                     recent.append((f, mtime))
                 else:
@@ -68,23 +69,21 @@ class FindFilesTool(Tool):
         """Find files matching pattern, with recently modified files listed first."""
         try:
             path = self._resolve_path(directory)
-            if not path.exists():
+            fs = self._get_fs()
+            if not fs.exists(path):
                 return f"Error: Directory {directory} does not exist"
 
             matches = []
-            if "**" in pattern:
-                for item in path.rglob(pattern.replace("**/", "")):
-                    if item.is_file():
-                        matches.append(str(item.relative_to(path)))
-            else:
-                for item in path.glob(pattern):
-                    if item.is_file():
-                        matches.append(str(item.relative_to(path)))
+            recursive = "**" in pattern
+            search_pattern = pattern.replace("**/", "") if recursive else pattern
+            for item in fs.glob(path, search_pattern, recursive=recursive):
+                if fs.is_file(item):
+                    matches.append(str(item.relative_to(path)))
 
             if not matches:
                 return f"No files found matching pattern: {pattern}"
 
-            sorted_matches = self._sort_by_recency(path, matches)
+            sorted_matches = self._sort_by_recency(path, matches, fs)
             return f"Found {len(sorted_matches)} file(s):\n\n" + "\n".join(sorted_matches)
         except Exception as e:
             return f"Error finding files: {str(e)}"
@@ -224,7 +223,8 @@ class SearchTextTool(Tool):
         """Search for text in files. Uses git grep when available for performance."""
         try:
             path = self._resolve_directory(directory)
-            if not path.exists():
+            fs = self._get_fs()
+            if not fs.exists(path):
                 return f"Error: Directory {directory} does not exist"
 
             # Try git grep first (much faster in git repos)
@@ -244,31 +244,32 @@ class SearchTextTool(Tool):
                 if not case_sensitive:
                     pattern = pattern.lower()
 
-            files_to_search = []
-            if "**" in file_pattern:
-                files_to_search = list(path.rglob(file_pattern.replace("**/", "")))
-            else:
-                files_to_search = list(path.glob(file_pattern))
+            recursive = "**" in file_pattern
+            search_pattern = file_pattern.replace("**/", "") if recursive else file_pattern
+            files_to_search = fs.glob(path, search_pattern, recursive=recursive)
 
             results = []
             for file_path in files_to_search:
-                if not file_path.is_file():
+                if not fs.is_file(file_path):
                     continue
 
                 try:
-                    with open(file_path, "r", encoding="utf-8") as f:
-                        for line_num, line in enumerate(f, 1):
-                            match = False
-                            if regex:
-                                match = compiled_pattern.search(line) is not None
-                            else:
-                                search_line = line if case_sensitive else line.lower()
-                                match = pattern in search_line
+                    line_iter = fs.open_text(file_path)
+                except (UnicodeDecodeError, PermissionError, OSError):
+                    continue
 
-                            if match:
-                                rel_path = file_path.relative_to(path)
-                                results.append(f"{rel_path}:{line_num}: {line.rstrip()}")
-                except (UnicodeDecodeError, PermissionError):
+                try:
+                    for line_num, line in enumerate(line_iter, 1):
+                        if regex:
+                            match = compiled_pattern.search(line) is not None
+                        else:
+                            search_line = line if case_sensitive else line.lower()
+                            match = pattern in search_line
+
+                        if match:
+                            rel_path = file_path.relative_to(path)
+                            results.append(f"{rel_path}:{line_num}: {line.rstrip()}")
+                except (UnicodeDecodeError, PermissionError, OSError):
                     continue
 
             if not results:

--- a/agentao/tools/shell.py
+++ b/agentao/tools/shell.py
@@ -10,7 +10,7 @@ IS_WINDOWS = sys.platform == "win32"
 IS_MACOS = sys.platform == "darwin"
 
 from .base import Tool
-from ..capabilities import BackgroundHandle, ShellRequest, ShellResult
+from ..capabilities import BackgroundHandle, LocalShellExecutor, ShellRequest, ShellResult
 from ..capabilities.shell import _is_binary
 from ..sandbox import SandboxProfile
 from ..security import PathPolicy, PathPolicyError
@@ -230,7 +230,11 @@ class ShellTool(Tool):
             cwd = PathPolicy.for_tool(self).contain_directory(working_directory)
         except PathPolicyError as e:
             return f"Error: {e}"
-        if not cwd.is_dir():
+        # Only validate cwd against the local filesystem when using the default
+        # local executor. An injected ShellExecutor (Docker, remote host, …)
+        # may accept a container/remote path that does not exist locally; let
+        # that executor validate the cwd itself.
+        if isinstance(self._get_shell(), LocalShellExecutor) and not cwd.is_dir():
             return (
                 f"Error: working_directory '{working_directory}' does not exist "
                 "or is not a directory."

--- a/agentao/tools/shell.py
+++ b/agentao/tools/shell.py
@@ -1,34 +1,23 @@
 """Shell command execution tool."""
 
-import os
 import re
 import shlex
-import signal
-import subprocess
 import sys
-import threading
-import time
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Dict, Optional
 
 IS_WINDOWS = sys.platform == "win32"
 IS_MACOS = sys.platform == "darwin"
 
 from .base import Tool
+from ..capabilities import BackgroundHandle, ShellRequest, ShellResult
+from ..capabilities.shell import _is_binary
 from ..sandbox import SandboxProfile
 from ..security import PathPolicy, PathPolicyError
 
 # Maximum combined stdout+stderr before truncation (~10K tokens).
 # Matches Gemini CLI's default threshold of 40,000 characters.
 _MAX_OUTPUT_CHARS = 40_000
-
-# Number of bytes to sniff for binary detection.
-_BINARY_SNIFF_BYTES = 8_192
-
-
-def _is_binary(data: bytes) -> bool:
-    """Return True if data looks like binary (null bytes present)."""
-    return b"\x00" in data[:_BINARY_SNIFF_BYTES]
 
 
 def _decode(raw: bytes) -> str:
@@ -268,48 +257,33 @@ class ShellTool(Tool):
     def _run_background(self, command: str, cwd: Path) -> str:
         """Start command detached; return PID (and PGID on Unix) immediately."""
         try:
-            if IS_WINDOWS:
-                proc = subprocess.Popen(
-                    command,
-                    shell=True,
-                    cwd=cwd,
-                    # Detach stdin so we never inherit the parent's stdin —
-                    # under the ACP stdio transport the parent stdin is the
-                    # JSON-RPC channel, and a shell=True child inheriting it
-                    # can corrupt framing or deadlock.
-                    stdin=subprocess.DEVNULL,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    creationflags=subprocess.CREATE_NEW_PROCESS_GROUP | subprocess.DETACHED_PROCESS,
-                )
-                return (
-                    f"Background process started.\n"
-                    f"PID: {proc.pid}\n"
-                    f"Command: {command}\n"
-                    f"Working directory: {cwd}\n"
-                    f"To stop: taskkill /F /T /PID {proc.pid}"
-                )
-            else:
-                proc = subprocess.Popen(
-                    command,
-                    shell=True,
-                    cwd=cwd,
-                    stdin=subprocess.DEVNULL,
-                    stdout=subprocess.DEVNULL,
-                    stderr=subprocess.DEVNULL,
-                    start_new_session=True,  # equivalent to preexec_fn=os.setsid
-                )
-                pgid = os.getpgid(proc.pid)
-                return (
-                    f"Background process started.\n"
-                    f"PID: {proc.pid}\n"
-                    f"PGID: {pgid}\n"
-                    f"Command: {command}\n"
-                    f"Working directory: {cwd}\n"
-                    f"To stop: kill -- -{pgid}"
-                )
+            handle: BackgroundHandle = self._get_shell().run_background(
+                ShellRequest(command=command, cwd=cwd)
+            )
+        except NotImplementedError:
+            return (
+                "Error: shell executor does not support background execution. "
+                "Run this command with is_background=false."
+            )
         except Exception as e:
             return f"Error starting background command: {e}"
+
+        if IS_WINDOWS or handle.pgid is None:
+            return (
+                f"Background process started.\n"
+                f"PID: {handle.pid}\n"
+                f"Command: {command}\n"
+                f"Working directory: {cwd}\n"
+                f"To stop: taskkill /F /T /PID {handle.pid}"
+            )
+        return (
+            f"Background process started.\n"
+            f"PID: {handle.pid}\n"
+            f"PGID: {handle.pgid}\n"
+            f"Command: {command}\n"
+            f"Working directory: {cwd}\n"
+            f"To stop: kill -- -{handle.pgid}"
+        )
 
     # ------------------------------------------------------------------
     # Foreground execution with inactivity timeout
@@ -317,78 +291,26 @@ class ShellTool(Tool):
 
     def _run_foreground(self, command: str, cwd: Path, timeout: float) -> str:
         """Run command, killing it after `timeout` seconds without any output."""
-        popen_kwargs: Dict[str, Any] = dict(
-            shell=True,
-            cwd=cwd,
-            # See _run_background: never inherit parent stdin (JSON-RPC channel
-            # under ACP stdio).
-            stdin=subprocess.DEVNULL,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.PIPE,
-        )
-        if not IS_WINDOWS:
-            popen_kwargs["start_new_session"] = True  # equivalent to preexec_fn=os.setsid
         try:
-            proc = subprocess.Popen(command, **popen_kwargs)
+            result: ShellResult = self._get_shell().run(
+                ShellRequest(
+                    command=command,
+                    cwd=cwd,
+                    timeout=timeout,
+                    on_chunk=self.output_callback,
+                )
+            )
         except Exception as e:
             return f"Error starting command: {e}"
 
-        stdout_chunks: List[bytes] = []
-        stderr_chunks: List[bytes] = []
-        last_activity = [time.monotonic()]
-        timed_out = [False]
-        callback = self.output_callback
-
-        def _read(stream, chunks: List[bytes], on_chunk: Optional[Callable[[str], None]] = None) -> None:
-            for chunk in iter(lambda: stream.read(4096), b""):
-                chunks.append(chunk)
-                last_activity[0] = time.monotonic()
-                if on_chunk and not _is_binary(chunk):
-                    try:
-                        on_chunk(chunk.decode("utf-8", errors="replace"))
-                    except Exception:
-                        pass  # Never let display errors kill the reader thread
-
-        t_out = threading.Thread(target=_read, args=(proc.stdout, stdout_chunks, callback), daemon=True)
-        t_err = threading.Thread(target=_read, args=(proc.stderr, stderr_chunks, callback), daemon=True)
-        t_out.start()
-        t_err.start()
-
-        # Poll for inactivity timeout
-        while proc.poll() is None:
-            if time.monotonic() - last_activity[0] > timeout:
-                timed_out[0] = True
-                try:
-                    if IS_WINDOWS:
-                        # Kill the entire process tree: shell=True wraps the real
-                        # command in cmd.exe, so proc.kill() alone would only
-                        # terminate the wrapper and leave children running.
-                        subprocess.run(
-                            ["taskkill", "/T", "/F", "/PID", str(proc.pid)],
-                            stdin=subprocess.DEVNULL,
-                            capture_output=True,
-                        )
-                    else:
-                        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-                except ProcessLookupError:
-                    proc.kill()
-                break
-            time.sleep(0.05)
-
-        t_out.join(timeout=2)
-        t_err.join(timeout=2)
-
-        stdout_raw = b"".join(stdout_chunks)
-        stderr_raw = b"".join(stderr_chunks)
-
-        if timed_out[0]:
-            partial = _decode(stdout_raw + stderr_raw)
+        if result.timed_out:
+            partial = _decode(result.stdout + result.stderr)
             msg = f"Command timed out after {timeout:.0f}s of inactivity.\nCommand: {command}"
             if partial:
                 msg += f"\n\nPartial output before timeout:\n{partial}"
             return msg
 
-        return self._format_result(proc.returncode, stdout_raw, stderr_raw)
+        return self._format_result(result.returncode, result.stdout, result.stderr)
 
     # ------------------------------------------------------------------
     # Output formatting

--- a/agentao/transport/events.py
+++ b/agentao/transport/events.py
@@ -46,6 +46,10 @@ class AgentEvent:
     All data values must be JSON-serializable so transports can forward
     events over SSE / WebSocket without extra marshalling.
 
+    ``schema_version`` is the runtime-payload version contract for the
+    wire form (independent of ACP's protocol version); bump it when a
+    payload field's shape or semantics change.
+
     Common data payloads:
         TURN_START    {}
         TOOL_START    {"tool": "run_shell_command", "args": {...}, "call_id": "uuid"}
@@ -73,3 +77,15 @@ class AgentEvent:
 
     type: EventType
     data: Dict[str, Any] = field(default_factory=dict)
+    schema_version: int = 1
+
+    def to_dict(self) -> Dict[str, Any]:
+        """Serialize to the JSON-safe wire shape ``{type, schema_version, data}``.
+
+        ``data`` aliases ``self.data`` (no copy); callers must not mutate it.
+        """
+        return {
+            "type": self.type.value,
+            "schema_version": self.schema_version,
+            "data": self.data,
+        }

--- a/agentao/transport/sdk.py
+++ b/agentao/transport/sdk.py
@@ -20,12 +20,21 @@ class SdkTransport:
     All callback parameters are optional; unset ones fall back to the
     ``NullTransport`` behaviour (ignore / auto-approve).
 
+    The ``on_event`` callback receives the live :class:`AgentEvent`
+    dataclass so embedded callers can branch on ``event.type`` cheaply.
+    Hosts that need to forward events over a wire protocol (SSE,
+    WebSocket, IPC) should call :meth:`AgentEvent.to_dict` to get the
+    versioned ``{"type", "schema_version", "data"}`` payload.
+
     Example::
 
         events = []
         transport = SdkTransport(on_event=events.append)
         agent = Agentao(transport=transport)
         agent.chat("hello")
+
+        # Wire form (versioned by AgentEvent.schema_version):
+        wire = [e.to_dict() for e in events]
     """
 
     def __init__(

--- a/developer-guide/en/appendix/a-api-reference.md
+++ b/developer-guide/en/appendix/a-api-reference.md
@@ -5,7 +5,9 @@ This is a **surface reference** — the public symbols that form Agentao's embed
 Authoritative `__all__`:
 
 - `from agentao import ...` → `Agentao`, `SkillManager`
+- `from agentao.embedding import ...` → `build_from_environment`
 - `from agentao.transport import ...` → `AgentEvent`, `EventType`, `Transport`, `NullTransport`, `SdkTransport`, `build_compat_transport`
+- `from agentao.capabilities import ...` → `FileSystem`, `LocalFileSystem`, `FileEntry`, `FileStat`, `ShellExecutor`, `LocalShellExecutor`, `ShellRequest`, `ShellResult`, `BackgroundHandle`
 - `from agentao.tools.base import ...` → `Tool`, `ToolRegistry`
 - `from agentao.permissions import ...` → `PermissionEngine`, `PermissionMode`, `PermissionDecision`
 - `from agentao.memory.manager import MemoryManager`
@@ -18,6 +20,8 @@ The core class — see [Part 2.2](/en/part-2/2-constructor-reference) for the fu
 
 ### Constructor
 
+See [Part 2.2](/en/part-2/2-constructor-reference) for the full parameter table. **Since 0.2.16**, `Agentao()` without `working_directory=` emits a `DeprecationWarning` and will become a `TypeError` in 0.3.0.
+
 ```python
 Agentao(
     api_key: str | None = None,
@@ -26,24 +30,51 @@ Agentao(
     temperature: float | None = None,
     transport: Transport | None = None,
     working_directory: Path | None = None,
-    extra_mcp_servers: list[dict] | None = None,
+    extra_mcp_servers: dict[str, dict] | None = None,
     permission_engine: PermissionEngine | None = None,
     max_context_tokens: int = 200_000,
-    plan_session: bool = False,
-    # legacy callbacks (prefer `transport=`)
+    plan_session: PlanSession | None = None,
+    # Embedded-harness explicit injections (0.2.16+)
+    llm_client: LLMClient | None = None,
+    logger: logging.Logger | None = None,
+    memory_manager: MemoryManager | None = None,
+    skill_manager: SkillManager | None = None,
+    project_instructions: str | None = None,
+    mcp_manager: McpClientManager | None = None,
+    filesystem: FileSystem | None = None,
+    shell: ShellExecutor | None = None,
+    # Legacy callbacks (prefer `transport=`)
     output_callback: Callable[[str], None] | None = None,
     confirmation_callback: Callable[[str, str, dict], bool] | None = None,
-    input_callback: Callable[[str], str] | None = None,
+    ask_user_callback: Callable[[str], str] | None = None,
     on_max_iterations_callback: Callable[[int, list], dict] | None = None,
     # ...
 )
 ```
+
+Mutual-exclusion rules (raise `ValueError` if violated):
+
+- `llm_client=` together with any of `api_key=` / `base_url=` / `model=` / `temperature=`
+- `mcp_manager=` together with `extra_mcp_servers=`
+
+### `agentao.embedding.build_from_environment`
+
+```python
+def build_from_environment(
+    working_directory: Path | None = None,
+    **overrides,
+) -> Agentao:
+    ...
+```
+
+CLI-style auto-discovery factory: reads `.env`, `LLM_PROVIDER`-prefixed env vars, `<wd>/.agentao/permissions.json`, `<wd>/.agentao/mcp.json`, memory roots; constructs `Agentao` with the discovered values. **Caller-supplied `**overrides` win** over auto-discovered ones. Raises `ValueError` on the same mutual-exclusion conflicts as the constructor (if `llm_client` is in `overrides`, the factory's discovered `api_key` / `base_url` / `model` are dropped before forwarding).
 
 ### Methods
 
 | Method | Signature | Purpose |
 |--------|-----------|---------|
 | `chat` | `chat(user_message: str, max_iterations: int = 100, cancellation_token: CancellationToken | None = None) -> str` | Run one turn. Returns final assistant text. |
+| `arun` | `async arun(user_message: str, max_iterations: int = 100, cancellation_token: CancellationToken | None = None) -> str` | Async surface — bridges `chat()` through `loop.run_in_executor`. Same semantics for cancellation, replay, max_iterations. |
 | `clear_history` | `clear_history() -> None` | Reset `self.messages`; does not touch memory DB. |
 | `close` | `close() -> None` | Release MCP subprocesses, close DB handles. Call in `finally:`. |
 | `set_provider` | `set_provider(api_key: str, base_url: str | None = None, model: str | None = None) -> None` | Runtime LLM swap. |
@@ -128,7 +159,14 @@ class Tool(ABC):
     # populated by Agentao at registration time
     working_directory: Path | None
     output_callback: Callable[[str], None] | None
+    filesystem: FileSystem | None
+    shell: ShellExecutor | None
+
+    def _get_fs(self) -> FileSystem: ...      # lazy LocalFileSystem fallback
+    def _get_shell(self) -> ShellExecutor: ... # lazy LocalShellExecutor fallback
 ```
+
+Custom tool subclasses that need to read/write files should call `self._get_fs()` rather than touching `pathlib` directly — that way the host's injected `FileSystem` (Docker, virtual FS, audit proxy) is honored.
 
 ### `ToolRegistry`
 
@@ -138,6 +176,32 @@ class Tool(ABC):
 | `get(name: str) -> Tool` | Raises `KeyError` with available-tools list |
 | `list_tools() -> list[Tool]` | |
 | `to_openai_format() -> list[dict]` | OpenAI function-calling schemas |
+
+### Capabilities (`agentao.capabilities`)
+
+Runtime-checkable `Protocol`s that file/search/shell tools route IO through. Hosts inject custom implementations via `Agentao(filesystem=..., shell=...)` to redirect through Docker exec, virtual filesystems, audit proxies, or remote runners. The package also exports byte-equivalent `LocalFileSystem` / `LocalShellExecutor` defaults.
+
+```python
+class FileSystem(Protocol):
+    def read_bytes(self, path: Path) -> bytes: ...
+    def read_partial(self, path: Path, n: int) -> bytes: ...
+    def open_text(self, path: Path) -> Iterator[str]: ...      # streaming
+    def write_text(self, path: Path, data: str, *, append: bool = False) -> None: ...
+    def list_dir(self, path: Path) -> list[FileEntry]: ...
+    def glob(self, base: Path, pattern: str, *, recursive: bool) -> list[Path]: ...
+    def stat(self, path: Path) -> FileStat: ...
+    def exists(self, path: Path) -> bool: ...
+    def is_dir(self, path: Path) -> bool: ...
+    def is_file(self, path: Path) -> bool: ...
+
+class ShellExecutor(Protocol):
+    def run(self, request: ShellRequest) -> ShellResult: ...
+    def run_background(self, request: ShellRequest) -> BackgroundHandle: ...
+```
+
+Frozen dataclasses: `FileEntry(name, is_dir, is_file, size)`, `FileStat(size, mtime, is_dir, is_file)`, `ShellRequest(command, cwd, timeout, on_chunk, env)`, `ShellResult(returncode, stdout, stderr, timed_out)`, `BackgroundHandle(pid, pgid, command, cwd)`.
+
+Hosts that cannot support real backgrounding may raise `NotImplementedError` from `run_background` — `ShellTool` surfaces that as a normal tool error string.
 
 ## A.4 Permissions
 

--- a/developer-guide/en/part-2/2-constructor-reference.md
+++ b/developer-guide/en/part-2/2-constructor-reference.md
@@ -1,6 +1,36 @@
 # 2.2 Constructor Reference
 
-Full signature (`agentao/agent.py`, `Agentao.__init__`):
+There are now **two stable construction paths**, picked by what your host already knows:
+
+- **`agentao.embedding.build_from_environment(...)`** — CLI-style auto-discovery: reads `.env`, `LLM_PROVIDER`, `<wd>/.agentao/permissions.json`, `<wd>/.agentao/mcp.json`, memory roots, then constructs `Agentao` for you. Use this when your host follows the same project-directory conventions as the CLI.
+- **`Agentao(...)` directly** — explicit injection: you already have an `LLMClient`, `PermissionEngine`, etc. and don't want any env / disk side effects at construction time.
+
+**Important (0.2.16)**: `Agentao()` without `working_directory=` now emits a `DeprecationWarning` and will become a `TypeError` in 0.3.0. Always pass an explicit `Path`, or go through `build_from_environment()`.
+
+## The factory: `build_from_environment()`
+
+```python
+from pathlib import Path
+from agentao.embedding import build_from_environment
+
+agent = build_from_environment(
+    working_directory=Path("/data/tenant-acme"),
+    transport=my_transport,
+    max_context_tokens=128_000,
+)
+```
+
+What it does:
+
+1. Resolves `working_directory` (defaults to `Path.cwd()`) once and freezes the result.
+2. Calls `load_dotenv()` against `<wd>/.env` if it exists, else process-wide.
+3. Reads `LLM_PROVIDER` and the matching `*_API_KEY` / `*_BASE_URL` / `*_MODEL` env vars.
+4. Builds a `PermissionEngine(project_root=wd)` and a `MemoryManager(project_root=wd/.agentao, global_root=~/.agentao)`.
+5. Forwards everything explicitly to `Agentao(...)`. **Caller `**overrides` win** over auto-discovered values.
+
+This is the only place in the codebase that reads env / dotenv / `.agentao/*.json` at startup. Hosts that don't want any of that should construct `Agentao` directly.
+
+## `Agentao.__init__` full signature (`agentao/agent.py`)
 
 ```python
 Agentao(
@@ -8,7 +38,7 @@ Agentao(
     base_url:         Optional[str]    = None,
     model:            Optional[str]    = None,
     temperature:      Optional[float]  = None,
-    # ── The 8 below are deprecated legacy callbacks (still accepted) ──
+    # ── Deprecated legacy callbacks (still accepted) ──
     confirmation_callback:      Optional[Callable] = None,
     max_context_tokens:         int                = 200_000,
     step_callback:              Optional[Callable] = None,
@@ -24,6 +54,15 @@ Agentao(
     *,
     working_directory:  Optional[Path]                     = None,
     extra_mcp_servers:  Optional[Dict[str, Dict[str, Any]]] = None,
+    # ── Embedded-harness explicit-injection kwargs (0.2.16+) ──
+    llm_client:           Optional[LLMClient]         = None,
+    logger:               Optional[logging.Logger]    = None,
+    memory_manager:       Optional[MemoryManager]     = None,
+    skill_manager:        Optional[SkillManager]      = None,
+    project_instructions: Optional[str]               = None,
+    mcp_manager:          Optional[McpClientManager]  = None,
+    filesystem:           Optional[FileSystem]        = None,
+    shell:                Optional[ShellExecutor]     = None,
 )
 ```
 
@@ -31,24 +70,64 @@ Agentao(
 
 | Param | Type | Default | Purpose |
 |-------|------|---------|---------|
-| `api_key` | `str` | `OPENAI_API_KEY` env | LLM credential |
-| `base_url` | `str` | env or vendor default | Switch compatible endpoint (DeepSeek, Gemini gateway, vLLM…) |
-| `model` | `str` | env or vendor default | Model id |
-| `temperature` | `float` | env `LLM_TEMPERATURE` or `0.2` | Sampling temperature |
+| `api_key` | `str` | — (must be supplied or come from `llm_client=`) | LLM credential |
+| `base_url` | `str` | — | Switch compatible endpoint (DeepSeek, Gemini gateway, vLLM…) |
+| `model` | `str` | — | Model id |
+| `temperature` | `float` | `0.2` | Sampling temperature |
 
-**Recommendation**: pass all four explicitly. Skipping env vars makes debugging and auditing cleaner:
+Pass all four explicitly, or pass a fully-constructed `llm_client=` (see below). **Mutually exclusive**: passing both `llm_client=` and any of the raw LLM params raises `ValueError`.
+
+For multi-tenant apps, each session can carry **different credentials** (e.g. per customer) — see Part 7.2.
+
+## Embedded-harness explicit injections (0.2.16+)
+
+When you don't want `Agentao()` to construct a subsystem from defaults, inject your own:
+
+| Param | Type | What gets skipped when injected |
+|-------|------|---------------------------------|
+| `llm_client` | `LLMClient` | No `LLMClient(...)` is constructed; no env reads for credentials |
+| `logger` | `logging.Logger` | The package-root level/handler mutation in `LLMClient.__init__` is skipped — your stack stays untouched |
+| `memory_manager` | `MemoryManager` | No `<wd>/.agentao/memory.db` open at startup |
+| `skill_manager` | `SkillManager` | The bundled-skill auto-discovery scan is skipped — your instance is used verbatim |
+| `project_instructions` | `str` | The `<wd>/AGENTAO.md` disk read is skipped — your string is used verbatim |
+| `mcp_manager` | `McpClientManager` | No `.agentao/mcp.json` discovery; you own the MCP lifecycle |
+| `filesystem` | `FileSystem` | File / search tools route through your `FileSystem` (see Part 6.4) |
+| `shell` | `ShellExecutor` | The shell tool routes through your `ShellExecutor` |
+
+These are the bridges hosts use when they want Agentao's runtime but not its CLI-style implicit reads. Combine freely:
 
 ```python
+from agentao import Agentao
+from agentao.llm import LLMClient
+from agentao.capabilities import LocalFileSystem
+
 agent = Agentao(
-    api_key=settings.openai_api_key,
-    base_url=settings.openai_base_url,
-    model=settings.openai_model,
-    temperature=0.1,
-    ...
+    working_directory=Path("/srv/agent-workdir"),
+    llm_client=LLMClient(
+        api_key=secrets.openai_api_key,
+        base_url="https://api.openai.com/v1",
+        model="gpt-5.4",
+        log_file=None,             # don't write a log file
+        logger=app.logger,         # use the host's logger
+    ),
+    skill_manager=preloaded_skill_manager,
+    filesystem=LocalFileSystem(),  # or your sandboxed FS
+    transport=my_transport,
 )
 ```
 
-For multi-tenant apps, each session can carry **different credentials** (e.g. per customer) — see Part 7.2.
+### Capability protocols
+
+`FileSystem` / `ShellExecutor` are runtime-checkable `Protocol`s defined in `agentao.capabilities`. The package exports default `LocalFileSystem` / `LocalShellExecutor` implementations that match Agentao's pre-0.2.16 behavior byte-for-byte. Hosts replace them to route IO through Docker exec, virtual filesystems, audit proxies, or remote runners.
+
+```python
+from agentao.capabilities import (
+    FileSystem, FileEntry, FileStat,
+    ShellExecutor, ShellRequest, ShellResult, BackgroundHandle,
+)
+```
+
+See Part 6.4 for the multi-tenant filesystem isolation pattern.
 
 ## Transport (recommended)
 
@@ -56,7 +135,7 @@ For multi-tenant apps, each session can carry **different credentials** (e.g. pe
 |-------|------|---------|---------|
 | `transport` | `Transport` | `NullTransport()` | UI interaction + event stream |
 
-One `Transport` covers all interaction: tool confirmations, user asks, event streaming, max-iteration fallback. **Skip it = auto-approve everything, no event listener** (that's `NullTransport`) — fine for headless batch jobs.
+One `Transport` covers all interaction: tool confirmations, user asks, event streaming, max-iteration fallback. **Skip it = auto-approve everything, no event listener** (`NullTransport`) — fine for headless batch jobs.
 
 ```python
 from agentao.transport import SdkTransport
@@ -67,7 +146,7 @@ transport = SdkTransport(
     ask_user=prompt_user,
     on_max_iterations=lambda n, msgs: {"action": "stop"},
 )
-agent = Agentao(transport=transport, ...)
+agent = Agentao(transport=transport, working_directory=workdir, ...)
 ```
 
 Implementing a custom Transport: see [Part 4](/en/part-4/).
@@ -85,7 +164,7 @@ Implementing a custom Transport: see [Part 4](/en/part-4/).
 | `llm_text_callback` | `on_event=` + `LLM_TEXT` |
 | `on_max_iterations_callback` | `SdkTransport(on_max_iterations=...)` |
 
-**All 8 still work** — Agentao wraps them in a `build_compat_transport()` shim internally. New code should go straight through `Transport` to avoid two parallel channels.
+**All 8 still work** — Agentao wraps them in a `build_compat_transport()` shim internally. New code should go straight through `Transport`.
 
 ## Runtime behavior
 
@@ -93,22 +172,22 @@ Implementing a custom Transport: see [Part 4](/en/part-4/).
 |-------|------|---------|---------|
 | `max_context_tokens` | `int` | `200_000` | Triggers compression (Part 7.3) |
 | `plan_session` | `PlanSession` | `None` | Enables Plan mode; rarely needed in embedders |
-| `permission_engine` | `PermissionEngine` | loaded from `.agentao/permissions.json` | Rule engine (Parts 5.4 / 6.3) |
+| `permission_engine` | `PermissionEngine` | `None` (factory builds one rooted at `wd`) | Rule engine (Parts 5.4 / 6.3) |
 
 ## Session isolation (critical!)
 
 | Param | Type | Default | Purpose |
 |-------|------|---------|---------|
-| `working_directory` | `Path` | `None` (dynamic `Path.cwd()`) | **Must be set explicitly for multi-instance** |
+| `working_directory` | `Path` | `None` (deprecated; will become required in 0.3.0) | **Must be set explicitly for multi-instance** |
 
 **Why it matters**:
-- `None` → agent reads live `Path.cwd()` on every access (CLI behavior; user `cd` is respected)
+- `None` → agent reads live `Path.cwd()` on every access (CLI behavior; user `cd` is respected) — emits `DeprecationWarning` since 0.2.16
 - `Path(...)` → agent freezes on that directory at construction; file tools, `AGENTAO.md`, `.agentao/` config, shell CWD all resolve against it
 
-In embedded contexts (web server, ACP sessions), `Path.cwd()` is **process-global state** — two concurrent sessions will cross-contaminate. Always pass `working_directory=` explicitly per instance.
+In embedded contexts (web server, ACP sessions), `Path.cwd()` is **process-global state** — two concurrent sessions cross-contaminate. Always pass `working_directory=` explicitly per instance.
 
 ```python
-# ❌ Bad: sessions share cwd
+# ❌ Bad: sessions share cwd, plus DeprecationWarning
 agent_a = Agentao(...)
 agent_b = Agentao(...)
 
@@ -123,7 +202,7 @@ agent_b = Agentao(..., working_directory=Path("/tmp/tenant-b"))
 |-------|------|---------|---------|
 | `extra_mcp_servers` | `Dict[str, Dict]` | `None` | Programmatic MCP server injection |
 
-Add MCP servers to a **single session** without touching the project's `.agentao/mcp.json`. Typical use: swap GitHub-token-per-tenant:
+Add MCP servers to a **single session** without touching the project's `.agentao/mcp.json`. Typical use: per-tenant GitHub token:
 
 ```python
 agent = Agentao(
@@ -139,6 +218,23 @@ agent = Agentao(
 ```
 
 Merge rule: **entries here override** same-named entries in `.agentao/mcp.json`.
+
+**Mutually exclusive** with `mcp_manager=`: pass either an already-built manager or the dict to merge, not both.
+
+## Async hosts: `Agentao.arun()`
+
+Sync callers use `agent.chat(user_message)`; async hosts use `await agent.arun(user_message)`.
+
+```python
+async def handle_request(request):
+    response = await agent.arun(
+        request.text,
+        cancellation_token=request.cancel_token,
+    )
+    return {"reply": response}
+```
+
+`arun()` bridges the (still-sync) chat loop through `asyncio.get_running_loop().run_in_executor(None, self.chat, ...)`. Cancellation, replay, and `max_iterations` behave identically across both surfaces. The runtime internals stay sync because they are sequential I/O — exposing async all the way down would expand surface without benefit.
 
 ## Full example: production embedding template
 
@@ -156,7 +252,6 @@ def make_agent_for_session(
     on_event,
     confirm_tool,
 ) -> Agentao:
-    # Per-session permission engine (tunable per tenant)
     engine = PermissionEngine(project_root=tenant_workdir)
     engine.set_mode(PermissionMode.WORKSPACE_WRITE)
 
@@ -167,20 +262,14 @@ def make_agent_for_session(
     )
 
     return Agentao(
-        # LLM
         api_key=os.environ["OPENAI_API_KEY"],
         base_url=os.environ.get("OPENAI_BASE_URL"),
         model="gpt-5.4",
         temperature=0.1,
-        # Interaction
         transport=transport,
-        # Isolation
         working_directory=tenant_workdir,
-        # Resource limits
         max_context_tokens=128_000,
-        # Security
         permission_engine=engine,
-        # Session-scoped MCP
         extra_mcp_servers={
             "gh": {
                 "command": "npx",
@@ -189,6 +278,18 @@ def make_agent_for_session(
             },
         },
     )
+```
+
+Or, when your host already follows the CLI conventions:
+
+```python
+from agentao.embedding import build_from_environment
+
+agent = build_from_environment(
+    working_directory=tenant_workdir,
+    transport=transport,
+    max_context_tokens=128_000,
+)
 ```
 
 Next: [2.3 Lifecycle →](./3-lifecycle)

--- a/developer-guide/zh/appendix/a-api-reference.md
+++ b/developer-guide/zh/appendix/a-api-reference.md
@@ -5,7 +5,9 @@
 权威 `__all__`：
 
 - `from agentao import ...` → `Agentao`、`SkillManager`
+- `from agentao.embedding import ...` → `build_from_environment`
 - `from agentao.transport import ...` → `AgentEvent`、`EventType`、`Transport`、`NullTransport`、`SdkTransport`、`build_compat_transport`
+- `from agentao.capabilities import ...` → `FileSystem`、`LocalFileSystem`、`FileEntry`、`FileStat`、`ShellExecutor`、`LocalShellExecutor`、`ShellRequest`、`ShellResult`、`BackgroundHandle`
 - `from agentao.tools.base import ...` → `Tool`、`ToolRegistry`
 - `from agentao.permissions import ...` → `PermissionEngine`、`PermissionMode`、`PermissionDecision`
 - `from agentao.memory.manager import MemoryManager`
@@ -18,6 +20,8 @@
 
 ### 构造器
 
+完整参数表见 [Part 2.2](/zh/part-2/2-constructor-reference)。**0.2.16 起**，不传 `working_directory=` 调用 `Agentao()` 会发 `DeprecationWarning`，0.3.0 起会变成 `TypeError`。
+
 ```python
 Agentao(
     api_key: str | None = None,
@@ -26,24 +30,51 @@ Agentao(
     temperature: float | None = None,
     transport: Transport | None = None,
     working_directory: Path | None = None,
-    extra_mcp_servers: list[dict] | None = None,
+    extra_mcp_servers: dict[str, dict] | None = None,
     permission_engine: PermissionEngine | None = None,
     max_context_tokens: int = 200_000,
-    plan_session: bool = False,
+    plan_session: PlanSession | None = None,
+    # 嵌入式 harness 显式注入（0.2.16+）
+    llm_client: LLMClient | None = None,
+    logger: logging.Logger | None = None,
+    memory_manager: MemoryManager | None = None,
+    skill_manager: SkillManager | None = None,
+    project_instructions: str | None = None,
+    mcp_manager: McpClientManager | None = None,
+    filesystem: FileSystem | None = None,
+    shell: ShellExecutor | None = None,
     # 老式回调（建议改用 `transport=`）
     output_callback: Callable[[str], None] | None = None,
     confirmation_callback: Callable[[str, str, dict], bool] | None = None,
-    input_callback: Callable[[str], str] | None = None,
+    ask_user_callback: Callable[[str], str] | None = None,
     on_max_iterations_callback: Callable[[int, list], dict] | None = None,
     # ...
 )
 ```
+
+互斥规则（违反时抛 `ValueError`）：
+
+- `llm_client=` 与任何 `api_key=` / `base_url=` / `model=` / `temperature=` 同时传
+- `mcp_manager=` 与 `extra_mcp_servers=` 同时传
+
+### `agentao.embedding.build_from_environment`
+
+```python
+def build_from_environment(
+    working_directory: Path | None = None,
+    **overrides,
+) -> Agentao:
+    ...
+```
+
+CLI 风格的自动发现工厂：读 `.env`、`LLM_PROVIDER` 前缀的 env 变量、`<wd>/.agentao/permissions.json`、`<wd>/.agentao/mcp.json`、内存目录，然后用发现到的值构造 `Agentao`。**调用方传入的 `**overrides` 优先**。同样会触发上面构造器的互斥校验（如果 `overrides` 含 `llm_client`，工厂会先把发现到的 `api_key` / `base_url` / `model` 丢掉再转发）。
 
 ### 方法
 
 | 方法 | 签名 | 作用 |
 |------|------|------|
 | `chat` | `chat(user_message: str, max_iterations: int = 100, cancellation_token: CancellationToken | None = None) -> str` | 跑一轮，返回助手最终文本 |
+| `arun` | `async arun(user_message: str, max_iterations: int = 100, cancellation_token: CancellationToken | None = None) -> str` | 异步接口——通过 `loop.run_in_executor` 桥到 `chat()`。取消、replay、`max_iterations` 语义与同步版完全一致 |
 | `clear_history` | `clear_history() -> None` | 清 `self.messages`；不影响 memory DB |
 | `close` | `close() -> None` | 关 MCP 子进程与 DB handle；请放 `finally:` |
 | `set_provider` | `set_provider(api_key, base_url=None, model=None) -> None` | 运行时换 LLM |
@@ -128,7 +159,14 @@ class Tool(ABC):
     # 注册时由 Agentao 注入
     working_directory: Path | None
     output_callback: Callable[[str], None] | None
+    filesystem: FileSystem | None
+    shell: ShellExecutor | None
+
+    def _get_fs(self) -> FileSystem: ...      # 没注入时 lazy 构造 LocalFileSystem
+    def _get_shell(self) -> ShellExecutor: ... # 没注入时 lazy 构造 LocalShellExecutor
 ```
+
+自定义 Tool 子类需要读写文件时，调用 `self._get_fs()` 而不是直接用 `pathlib`——这样宿主注入的 `FileSystem`（Docker、虚拟 FS、审计代理）会被正确尊重。
 
 ### `ToolRegistry`
 
@@ -138,6 +176,32 @@ class Tool(ABC):
 | `get(name: str) -> Tool` | 不存在时抛 `KeyError`，带可用工具列表 |
 | `list_tools() -> list[Tool]` | |
 | `to_openai_format() -> list[dict]` | OpenAI function-calling schemas |
+
+### Capabilities（`agentao.capabilities`）
+
+文件 / 搜索 / Shell 工具的 IO 都路由经过这两个 runtime-checkable `Protocol`。宿主通过 `Agentao(filesystem=..., shell=...)` 注入自定义实现，可以重定向到 Docker exec、虚拟文件系统、审计代理或远程 runner。包还导出与 0.2.16 之前字节级一致的默认实现 `LocalFileSystem` / `LocalShellExecutor`。
+
+```python
+class FileSystem(Protocol):
+    def read_bytes(self, path: Path) -> bytes: ...
+    def read_partial(self, path: Path, n: int) -> bytes: ...
+    def open_text(self, path: Path) -> Iterator[str]: ...      # 流式读取
+    def write_text(self, path: Path, data: str, *, append: bool = False) -> None: ...
+    def list_dir(self, path: Path) -> list[FileEntry]: ...
+    def glob(self, base: Path, pattern: str, *, recursive: bool) -> list[Path]: ...
+    def stat(self, path: Path) -> FileStat: ...
+    def exists(self, path: Path) -> bool: ...
+    def is_dir(self, path: Path) -> bool: ...
+    def is_file(self, path: Path) -> bool: ...
+
+class ShellExecutor(Protocol):
+    def run(self, request: ShellRequest) -> ShellResult: ...
+    def run_background(self, request: ShellRequest) -> BackgroundHandle: ...
+```
+
+冻结的 dataclass：`FileEntry(name, is_dir, is_file, size)`、`FileStat(size, mtime, is_dir, is_file)`、`ShellRequest(command, cwd, timeout, on_chunk, env)`、`ShellResult(returncode, stdout, stderr, timed_out)`、`BackgroundHandle(pid, pgid, command, cwd)`。
+
+宿主无法支持真正的后台执行时，可以在 `run_background` 抛 `NotImplementedError`——`ShellTool` 会把它呈现为普通的工具错误字符串。
 
 ## A.4 权限
 

--- a/developer-guide/zh/part-2/2-constructor-reference.md
+++ b/developer-guide/zh/part-2/2-constructor-reference.md
@@ -1,6 +1,36 @@
 # 2.2 构造器完整参数表
 
-`Agentao.__init__` 的签名（`agentao/agent.py`，`Agentao.__init__`）：
+现在有**两条稳定的构造路径**，按宿主已掌握的信息选择：
+
+- **`agentao.embedding.build_from_environment(...)`** —— CLI 风格的自动发现：读 `.env`、`LLM_PROVIDER`、`<wd>/.agentao/permissions.json`、`<wd>/.agentao/mcp.json`、内存目录，然后帮你构造 `Agentao`。当宿主沿用 CLI 的项目目录约定时使用。
+- **直接 `Agentao(...)`** —— 显式注入：你已经持有 `LLMClient`、`PermissionEngine` 等子系统，构造时不希望发生任何 env / 磁盘副作用。
+
+**重要（0.2.16）**：不传 `working_directory=` 调用 `Agentao()` 现在会发 `DeprecationWarning`，0.3.0 起会变成 `TypeError`。请显式传入 `Path`，或走 `build_from_environment()`。
+
+## 工厂：`build_from_environment()`
+
+```python
+from pathlib import Path
+from agentao.embedding import build_from_environment
+
+agent = build_from_environment(
+    working_directory=Path("/data/tenant-acme"),
+    transport=my_transport,
+    max_context_tokens=128_000,
+)
+```
+
+它做的事：
+
+1. 解析 `working_directory`（默认 `Path.cwd()`），冻结成绝对路径。
+2. `<wd>/.env` 存在则按它 `load_dotenv`，否则全局回落。
+3. 读 `LLM_PROVIDER` 与对应的 `*_API_KEY` / `*_BASE_URL` / `*_MODEL`。
+4. 构造 `PermissionEngine(project_root=wd)` 与 `MemoryManager(project_root=wd/.agentao, global_root=~/.agentao)`。
+5. 把所有显式参数传入 `Agentao(...)`。**调用方传入的 `**overrides` 优先**。
+
+整个代码库里只有这一处会在启动时读 env / dotenv / `.agentao/*.json`。不希望发生这些副作用的宿主直接构造 `Agentao` 即可。
+
+## `Agentao.__init__` 完整签名（`agentao/agent.py`）
 
 ```python
 Agentao(
@@ -8,7 +38,7 @@ Agentao(
     base_url:         Optional[str]    = None,
     model:            Optional[str]    = None,
     temperature:      Optional[float]  = None,
-    # ── 下面 8 个是已废弃的 legacy 回调（仍保留向后兼容） ──
+    # ── 已废弃的 legacy 回调（仍保留向后兼容） ──
     confirmation_callback:      Optional[Callable] = None,
     max_context_tokens:         int                = 200_000,
     step_callback:              Optional[Callable] = None,
@@ -24,6 +54,15 @@ Agentao(
     *,
     working_directory:  Optional[Path]                     = None,
     extra_mcp_servers:  Optional[Dict[str, Dict[str, Any]]] = None,
+    # ── 嵌入式 harness 显式注入参数（0.2.16+） ──
+    llm_client:           Optional[LLMClient]         = None,
+    logger:               Optional[logging.Logger]    = None,
+    memory_manager:       Optional[MemoryManager]     = None,
+    skill_manager:        Optional[SkillManager]      = None,
+    project_instructions: Optional[str]               = None,
+    mcp_manager:          Optional[McpClientManager]  = None,
+    filesystem:           Optional[FileSystem]        = None,
+    shell:                Optional[ShellExecutor]     = None,
 )
 ```
 
@@ -31,24 +70,64 @@ Agentao(
 
 | 参数 | 类型 | 默认 | 说明 |
 |------|------|------|------|
-| `api_key` | `str` | 从环境读 `OPENAI_API_KEY` | LLM 凭据 |
-| `base_url` | `str` | 环境 `OPENAI_BASE_URL` 或官方默认 | 切换兼容端点（DeepSeek / Gemini gateway / vLLM 等） |
-| `model` | `str` | 环境 `OPENAI_MODEL` 或厂商默认 | 模型 ID |
-| `temperature` | `float` | 环境 `LLM_TEMPERATURE` 或 `0.2` | 采样温度 |
+| `api_key` | `str` | —— 必须显式传入或来自 `llm_client=` | LLM 凭据 |
+| `base_url` | `str` | —— | 切换兼容端点（DeepSeek / Gemini gateway / vLLM 等） |
+| `model` | `str` | —— | 模型 ID |
+| `temperature` | `float` | `0.2` | 采样温度 |
 
-**推荐做法**：全部显式传入，不依赖环境变量。这样嵌入你的产品时，调试和审计都更清晰：
+要么 4 个全部显式传入，要么传入已经构造好的 `llm_client=`（见下文）。**互斥**：同时传 `llm_client=` 与任意原始 LLM 参数会抛 `ValueError`。
+
+多租户/多会话场景下：每个会话可以有**不同的凭据**（比如按客户区分），详见第 7.2 节。
+
+## 嵌入式 harness 显式注入（0.2.16+）
+
+不希望 `Agentao()` 用默认值构造某个子系统时，把你自己的实例注入进来：
+
+| 参数 | 类型 | 注入后跳过的行为 |
+|------|------|-----------------|
+| `llm_client` | `LLMClient` | 不再构造 `LLMClient(...)`，凭据相关的 env 读取被跳过 |
+| `logger` | `logging.Logger` | 跳过 `LLMClient.__init__` 里对包根 logger 的 level/handler 改动——你的日志栈保持不变 |
+| `memory_manager` | `MemoryManager` | 启动时不再打开 `<wd>/.agentao/memory.db` |
+| `skill_manager` | `SkillManager` | 跳过自带技能扫描，按你给的实例原样使用 |
+| `project_instructions` | `str` | 跳过 `<wd>/AGENTAO.md` 的磁盘读取，按你给的字符串原样使用 |
+| `mcp_manager` | `McpClientManager` | 不读 `.agentao/mcp.json`，由你掌控 MCP 生命周期 |
+| `filesystem` | `FileSystem` | 文件 / 搜索工具走你提供的 `FileSystem`（详见 6.4 节） |
+| `shell` | `ShellExecutor` | Shell 工具走你提供的 `ShellExecutor` |
+
+这是宿主在"我要 Agentao 的运行时但不要它的 CLI 风格隐式读取"场景下的桥梁。可以自由组合：
 
 ```python
+from agentao import Agentao
+from agentao.llm import LLMClient
+from agentao.capabilities import LocalFileSystem
+
 agent = Agentao(
-    api_key=settings.openai_api_key,
-    base_url=settings.openai_base_url,
-    model=settings.openai_model,
-    temperature=0.1,
-    ...
+    working_directory=Path("/srv/agent-workdir"),
+    llm_client=LLMClient(
+        api_key=secrets.openai_api_key,
+        base_url="https://api.openai.com/v1",
+        model="gpt-5.4",
+        log_file=None,            # 不落本地日志
+        logger=app.logger,        # 走宿主自己的 logger
+    ),
+    skill_manager=preloaded_skill_manager,
+    filesystem=LocalFileSystem(),  # 或者你自己的沙盒 FS
+    transport=my_transport,
 )
 ```
 
-多租户/多会话场景下：每个会话可以有**不同的凭据**（比如按客户区分），详见第 7.2 节。
+### Capability 协议
+
+`FileSystem` / `ShellExecutor` 是 `agentao.capabilities` 里的 runtime-checkable `Protocol`。包同时导出默认实现 `LocalFileSystem` / `LocalShellExecutor`，行为与 0.2.16 之前的 Agentao 字节级一致。宿主可替换为基于 Docker exec、虚拟文件系统、审计代理或远程 runner 的实现。
+
+```python
+from agentao.capabilities import (
+    FileSystem, FileEntry, FileStat,
+    ShellExecutor, ShellRequest, ShellResult, BackgroundHandle,
+)
+```
+
+多租户文件隔离方式参考 6.4 节。
 
 ## Transport（推荐）
 
@@ -67,7 +146,7 @@ transport = SdkTransport(
     ask_user=prompt_user,
     on_max_iterations=lambda n, msgs: {"action": "stop"},
 )
-agent = Agentao(transport=transport, ...)
+agent = Agentao(transport=transport, working_directory=workdir, ...)
 ```
 
 自己实现 Transport Protocol 参见 [第 4 部分](/zh/part-4/)。
@@ -85,7 +164,7 @@ agent = Agentao(transport=transport, ...)
 | `llm_text_callback` | `on_event=` + 监听 `LLM_TEXT` |
 | `on_max_iterations_callback` | `SdkTransport(on_max_iterations=...)` |
 
-**这 8 个参数仍然被接收并工作**——Agentao 内部 `build_compat_transport()` 会把它们翻译成一个 `SdkTransport`。但新写的代码应直接用 Transport 路径，避免双通道混淆。
+**这 8 个参数仍然被接收并工作**——Agentao 内部 `build_compat_transport()` 会把它们翻译成一个 `SdkTransport`。但新写的代码应直接用 Transport 路径。
 
 ## 运行时行为控制
 
@@ -93,22 +172,22 @@ agent = Agentao(transport=transport, ...)
 |------|------|------|------|
 | `max_context_tokens` | `int` | `200_000` | 超过触发上下文压缩（第 7.3 节） |
 | `plan_session` | `PlanSession` | `None` | 启用 Plan 模式；一般宿主无需设置 |
-| `permission_engine` | `PermissionEngine` | 从 `.agentao/permissions.json` 加载 | 权限规则引擎（第 5.4 / 6.3 节） |
+| `permission_engine` | `PermissionEngine` | `None`（工厂会建一个 `project_root=wd` 的） | 权限规则引擎（第 5.4 / 6.3 节） |
 
 ## 会话隔离（关键！）
 
 | 参数 | 类型 | 默认 | 说明 |
 |------|------|------|------|
-| `working_directory` | `Path` | `None`（= 运行时动态 `Path.cwd()`） | **多实例嵌入必须显式传入** |
+| `working_directory` | `Path` | `None`（已废弃；0.3.0 起变成必传） | **多实例嵌入必须显式传入** |
 
 **为什么重要**：
-- `None` 时，Agent 每次访问当前目录都读实时 `Path.cwd()` ——这是 CLI 行为，用户 `cd` 进去就生效
+- `None` 时，Agent 每次访问当前目录都读实时 `Path.cwd()` ——CLI 行为，用户 `cd` 进去就生效；0.2.16 起会发 `DeprecationWarning`
 - 传入具体 `Path` 时，Agent 在构造时**冻结**到这个目录，之后所有文件操作、`AGENTAO.md`、`.agentao/` 配置、Shell CWD 全部相对它
 
 嵌入场景（Web 服务器、ACP sessions）里，`Path.cwd()` 是进程全局状态；两个并发会话会**互相污染**。务必为每个 Agent 实例显式 `working_directory=`。
 
 ```python
-# ❌ 不好：两个会话会串目录
+# ❌ 不好：两个会话会串目录，还会触发 DeprecationWarning
 agent_a = Agentao(...)
 agent_b = Agentao(...)
 
@@ -140,11 +219,28 @@ agent = Agentao(
 
 合并策略：**同名键会覆盖** `.agentao/mcp.json` 里的同名服务器。
 
+**与 `mcp_manager=` 互斥**：要么传已经构造好的 manager，要么传待合并的 dict，不能两个都传。
+
+## 异步宿主：`Agentao.arun()`
+
+同步调用方仍然用 `agent.chat(user_message)`；异步宿主用 `await agent.arun(user_message)`。
+
+```python
+async def handle_request(request):
+    response = await agent.arun(
+        request.text,
+        cancellation_token=request.cancel_token,
+    )
+    return {"reply": response}
+```
+
+`arun()` 通过 `asyncio.get_running_loop().run_in_executor(None, self.chat, ...)` 把（仍是同步的）chat 循环桥到线程池。取消、replay、`max_iterations` 在两条接口上的语义完全一致。运行时内部刻意保持同步——它本质是顺序 I/O，自上而下的异步会扩大表面但不带来收益。
+
 ## 全量示例：生产嵌入模板
 
 ```python
 from pathlib import Path
-import logging
+import os
 from agentao import Agentao
 from agentao.transport import SdkTransport
 from agentao.permissions import PermissionEngine, PermissionMode
@@ -156,7 +252,6 @@ def make_agent_for_session(
     on_event,
     confirm_tool,
 ) -> Agentao:
-    # 每会话独立的权限引擎（可按租户不同）
     engine = PermissionEngine(project_root=tenant_workdir)
     engine.set_mode(PermissionMode.WORKSPACE_WRITE)
 
@@ -167,20 +262,14 @@ def make_agent_for_session(
     )
 
     return Agentao(
-        # LLM
         api_key=os.environ["OPENAI_API_KEY"],
         base_url=os.environ.get("OPENAI_BASE_URL"),
         model="gpt-5.4",
         temperature=0.1,
-        # 交互
         transport=transport,
-        # 隔离
         working_directory=tenant_workdir,
-        # 资源治理
         max_context_tokens=128_000,
-        # 安全
         permission_engine=engine,
-        # 会话级 MCP
         extra_mcp_servers={
             "gh": {
                 "command": "npx",
@@ -189,6 +278,18 @@ def make_agent_for_session(
             },
         },
     )
+```
+
+如果宿主沿用 CLI 的目录约定，可以走工厂：
+
+```python
+from agentao.embedding import build_from_environment
+
+agent = build_from_environment(
+    working_directory=tenant_workdir,
+    transport=transport,
+    max_context_tokens=128_000,
+)
 ```
 
 下一节：[2.3 生命周期管理 →](./3-lifecycle)

--- a/docs/LOGGING.md
+++ b/docs/LOGGING.md
@@ -347,11 +347,13 @@ grep -B 2 -A 5 "Tool Calls" agentao.log
 在初始化 `Agentao` 时，可以传递日志配置：
 
 ```python
+from pathlib import Path
 from agentao.agent import Agentao
 
 agent = Agentao(
     api_key="your-key",
     model="claude-sonnet-4-5",
+    working_directory=Path.cwd(),
     # log_file 会传递给 LLMClient
 )
 ```

--- a/docs/MODEL_SWITCHING.md
+++ b/docs/MODEL_SWITCHING.md
@@ -172,9 +172,10 @@ OPENAI_MODEL=gpt-5.4
 Or when initializing:
 
 ```python
+from pathlib import Path
 from agentao import Agentao
 
-agent = Agentao(model="gpt-5.4")
+agent = Agentao(model="gpt-5.4", working_directory=Path.cwd())
 ```
 
 ### API Configuration
@@ -312,9 +313,10 @@ This is useful for:
 ### Programmatic Access
 
 ```python
+from pathlib import Path
 from agentao import Agentao
 
-agent = Agentao()
+agent = Agentao(working_directory=Path.cwd())
 
 # Get current model
 current = agent.get_current_model()

--- a/docs/features/CHATAGENT_MD_FEATURE.md
+++ b/docs/features/CHATAGENT_MD_FEATURE.md
@@ -204,8 +204,9 @@ Potential improvements:
 
 View the system prompt to verify instructions are loaded:
 ```python
+from pathlib import Path
 from agentao.agent import Agentao
-agent = Agentao()
+agent = Agentao(working_directory=Path.cwd())
 print(agent._build_system_prompt())
 ```
 

--- a/docs/implementation/EMBEDDED_HARNESS_GITHUB_EPIC.md
+++ b/docs/implementation/EMBEDDED_HARNESS_GITHUB_EPIC.md
@@ -1,0 +1,583 @@
+# Embedded Harness Epic
+
+## Epic
+
+**Title**
+
+Make Agentao a clean embeddable harness via in-place cleanup of construction side effects
+
+**Summary**
+
+Agentao's intended positioning is "an embeddable agent harness inside someone else's app, not a standalone runtime." Today `Agentao.__init__` is a 245-line constructor that implicitly reads env vars, dotenv, `Path.cwd()`, `Path.home()`, and several `.agentao/*.json` files. Embedded hosts (in-process Python, child process, remote service) cannot construct Agentao without inheriting all of those side effects.
+
+This epic does the in-place cleanup: lift implicit environment, cwd/home, and `.agentao/*` reads out of `Agentao.__init__` into a thin `agentao.embedding.build_from_environment()` factory, then remove the remaining fallback reads in staged follow-up issues. By the end of M4, `Agentao(...)` is pure-injection construction. CLI and ACP route through the factory and see zero behavior change. Embedded hosts get a deterministic, side-effect-free construction surface.
+
+We do NOT introduce a parallel `AgentSession` class — `Agentao` remains the single long-term embedding API. We do NOT async-ify the runtime internals — only the public `arun()` surface is async, runtime stays sync.
+
+**Goals**
+
+- Make `Agentao(...)` a pure-injection construction surface with zero implicit env / disk / cwd reads after the capability, factory, fallback-removal, and opt-in subsystem issues land
+- Lift env / dotenv / cwd / home / `.agentao/*` reads into `agentao.embedding.factory.build_from_environment()`
+- Inject `FileSystem` and `ShellExecutor` capability into existing file/search/shell tools (no tool rewrites)
+- Add `schema_version` to `AgentEvent` for versioned wire schema
+- Invert `LLMClient` logger ownership so embedded hosts can inject their own logger without `getLogger("agentao")` being mutated
+- Add async public surface `Agentao.arun()` (runtime internals stay sync)
+- Force explicit `working_directory` in 0.3.0 (minor, BREAKING) after one patch release of soft deprecation in 0.2.16
+- Make `Replay` / `Sandbox` / `BgStore` opt-in (None = disabled) for embedded hosts
+
+**Non-goals for v1**
+
+- New parallel `AgentSession` class (rejected — `Agentao` is the long-term embedding API)
+- Async runtime internals (`ToolRunner` / `ChatLoopRunner` stay sync)
+- `AsyncTransport` (only public `arun()` is async; internal `Transport` Protocol unchanged)
+- `MemoryStore` / `MCPRegistry` / `Logger` / `Tracer` Protocol abstraction (deferred to M5)
+- Removing `Agentao` 's existing transport / cancellation / replay primitives — they are reused as-is
+
+**Acceptance Criteria**
+
+- An embedded host can construct `Agentao(working_directory=Path(...), llm_config=..., filesystem=..., shell=...)` with **zero** implicit env / disk / cwd reads after M4 completes
+- `agentao.embedding.build_from_environment()` reproduces today's CLI behavior end-to-end
+- CLI launch (`./run.sh`) and ACP `session/new` behavior unchanged
+- File, search, and shell tools route through capability backends; in-memory fakes can replace them
+- `AgentEvent.schema_version == 1` ships in all wire payloads (ACP/SSE/host)
+- `LLMClient` no longer mutates `getLogger("agentao")` (level or handlers) when caller injects a logger
+- `LLMClient(log_file=None, logger=injected)` constructs with zero package-root side effects
+- Embedded async host can `await agent.arun(...)` without manual thread bridging
+- After 0.3.0, `Agentao()` without `working_directory=` raises `TypeError`
+
+**Dependencies / Reuse**
+
+- Existing runtime layering: `agentao/runtime/` (`ToolRunner`, `ChatLoopRunner`, `ToolExecutor`)
+- Existing transport abstraction: `agentao/transport/` (Protocol unchanged)
+- Existing tool base: `agentao/tools/base.py`
+- Existing memory / permission / MCP / replay / sandbox subsystems retain public APIs; only their fallback paths are removed
+
+**Risks**
+
+- **Factory + fallback cleanup touches many files.** Mitigated by splitting into Issue 4 (factory + CLI/ACP migration, fallbacks intact), Issue 5 (subsystem fallback deletion), and Issue 9 (opt-in replay/sandbox/background subsystems).
+- **Hard break of `Agentao()` would surprise PyPI users and break repo's own `examples/`.** Mitigated by Issue 7 soft deprecation cycle (0.2.16 patch) before Issue 8 hard break (0.3.0 minor, standard SemVer breaking).
+- **Capability injection threads through every file/search/shell tool.** Mitigated by Issue 3 keeping default `LocalFileSystem` / `LocalShellExecutor` byte-equivalent to today.
+- **`Path.cwd()` removal interacts with CLI `cd` semantics.** Factory captures `Path.cwd()` once at startup; CLI users who rely on lazy cwd switching mid-process will see a change. Documented in Issue 8.
+
+## Issue 1
+
+**Title**
+
+Add `schema_version` to `AgentEvent` for versioned wire payloads
+
+**Problem**
+
+`AgentEvent` is a dataclass with only `type` and `data` fields (`agentao/transport/events.py:42-76`). The wire payload that ACP / SSE / embedded host receives carries no schema version, so future schema changes cannot be negotiated. ACP has its own `ACP_PROTOCOL_VERSION = 1` (`agentao/acp/protocol.py:16`), but the runtime event payload itself is unversioned.
+
+**Scope**
+
+- Add `schema_version: int = 1` to `AgentEvent`
+- Add `to_dict() -> dict[str, Any]` serializer
+- Wire transports emit `schema_version` in their payload
+
+**Implementation Checklist**
+
+- [ ] Add `schema_version: int = 1` field to `AgentEvent` dataclass
+- [ ] Add `to_dict()` method returning `{"type": ..., "schema_version": ..., "data": ...}`
+- [ ] Update `agentao/transport/sdk.py` to emit `schema_version` in serialized payload
+- [ ] Update `agentao/acp/transport.py` to forward `schema_version` in `session/update` notifications
+- [ ] Add `tests/test_event_schema_version.py` asserting default value on a concrete event and presence in wire output
+- [ ] Audit replay snapshot fixtures (`tests/test_replay*.py`), ACP wire-trace assertions, and any test using `==` on a serialized event dict for two-key `{type, data}` shape strictness — update to expect the three-key shape
+- [ ] Document the field on `AgentEvent` docstring as the runtime-payload version contract
+
+**Acceptance Criteria**
+
+- `AgentEvent(EventType.TURN_START).schema_version == 1`
+- ACP wire trace shows `schema_version` field in every notification payload
+- Existing tests pass after the dict-shape audit; no consumer pins the legacy two-key shape
+
+## Issue 2
+
+**Title**
+
+Invert `LLMClient` logger ownership for embedded hosts
+
+**Problem**
+
+`LLMClient.__init__` writes to the `getLogger("agentao")` package root: it sets level to DEBUG and attaches a `RotatingFileHandler` (`agentao/llm/client.py:142-180`). The current code already tags its own handlers with `_agentao_llm_file_handler=True` and only evicts marked handlers on reconstruction, so it does **not** drop outsider handlers (e.g. AcpServer's stderr guard). The remaining problem is **inversion of control**: an embedded host that injects its own logger still has its package-root level and handler list mutated underneath it. There is no way to say "I own this logger; don't touch it."
+
+**Scope**
+
+- Accept injected `logger` parameter
+- When caller provides a logger, do not mutate `getLogger("agentao")` package root (no level set, no handler attach/evict)
+- `log_file` becomes optional (None = no file handler)
+
+**Implementation Checklist**
+
+- [ ] Add `logger: logging.Logger | None = None` parameter to `LLMClient.__init__`
+- [ ] Make `log_file: str | None = None` (None means no file handler)
+- [ ] When `logger` is provided, skip `pkg_logger.setLevel()` / `pkg_logger.removeHandler()` / `addHandler()` entirely
+- [ ] Update `Agentao.__init__` to keep current CLI behavior: still pass `log_file=str(self.working_directory / "agentao.log")`
+- [ ] Add `tests/test_llm_client_logger_injection.py`:
+  - assert `LLMClient(logger=mock)` does not touch `getLogger("agentao").level` or `.handlers`
+  - assert repeated reconstruction with `logger=mock` is a no-op against the package root
+  - assert `LLMClient(log_file=None)` does not attach any file handler
+- [ ] Document the new behavior in `LLMClient` docstring
+
+**Acceptance Criteria**
+
+- Embedded host can pass own logger and Agentao does not mutate `getLogger("agentao")`
+- `LLMClient(log_file=None)` is a clean construction with zero package-root side effects
+- Existing CLI behavior (file at `<wd>/agentao.log`, package-root DEBUG level) unchanged when `logger=None`
+
+## Issue 3
+
+**Title**
+
+Add `FileSystem` / `ShellExecutor` capability protocols and inject into file/search/shell tools
+
+**Problem**
+
+File, search, and shell tools call local filesystem and process APIs directly (`agentao/tools/file_ops.py`, `agentao/tools/search.py`, `agentao/tools/shell.py`). Embedded hosts cannot route IO through Docker exec, audit logs, virtual FS, remote runners, etc. — the only escape today is monkey-patching.
+
+**Scope**
+
+- Define `FileSystem` and `ShellExecutor` as `Protocol`
+- Provide `LocalFileSystem` / `LocalShellExecutor` defaults with byte-equivalent current behavior
+- `Agentao.__init__` accepts optional capability instances
+- Refactor `ReadFileTool`, `WriteFileTool`, `EditTool`, `ReadFolderTool`, `FindFilesTool`, `SearchTextTool`, `ShellTool` to call capabilities
+
+**Implementation Checklist**
+
+- [ ] Create `agentao/capabilities/__init__.py`
+- [ ] Create `agentao/capabilities/filesystem.py`:
+  - [ ] `FileEntry`, `FileStat` dataclasses
+  - [ ] `class FileSystem(Protocol)` with `read_bytes`, `write_text`, `list_dir`, `glob`, `stat`, `exists`, `is_dir`, `is_file`
+  - [ ] `class LocalFileSystem` with byte-equivalent default implementations
+- [ ] Create `agentao/capabilities/shell.py`:
+  - [ ] `ShellRequest`, `ShellResult`, `BackgroundHandle` dataclasses
+  - [ ] `class ShellExecutor(Protocol)` with `run`, `run_background`
+  - [ ] `class LocalShellExecutor` reusing `agentao/tools/shell.py:_run_foreground` / `_run_background` logic
+- [ ] Refactor `agentao/tools/file_ops.py` to take a `FileSystem` and route through it
+- [ ] Refactor `agentao/tools/search.py` to take a `FileSystem` and route glob/search reads through it
+- [ ] Refactor `agentao/tools/shell.py` to take a `ShellExecutor` and route through it
+- [ ] Add `filesystem: FileSystem | None = None`, `shell: ShellExecutor | None = None` to `Agentao.__init__` (None = local default)
+- [ ] Update `agentao/tooling/registry.py::register_builtin_tools` to wire capabilities to tools
+- [ ] Add `tests/test_filesystem_capability_swap.py` with in-memory fake FS verifying tool calls route through it
+- [ ] Add `tests/test_shell_capability_swap.py` with mock executor capturing all shell invocations
+- [ ] Add `tests/test_local_filesystem_byte_equivalence.py`: snapshot fixture-tree listing / glob / stat output before refactor; assert exact equality after `LocalFileSystem` is in place — covers `os.scandir` ordering, `Path.glob` symlink follow, and exposed stat fields
+
+**Acceptance Criteria**
+
+- Default behavior identical to today; CLI / ACP / existing test suite unchanged
+- Embedded host can pass an in-memory `FileSystem` and file/search tool reads/writes/listing route through it
+- Embedded host can pass a Docker-backed `ShellExecutor` and shell calls route through it
+- Existing working-directory-relative path resolution and any tool-side path-restriction logic continue to apply (capability is the IO layer; restriction stays in the tool)
+
+## Issue 4
+
+**Title**
+
+Add `agentao/embedding/factory.py` and migrate CLI/ACP to it
+
+**Problem**
+
+`Agentao.__init__` reads env (`LLM_PROVIDER`, `*_API_KEY`, `*_BASE_URL`, `*_MODEL`), dotenv, `Path.cwd()`, `Path.home()`, `.agentao/permissions.json`, `.agentao/mcp.json`, `.agentao/sandbox.json`, `.agentao/replay.json` implicitly. Embedded hosts cannot construct Agentao without inheriting all those side effects. CLI / ACP currently rely on this implicit behavior.
+
+**Scope**
+
+- Add `agentao.embedding.build_from_environment(...)` that captures all current implicit reads
+- CLI and ACP entrypoints route through it
+- `Agentao.__init__` continues to accept old keyword arguments (compatibility path) — no breaking change in this issue
+
+**Implementation Checklist**
+
+- [ ] Create `agentao/embedding/__init__.py` exporting `build_from_environment`
+- [ ] Create `agentao/embedding/factory.py::build_from_environment(working_directory: Path | None = None, **overrides) -> Agentao`
+- [ ] Inside factory:
+  - [ ] `load_dotenv()` (reads `.env` from working_directory or fallback)
+  - [ ] Read `LLM_PROVIDER` and provider-prefixed env vars → construct LLM config
+  - [ ] `working_directory or Path.cwd()` resolved to absolute Path
+  - [ ] Load `<wd>/.agentao/permissions.json` + `~/.agentao/permissions.json` → construct `PermissionEngine`
+  - [ ] Load `<wd>/.agentao/mcp.json` + `~/.agentao/mcp.json` → MCP server config dict
+  - [ ] Compute memory roots `<wd>/.agentao` + `~/.agentao`
+  - [ ] Load replay / sandbox / bg_store config from `<wd>/.agentao/`
+  - [ ] Pass everything explicitly to `Agentao(...)`
+- [ ] `Agentao.__init__` accepts new explicit-injection keyword args alongside the existing legacy args. Precedence rule: an injected fully-constructed object always wins over its raw-config sibling; if both are supplied, raise `ValueError`:
+  - [ ] `llm_client: LLMClient | None` (preferred; injected wins) **or** existing `api_key` / `base_url` / `model` / `temperature` (legacy raw config — factory uses these)
+  - [ ] `logger: logging.Logger | None` (forwarded to `LLMClient` per Issue 2)
+  - [ ] `permission_engine: PermissionEngine | None`
+  - [ ] `memory_manager: MemoryManager | None`
+  - [ ] `skill_manager: SkillManager | None` (when injected, suppress auto-discovery — see Issue 5)
+  - [ ] `project_instructions: str | None` (when injected, suppress `_load_project_instructions` disk read — see Issue 5)
+  - [ ] `mcp_manager: McpClientManager | None` (preferred) **or** existing `extra_mcp_servers: dict | None` (factory builds dict from disk)
+  - [ ] `filesystem: FileSystem | None` / `shell: ShellExecutor | None`
+- [ ] Migrate `agentao/cli/app.py` and `agentao/cli/entrypoints.py` to call `build_from_environment()`
+- [ ] Migrate `agentao/acp/session_new.py` to call `build_from_environment(working_directory=request_cwd)`
+- [ ] Migrate `agentao/acp/session_load.py` similarly
+- [ ] Add `tests/test_factory_build_from_environment.py` with tmpdir fixtures simulating `.env` + `.agentao/*.json`
+- [ ] Add a CLI smoke test confirming `./run.sh` startup is unchanged
+
+**Acceptance Criteria**
+
+- CLI launch behavior identical to today
+- ACP `session/new` and `session/load` behavior identical to today
+- Factory can be invoked with full env stub for deterministic testing
+- Existing tests all pass — fallback paths in subsystems remain (deletion is Issue 5)
+
+## Issue 5
+
+**Title**
+
+Tighten core: delete fallbacks from `LLMClient` / `MemoryManager` / `PermissionEngine` / `load_mcp_config`
+
+**Problem**
+
+After Issue 4 ships, the factory always passes explicit values to subsystems, but the underlying modules still have fallback paths (`os.getenv`, `Path.home()`, `Path.cwd()`) that allow implicit construction. These are dead code from CLI / ACP perspective post-Issue-4 but a foot-gun for any embedding host that constructs them directly.
+
+**Scope**
+
+Mostly deletion PR. No CLI / ACP behavior change because Issue 4 already passes subsystem values explicitly through the factory.
+
+**Implementation Checklist**
+
+- [ ] `LLMClient.__init__`: delete `os.getenv` block (`agentao/llm/client.py:108-127`); make `api_key`, `base_url`, `model`, `temperature` required
+- [ ] `MemoryManager.__init__`: delete `Path.home()` fallback; make `project_root` and `global_root` required
+- [ ] `PermissionEngine.__init__`: delete `Path.cwd()` fallback (`agentao/permissions.py:190-201`); make `project_root` required
+- [ ] `load_mcp_config()`: delete `Path.cwd()` fallback (`agentao/mcp/config.py:84-86`); make `project_root` required
+- [ ] Remove direct provider env reads from sub-agent construction (`agentao/agents/tools.py`); inherit resolved parent LLM config or use explicit factory-supplied provider config
+- [ ] **Skill auto-discovery skip path**: today `agent.py:142-144` always calls `SkillManager(working_directory=...)` which discovers project + bundled skills from disk. When `skill_manager` is injected via Issue 4, the constructor must skip the auto-discovery `SkillManager(...)` call entirely and use the injected instance verbatim
+- [ ] **Project-instructions skip path**: today `agent.py:255` unconditionally calls `self._load_project_instructions()` which reads `<wd>/AGENTAO.md`. When `project_instructions` is injected via Issue 4, `Agentao.__init__` must store the override and skip the disk read; `_load_project_instructions` becomes a fallback only used when the injection is `None`
+- [ ] Audit and update any test that constructs `LLMClient()` / `MemoryManager()` / `PermissionEngine()` without args
+- [ ] Add `tests/test_agent_subsystem_injection.py`: construct `Agentao` directly with explicit subsystem injections and verify a chat round-trip works
+- [ ] Add `tests/test_no_subsystem_fallback_reads.py`: monkeypatch `os.environ`, `Path.cwd()`, `Path.home()` to assert these subsystem constructors no longer read them
+- [ ] Add `tests/test_skill_manager_injection.py`: assert injected `skill_manager` is used as-is and no project-skill discovery happens
+- [ ] Add `tests/test_project_instructions_injection.py`: assert injected `project_instructions` is used as-is and `<wd>/AGENTAO.md` is never read
+
+**Acceptance Criteria**
+
+- Constructing `LLMClient()` / `MemoryManager()` / `PermissionEngine()` without args raises `TypeError`
+- CLI and ACP behavior unchanged (factory is the only path that reads env / disk for these subsystems)
+- `Agentao` is constructable with explicit subsystem injections and no env / cwd / home side effects from these fallback paths
+
+## Issue 6
+
+**Title**
+
+Add async public surface `Agentao.arun()` (runtime internals stay sync)
+
+**Problem**
+
+`Agentao.chat()` is sync (`agentao/agent.py:459-477`). Async hosts must wrap calls in `loop.run_in_executor` themselves; cancellation, permission, and event interactions all suffer from the sync facade.
+
+**Scope**
+
+Add `async def arun(...)`. Internal runtime stays sync; thread executor bridges through the same turn lifecycle as `chat()`. We deliberately do NOT introduce `AsyncTransport` — that would expand the change footprint without proportional benefit, since runtime is fundamentally sequential I/O.
+
+**Implementation Checklist**
+
+- [ ] Add `async def arun(self, user_message: str, max_iterations: int = 100, cancellation_token: CancellationToken | None = None) -> str`
+- [ ] Implementation: `await asyncio.get_running_loop().run_in_executor(None, self.chat, user_message, max_iterations, cancellation_token)`. The chat path today goes through `Agentao.chat()` → `ChatLoopRunner.run()` (`agentao/runtime/chat_loop.py`); reuse that pipeline as-is via the executor bridge, do not bypass into `ChatLoopRunner` internals
+- [ ] Keep sync `chat()` on the existing sync path; `chat()` must not call `asyncio.run()` because it would fail inside already-running async hosts
+- [ ] Document in `Agentao` docstring: runtime internals are sync; async surface is the public contract for embedded hosts
+- [ ] Document that `Transport` Protocol stays sync — host's async event handler should bridge at the transport level if needed
+- [ ] Add `tests/test_async_chat.py` running `asyncio.run(agent.arun(...))`
+- [ ] Verify cancellation, replay, max_iterations behave identically between sync and async paths
+
+**Acceptance Criteria**
+
+- Async host can `await agent.arun(...)` without manual thread bridge
+- Sync `chat()` continues to work for CLI
+- Cancellation, replay, max_iterations, transport events behave identically across both surfaces
+- All existing tests pass
+
+## Issue 7
+
+**Title**
+
+Soft deprecate `Agentao()` without `working_directory` and migrate internal docs / examples / tests
+
+**Problem**
+
+After Issues 4-6, embedded hosts have a clean factory entry, but `Agentao(working_directory=None)` still falls back to `Path.cwd()` lazily — keeping the implicit cwd dependency for any caller that doesn't follow the new path. README, multiple docs, and bundled `examples/data-workbench` + `examples/batch-scheduler` all currently demonstrate `Agentao()`. Hard break would surprise PyPI users and break repo's own examples.
+
+**Scope**
+
+Emit `DeprecationWarning` when `Agentao()` is constructed without `working_directory`. Migrate internal README, docs, examples, and tests to the explicit form. Plan hard break for the next minor (0.3.0, Issue 8).
+
+**Implementation Checklist**
+
+- [ ] In `Agentao.__init__`, when `working_directory is None`, emit:
+  ```python
+  warnings.warn(
+      "Agentao() without working_directory= is deprecated and will be required "
+      "in 0.3.0. Pass an explicit Path, or use "
+      "agentao.embedding.build_from_environment() for CLI-style auto-detection "
+      "of cwd/.env/.agentao/.",
+      DeprecationWarning,
+      stacklevel=2,
+  )
+  ```
+- [ ] Sweep all `examples/` (not just data-workbench / batch-scheduler — also `headless_worker.py`, `saas-assistant`, `ticket-automation`, `ide-plugin-ts`) for any `Agentao(...)` construction missing `working_directory=`. Note: `examples/data-workbench/src/workbench.py:86` and `examples/batch-scheduler/src/daily_digest.py:48` already pass `working_directory=workdir` — verify and skip
+- [ ] Update bare `Agentao()` recommendations:
+  - [ ] `README.md:753` ("just `Agentao()` — it uses `NullTransport` automatically") — rewrite to explicit form or `build_from_environment()`
+  - [ ] `README.zh.md:745` (Chinese counterpart)
+  - [ ] `docs/MODEL_SWITCHING.md:317` (bare `Agentao()`)
+  - [ ] `docs/features/CHATAGENT_MD_FEATURE.md:208` (bare `Agentao()`)
+- [ ] Update partial-arg examples missing `working_directory=`:
+  - [ ] `README.md:747` (`Agentao(transport=transport)`)
+  - [ ] `README.zh.md:739`
+  - [ ] `docs/MODEL_SWITCHING.md:177` (`Agentao(model="gpt-5.4")`)
+  - [ ] `docs/LOGGING.md:352` (`Agentao(api_key=..., model=...)`)
+- [ ] Update tests that construct `Agentao()` without args:
+  - [ ] `tests/test_multi_turn.py:21`
+  - [ ] `tests/test_skills_prompt.py:14`
+  - [ ] `tests/test_skill_integration.py:11`
+  - [ ] `tests/test_agentao_md.py:19,52`
+  - [ ] `tests/test_tool_confirmation.py:94`
+  - [ ] `tests/test_date_in_prompt.py:15`
+  - [ ] `tests/test_memory_renderer.py:356,391,424`
+- [ ] Add CHANGELOG entry: "0.2.16: `Agentao()` without `working_directory=` is deprecated; will be required in 0.3.0"
+- [ ] Run `pytest -W error::DeprecationWarning tests/` to ensure no internal warning leakage
+
+**Acceptance Criteria**
+
+- `Agentao()` without `working_directory` triggers a clear `DeprecationWarning` with migration guidance
+- All bundled docs and examples use explicit form or factory
+- `pytest -W error::DeprecationWarning tests/` passes — internal code raises zero warnings
+- CLI and ACP route through factory and raise no warnings
+
+## Issue 8
+
+**Title**
+
+Hard break: `Agentao` requires `working_directory` (0.3.0)
+
+**Problem**
+
+After one release cycle with deprecation (0.2.16 patch), complete the surface tightening in 0.3.0 minor: `working_directory` becomes required keyword-only. The `Path.cwd()` fallback inside `working_directory` property is removed.
+
+**Scope**
+
+Pure-collapse PR. Remove the deprecation warning, make `working_directory` a required keyword argument, delete the lazy property fallback. Bump version to 0.3.0.
+
+**Implementation Checklist**
+
+- [ ] Remove `warnings.warn` block from `Agentao.__init__` (added in Issue 7)
+- [ ] Change signature: `def __init__(self, *, working_directory: Path, ...)`  — keyword-only, required
+- [ ] Delete `Path.cwd()` branch in `working_directory` property (`agentao/agent.py:291-306`); property always returns frozen value
+- [ ] Delete lazy-cwd providers in subsystems that depended on the lazy fallback:
+  - [ ] `bg_store = BackgroundTaskStore(persistence_dir_provider=Path.cwd)` → frozen `persistence_dir=working_directory` (`agent.py:223`)
+  - [ ] `sandbox_policy = SandboxPolicy(project_root_provider=Path.cwd)` → frozen `project_root=working_directory` (`agent.py:268`)
+- [ ] **CLI cwd-change audit**: grep for `os.chdir` across `agentao/cli*` and decide policy. If the CLI never `chdir`s after startup, document "factory captures cwd once at startup; mid-process `cd` is not retargeted" in the CHANGELOG migration section. If the CLI does `chdir` (e.g. via a `/cd` command), re-invoke `build_from_environment()` from that command path or explicitly disable mid-process retargeting
+- [ ] Bump `__version__` in `agentao/__init__.py:8` to `0.3.0`
+- [ ] Update CHANGELOG with `BREAKING:` marker explaining the change and migration path, including the cwd-freeze semantic
+- [ ] Verify `pytest tests/` passes (Issue 7 should have left no implicit constructions)
+- [ ] Manually run `./run.sh` to confirm CLI startup, `/clear`, and post-`cd` behavior matches the documented policy
+
+**Acceptance Criteria**
+
+- `Agentao()` without `working_directory` raises `TypeError`, not warning
+- `agentao.embedding.build_from_environment()` continues to work transparently
+- CHANGELOG documents the migration step (`Agentao()` → `build_from_environment()` or `Agentao(working_directory=...)`)
+- All bundled tests pass
+- Version is `0.3.0`
+
+## Issue 9
+
+**Title**
+
+Make `Replay` / `Sandbox` / `BackgroundTaskStore` opt-in (None = disabled)
+
+**Problem**
+
+`Agentao.__init__` always constructs `ReplayConfig`, `SandboxPolicy`, `BackgroundTaskStore` — which read `<wd>/.agentao/*.json` and the cwd (`agentao/agent.py:216-280`). Embedded hosts that don't want persistence or sandboxing cannot disable them cleanly.
+
+**Scope**
+
+Make all three optional in `Agentao.__init__`. None = disabled. Factory enables them per current CLI behavior.
+
+**Implementation Checklist**
+
+- [ ] Add `replay_config: ReplayConfig | None = None` parameter to `Agentao.__init__`
+- [ ] Add `sandbox_policy: SandboxPolicy | None = None`
+- [ ] Add `bg_store: BackgroundTaskStore | None = None`
+- [ ] When None: skip construction; runtime treats feature as off
+- [ ] When `bg_store is None`, do not register `check_background_agent` / `cancel_background_agent`
+- [ ] When `bg_store is None`, **omit `run_in_background` from the sub-agent tool schema entirely** (do not expose-then-error). Decision: schema-level removal beats runtime error because the LLM can't be tempted to call a disabled feature, and ACP / OpenAI clients won't see a phantom tool. Document in `Agentao` docstring that disabling `bg_store` shrinks the visible tool surface
+- [ ] Update factory to construct all three from `<wd>/.agentao/*` and pass them explicitly (preserves CLI behavior)
+- [ ] Add `tests/test_agent_subsystems_optional.py` constructing `Agentao` with all three None and verifying chat / tool execution still work
+- [ ] Add tests asserting background tools are absent or disabled when `bg_store is None`
+- [ ] Document the opt-in semantics in `Agentao` docstring
+
+**Acceptance Criteria**
+
+- Embedded host can construct `Agentao` with replay / sandbox / bg_store all None and run a chat round-trip
+- CLI behavior preserved through factory
+- No silent default-on for these features in pure-injection mode
+- Background-agent tools cannot dereference `None` stores and expose clear disabled semantics
+
+## Issue 10
+
+**Title**
+
+Define `MemoryStore` Protocol and refactor `MemoryManager` to delegate
+
+**Problem**
+
+`MemoryManager` is tightly coupled to SQLite + filesystem. Embedded hosts that want to back memory with their own storage (Redis, postgres, in-memory, remote API) must subclass `MemoryManager` or fork it.
+
+**Scope**
+
+Define `MemoryStore` Protocol covering persistent memory and session-summary CRUD. Provide `SqliteMemoryStore` default. Refactor `MemoryManager` to consume the Protocol. This is intentionally deferred to M5 because protocol-izing the SQLite-shaped API is a larger surface decision than `FileSystem` / `ShellExecutor`.
+
+**Implementation Checklist**
+
+- [ ] Audit `MemoryManager` public surface: write, search, soft-delete, session-summary CRUD, retrieval
+- [ ] Define `MemoryStore` Protocol in `agentao/capabilities/memory.py`
+- [ ] Implement `SqliteMemoryStore` (current behavior, lifted out of `MemoryManager`)
+- [ ] Refactor `MemoryManager` to take `store: MemoryStore` rather than path roots
+- [ ] Factory builds `SqliteMemoryStore` from path roots and passes to `MemoryManager`
+- [ ] Add `InMemoryMemoryStore` test fake
+- [ ] Document Protocol surface and version policy
+- [ ] Tests: `tests/test_memory_store_swap.py` swaps in InMemoryMemoryStore and verifies all `MemoryManager` operations
+
+**Acceptance Criteria**
+
+- Embedded host can swap memory backend without changing `Agentao` or `MemoryManager`
+- CLI behavior unchanged
+- Protocol surface is documented as stable across future minor releases
+
+## Issue 11
+
+**Title**
+
+Define `MCPRegistry` Protocol and refactor `McpClientManager`
+
+**Problem**
+
+`agentao/mcp/config.py` and `McpClientManager` assume disk-loaded MCP server config. Embedded hosts that want to register MCP servers programmatically (e.g., from a host's plugin system, dynamic discovery, remote registry) must monkey-patch.
+
+**Scope**
+
+Define `MCPRegistry` Protocol covering server enumeration + lifecycle. Default `FileBackedMCPRegistry` reads `.agentao/mcp.json` (current behavior).
+
+**Implementation Checklist**
+
+- [ ] Define `MCPRegistry` Protocol in `agentao/capabilities/mcp.py` (`list_servers`, `get_server`, `connect`, `disconnect`)
+- [ ] Implement `FileBackedMCPRegistry` reading `<wd>/.agentao/mcp.json` + `~/.agentao/mcp.json`
+- [ ] Refactor `McpClientManager` to consume `MCPRegistry` rather than raw config dict
+- [ ] Factory constructs `FileBackedMCPRegistry`
+- [ ] Embedded host can pass an in-memory or remote `MCPRegistry`
+- [ ] Add `tests/test_mcp_registry_swap.py` with programmatic registry
+
+**Acceptance Criteria**
+
+- Embedded host can register MCP servers programmatically
+- CLI loads MCP servers from disk via factory unchanged
+- ACP `session/new` `mcpServers` injection still works (uses programmatic registry path)
+
+## Issue 12
+
+**Title**
+
+Add `docs/EMBEDDING.md` and update existing docs to point at new patterns
+
+**Problem**
+
+After all surface changes, embedded host integration is non-obvious. Capability injection, factory vs. direct construction, async usage, and the migration from old `Agentao()` to the new explicit form are each documented today only inside source comments and this epic.
+
+**Scope**
+
+Add `docs/EMBEDDING.md` covering end-to-end embedding. Update existing docs (README, MODEL_SWITCHING, LOGGING, CHATAGENT_MD_FEATURE) to point at the new patterns.
+
+**Implementation Checklist**
+
+- [ ] Add `docs/EMBEDDING.md` with sections:
+  - [ ] "Minimal embedded construction" (factory path)
+  - [ ] "Pure-injection construction" (`Agentao(workspace=..., llm_config=..., filesystem=..., shell=...)`)
+  - [ ] "Capability injection" (FileSystem / ShellExecutor examples)
+  - [ ] "Async usage" (`await agent.arun()`)
+  - [ ] "Replay / Sandbox / BgStore opt-in"
+  - [ ] "Migration: 0.2.15 → 0.2.16 → 0.3.0"
+- [ ] Update `README.md` to link `docs/EMBEDDING.md` from the embedding section
+- [ ] Update `docs/MODEL_SWITCHING.md`, `docs/LOGGING.md`, `docs/features/CHATAGENT_MD_FEATURE.md` to use the new construction patterns
+- [ ] Sweep all bundled examples and align with the new patterns: `examples/headless_worker.py`, `examples/saas-assistant`, `examples/ticket-automation`, `examples/ide-plugin-ts`, `examples/data-workbench`, `examples/batch-scheduler`. Each example should either call `build_from_environment()` or pass explicit `working_directory=` + capability injections
+
+**Acceptance Criteria**
+
+- An embedded host author can read `docs/EMBEDDING.md` and integrate Agentao without source-diving
+- Migration across 0.2.15 → 0.2.16 → 0.3.0 is documented step-by-step
+- Existing docs no longer show pre-cleanup `Agentao()` patterns
+
+## Suggested Milestones
+
+**M1: Cheap fixes (independently shippable, no dependencies)**
+
+- Issue 1 — Versioned `AgentEvent`
+- Issue 2 — `LLMClient` logger live bug
+
+**M2: Capability injection + factory (the heart of the epic)**
+
+- Issue 3 — `FileSystem` / `ShellExecutor` capability for file/search/shell tools
+- Issue 4 — `agentao/embedding/factory.py` + CLI/ACP migration (fallbacks intact)
+- Issue 5 — Tighten subsystem fallbacks (depends on Issue 4)
+
+**M3: Async surface + soft deprecation**
+
+- Issue 6 — `Agentao.arun()`
+- Issue 7 — Soft deprecate `Agentao()` (depends on Issue 4 — factory must exist)
+
+**M4: Opt-in subsystems + hard break (0.3.0)**
+
+- Issue 9 — Replay / Sandbox / BgStore opt-in
+- Issue 8 — Hard break `working_directory` required (depends on Issue 7 and Issue 9)
+
+**M5: Protocol surface for memory / MCP + docs**
+
+- Issue 10 — `MemoryStore` Protocol
+- Issue 11 — `MCPRegistry` Protocol
+- Issue 12 — `docs/EMBEDDING.md` and existing-docs migration
+
+## Dependency Graph
+
+```
+Issue 1 ──┐
+Issue 2 ──┴── M1 (parallel, independent)
+
+Issue 3 ──┐
+          ├── M2
+Issue 4 ──┤
+          │
+Issue 5 ──┴── (depends on 4)
+
+Issue 6 ──┐
+          ├── M3 (6 independent; 7 depends on 4)
+Issue 7 ──┘
+
+Issue 9 ──┐
+          ├── M4
+Issue 8 ──┘ (depends on 7 and 9)
+
+Issue 10 ─┐
+Issue 11 ─┼── M5
+Issue 12 ─┘
+```
+
+## Cross-References
+
+- Strategy doc: `docs/implementation/EMBEDDED_HARNESS_IMPLEMENTATION_PLAN.md`
+- Source feature plan: `workspace/reports/agentao-embedded-harness-feature-review-2026-04-27.md`
+- Sibling epic (ACP): `docs/implementation/ACP_GITHUB_EPIC.md`
+
+### Issue ↔ PR mapping (vs. IMPLEMENTATION_PLAN)
+
+| GitHub Issue | PR in IMPLEMENTATION_PLAN |
+|---|---|
+| Issue 1 (`schema_version`) | PR 1A |
+| Issue 2 (logger ownership) | PR 1B |
+| Issue 3 (FS / Shell capability) | PR 2 |
+| Issue 4 (factory + CLI/ACP migration) | PR 3a |
+| Issue 5 (delete subsystem fallbacks) | PR 3b |
+| Issue 6 (`Agentao.arun`) | PR 4 |
+| Issue 7 (soft deprecate `Agentao()`) | PR 5a |
+| Issue 8 (hard break, 0.3.0) | PR 5b |
+| Issue 9 (Replay / Sandbox / BgStore opt-in) | PR 6+ |
+| Issue 10 (`MemoryStore` Protocol) | PR 6+ |
+| Issue 11 (`MCPRegistry` Protocol) | PR 6+ |
+| Issue 12 (`docs/EMBEDDING.md`) | PR 6+ |

--- a/docs/implementation/EMBEDDED_HARNESS_IMPLEMENTATION_PLAN.md
+++ b/docs/implementation/EMBEDDED_HARNESS_IMPLEMENTATION_PLAN.md
@@ -1,0 +1,327 @@
+# Embedded Harness — Implementation Plan
+
+**Date:** 2026-04-27
+**Status:** Strategy locked in;待执行
+**Source PLAN:** `workspace/reports/agentao-embedded-harness-feature-review-2026-04-27.md`
+**Scope:** 评审 Codex 给出的"如何落地"建议,并基于用户决策定稿为可执行的 PR 序列。
+
+---
+
+## TL;DR
+
+- **目标:** 让 `Agentao` 成为长期唯一的 embedding API,in-place 清理 `__init__` 的隐式副作用(env / home / cwd / 读盘)。
+- **核心手段:** 把所有隐式行为上提到 `agentao/embedding/factory.py::build_from_environment()`。`Agentao(...)` 退化为纯组装,CLI / ACP 走 factory 保持行为零差异。
+- **不做:** 新建并行 `AgentSession`、ToolRunner / ChatLoopRunner 全量 async 化、P0 引入 MemoryStore / Logger capability。
+- **PR 序列:** PR 1(schema_version + logger 注入)→ PR 2(FS / Shell capability)→ PR 3a(factory + CLI/ACP 切换,0.2.16)→ PR 3b(删除 core fallback,0.2.16)→ PR 4(`arun` async surface)→ PR 5a(`Agentao()` soft deprecation + 内部 README/docs/examples/tests 迁移,0.2.16)→ PR 5b(`working_directory` 必传 hard break,0.3.0)→ PR 6+(MemoryStore / MCPRegistry protocol、Replay / Sandbox / BgStore 默认禁用)。
+
+---
+
+## Decisions locked in
+
+1. **`Agentao` 是 long-term embedding API**,不新建并行 `AgentSession`。所有改动 in-place 落在 `Agentao` 上。
+2. **P0 = in-place 清理副作用**,不是堆 capability 层。env / home / cwd / 读盘全部上提到 `agentao.embedding.factory`。
+3. **Async-first 仅在 public surface 落地**,runtime 内部仍 sync。`Agentao.arun()` 用 thread executor 桥接;不引入 `AsyncTransport`。
+4. **PR 3 拆成 3a + 3b**,降低 review 风险。3a 新增 factory + CLI/ACP 切换(fallback 仍在);3b 删除 core fallback、参数必传。3a 与 3b 不留长期中间态。
+5. **Logger 修复用最小 `logger` / `log_file` 参数**,不引入 logger capability。
+6. **MemoryStore / MCPRegistry protocol 推到 PR 6+**,P0 只做 memory roots / mcp config 显式注入。
+7. **Replay / Sandbox / BgStore 纳入构造副作用清理范围**,默认参数 None 禁用,factory 负责按 CLI 行为启用。
+8. **`Agentao()` 不走立即 hard-break,先在 0.2.16 patch 加 soft deprecation,下一 minor(0.3.0)再 hard break**(PR 5a → PR 5b)。理由:`Agentao` 是已发布的 public API,自带 `examples/` + README 把 `Agentao()` 写成正确用法,下游(PyPI 安装方)不可知。soft deprecation 增量 ~5 行 `warnings.warn`,代价接近零。**不允许跨过 0.3.0 之后还保留 deprecation** —— 拖更长会让"in-place 清理"形同虚设。
+
+---
+
+## Context
+
+原始 PLAN 把方向定下来了:agentao = embedded harness,核心工作是"拆耦合"。Codex 给出了具体落地策略(新增 `core/` 包、保留旧 `Agentao` 作 adapter、capability 注入到现有 tool、P0 分级)。
+
+我验证完代码,Codex 在事实层面准确(下面有逐条核对)。但**用户选定了 in-place 清理路线**,因此 Codex 的 side-by-side 方案(新建 `AgentSession`)被否决,其余核心建议(capability 注入、versioned events、logger 修复、配置注入、不读盘)依然适用 —— 只是落点全部从"新 core 类"改成"`Agentao` 自己 + 一个 thin factory"。Codex 没覆盖到的子系统(replay / plugins / sandbox / bg_store)也要纳入。
+
+---
+
+## 一、Codex 的事实判断 — 全部已核对
+
+| Codex claim | 现状代码 | 结论 |
+|---|---|---|
+| `Agentao.__init__` 是大构造器,12+ 子系统副作用 | `agentao/agent.py:46-289`(245 行 init body) | ✅ 准确,实际比 Codex 描述更严重 |
+| LLM 在 init 时读 env(provider/api/model) | `agentao/llm/client.py:108-127`,5 个 `os.getenv` | ✅ 准确 |
+| Logger 全局 handler 复写 | `agentao/llm/client.py:140-156` 改写 `getLogger("agentao")` package root | ✅ 准确,且**这是 ACP set_model 路径的 live bug** —— 切换 model 重建 LLMClient 会反复触发 |
+| `chat()` 同步 facade | `agentao/agent.py:459-477` | ✅ |
+| Transport 同步协议 | `agentao/transport/base.py:28-55`(`emit` / `confirm_tool` / `ask_user` / `on_max_iterations` 全 sync) | ✅ |
+| Shell 直接 `subprocess.Popen` | `agentao/tools/shell.py:268-310` | ✅ |
+| File ops 直接 `open()` | `agentao/tools/file_ops.py:68-75`(读)+ 写/编辑同样 | ✅ |
+| MCP/Permissions 读盘 | `agentao/mcp/config.py:84`(`Path.home()`)+ `agentao/permissions.py:190-201`(默认 `Path.cwd()`) | ✅ 已支持显式 `project_root` 注入,但 fallback 仍在 |
+| AgentEvent 缺 `schema_version` | `agentao/transport/events.py:42-76` 只有 `type` + `data` | ✅ 准确 |
+| `working_directory` 默认 `Path.cwd()` | `agentao/agent.py:291-306` 已是 lazy fallback | ✅ —— Codex 的描述略宽,实际已经分了"frozen vs lazy"两条路径 |
+| `runtime/` 已拆出 ToolRunner / ChatLoopRunner / ToolExecutor | `agentao/runtime/` 共 11 个文件 | ✅ Codex 正确指出这是好接入点 |
+
+**一处需要补充:** Codex 漏列了 `replay`、`plugins`、`sandbox_policy`、`bg_store`、`plan_session` —— 这五个也是 `Agentao.__init__` 里直接创建的子系统(`agent.py:216-280`),embedding host 同样无法控制。后续 capability 设计要把它们一起考虑。
+
+---
+
+## 二、Codex 推荐的方向 — 适配 in-place 路线后,我同意的部分
+
+1. **Capability 后端注入到现有 tool,不重写 tool** —— 这点尤其对。`ReadFileTool` / `WriteFileTool` / `EditTool` / `ShellTool` 各有 100-300 行的 schema/格式化/截断/二进制检测逻辑,这些都不应该重写,只换底层 `read_bytes` / `write_text` / `run` 调用即可。in-place 路线下,capability 直接注入到 `Agentao.__init__` 的 keyword 参数即可。
+
+2. **P0-B(versioned AgentEvent)优先级靠前** —— 这是最便宜的高收益项。给 dataclass 加一个 `schema_version: int = 1` 字段 + `to_dict()` 方法即可,零兼容风险。
+
+3. **P0-A(logger 注入)** —— 这是 **当下 live bug**,不只是架构债。修复的最小形态是 `LLMClient(logger=...)` 接收注入,不再去写 package root。
+
+4. **不删除 ACP/CLI** —— 同意。它们继续作为 adapter 存在,只是在 PR 3 之后改成走 `factory.build_from_environment()` 而不是直接调 `Agentao(...)`。
+
+### 否决:Codex 的 side-by-side 新建 `AgentSession`
+
+用户已确认长期只保留一个 embedding API(就是 `Agentao`)。所以 Codex 的"新建 `agentao/core/AgentSession`"被否决。代价是 in-place 清理 `Agentao.__init__` 的兼容压力会更大;对策见第四节的 PR 切分。
+
+---
+
+## 三、Codex 推荐的方向 — 我会 push back 的部分
+
+### 3.1 "Async-first" 的边界要更小
+
+Codex 建议:`AsyncTransport` + 旧 `Transport` 共存,`ToolRunner` 内部走 async。这会扩大改动面,而 ToolRunner / ChatLoopRunner 本质是单线程同步循环,async 化拿不到对应收益。
+
+**更小的方案:** 只让 **Session API 异步**(host 可以 `await session.run(...)`);**runtime 内部仍然同步**;async host 通过 `loop.run_in_executor()` 在边界处一次性桥接。`Transport` 不需要新增 async 版本,直接保留现有 sync 协议;真正需要 async 的只是 host 调用 session 的入口。
+
+为什么这样够用:host 关心的是"我从 async 代码里能不能 await",不关心"chat loop 内部怎么 yield"。chat loop 是 LLM 请求 → 工具执行 → 再 LLM 请求,本质是 sequential I/O,thread executor 完全够用。等真正出现 host 需要 cooperative cancellation 透到 LLM HTTP 请求那一层的需求,再做 async transport 不迟。
+
+### 3.2 MemoryStore 不应该在 P0
+
+Codex 把 `MemoryStore` 列为 capability。但 memory 不是 fs/shell 那种"换个 backend"的事:它有 SQLite schema、soft delete、tag 索引、session_summary 关联表、retrieval scoring。要抽 protocol 就要先把 `MemoryManager` 的 public API 钉死,这是 P1 工程量。
+
+**P0 应该只做:** `MemoryManager` 不再在 init 里默认 `Path.home() / ".agentao"`,改成由调用方传入两个 root 参数。`Agentao.__init__` 把这两个 path 算好后再传(保留 CLI 默认行为)。protocol 化推到 P1。
+
+### 3.3 Logger 修复比 Codex 描述的更小
+
+Codex 写的"实例级 logger"暗示要一个 `Logger` capability。但当下 P0 修复的最小形态只是:
+
+```python
+class LLMClient:
+    def __init__(self, ..., logger: logging.Logger | None = None, log_file: str | None = None):
+        self.logger = logger or logging.getLogger("agentao.llm")
+        if log_file:
+            ...  # 只在 log_file 显式传入时才装 file handler
+```
+
+CLI adapter 显式传 `log_file=str(working_dir / "agentao.log")`;embedded host 传 `logger=their_logger, log_file=None`。**不需要 capability protocol,一个 PR 就能落。**
+
+### 3.4 Workspace 显式化(in-place 路线下的真正切分)
+
+in-place 路线下,Codex 的"embedding API 强制显式 workspace"必须落在 `Agentao` 自己上 —— 但这是一个**会破坏现有 CLI 行为**的改动:今天 CLI 不传 `working_directory`,依赖 `Path.cwd()` lazy fallback。
+
+切分:
+- `Agentao.__init__(*, working_directory: Path)` —— 改成强制非 None(major version bump)
+- 新增 `agentao/embedding/factory.py::build_from_environment()` —— 内部 `Path.cwd()` 一次,显式传给 `Agentao(working_directory=...)`
+- CLI/ACP 全部迁移到 factory(在同一个 PR 里完成),零行为差异
+- 嵌入 host 直接 `Agentao(working_directory=Path(...))`,行为可预测
+
+**不能** 让 `Agentao.working_directory` property 继续 fallback,否则 in-place 清理就只是装饰性改动,host 仍然踩到 cwd 副作用。这是 PR 5,放在最后是因为它必须等所有 fallback(env / home / cwd)都集中到 factory 之后才能落。
+
+### 3.5 Codex 漏掉的子系统清单
+
+`Agentao.__init__` 里还有这五个子系统,in-place 清理时要一起考虑:
+
+| 子系统 | 现状 | 处理建议(in-place 路线) |
+|---|---|---|
+| `ReplayRecorder` / `ReplayConfig`(`agent.py:275-280`) | 默认从 `working_directory` 加载 config | `Agentao` 接受可选 `replay_config: ReplayConfig \| None = None`,None 时禁用;factory 负责从盘加载 |
+| `SandboxPolicy`(`agent.py:262-269`) | 读 `.agentao/sandbox.json` | 同上;`sandbox_policy: SandboxPolicy \| None = None` |
+| `BackgroundTaskStore`(`agent.py:217-224`) | 写 `.agentao/background_tasks.json` | `bg_store: BackgroundTaskStore \| None = None`,None 时不持久化 |
+| 插件 hook(`_plugin_hook_rules` / `_loaded_plugins`) | CLI 在 `Agentao` 实例化后注入 | 保持现状(已经是注入式) |
+| `PlanSession`(`agent.py:252`) | 已支持外部传入 | 保持,无需改 |
+
+**关键约束:** in-place 路线下,`Agentao` 默认行为仍然要等价于今天(否则 CLI 会退化)。因此 `replay_config=None` 等"默认禁用"语义只对**显式调用 `Agentao()` 的嵌入 host** 生效;CLI 走 factory,factory 显式启用所有功能保持现状。这等于把"今天 init 里隐式做的事"全部上提到 factory,`Agentao` 自己变成纯组装。
+
+---
+
+## 四、推荐的 PR 序列(in-place 清理路线)
+
+核心策略:把 `Agentao.__init__` 里隐式做的所有事(读 env / home / cwd / dotenv / `.agentao/*`)上提到一个 thin factory `build_from_environment()`,`Agentao` 本身退化成纯组装。CLI/ACP 走 factory(零行为差异);嵌入 host 直接 `Agentao(...)`(完全可控)。
+
+每个 PR 自身可独立 ship,前者不阻塞后者(除了显式标记的依赖)。
+
+### PR 1 — 两个无新抽象的修复(1-2 天,independently good)
+
+**1A. `AgentEvent` 加 `schema_version`**
+- `agentao/transport/events.py`:`@dataclass` 加 `schema_version: int = 1` + `to_dict()`
+- ACP `transport.py`、SSE adapter 的事件序列化路径输出 `schema_version`
+- 现有所有事件构造点零修改(default value)
+
+**1B. `LLMClient` 接受注入 logger**
+- 添加 `logger=None, log_file=None` 参数;`log_file=None` 时不装 file handler,不触动 package root
+- `Agentao.__init__` 继续传 `log_file=str(self.working_directory / "agentao.log")`,CLI 行为不变
+- 修掉 ACP set_model 反复 evict 的 live bug
+
+无依赖,可并行做。
+
+### PR 2 — Capability 接口 + 默认实现注入到 `Agentao.__init__`(3-5 天)
+
+新增 `agentao/capabilities/`:
+
+```python
+class FileSystem(Protocol):
+    def read_bytes(self, path: Path) -> bytes: ...
+    def write_text(self, path: Path, content: str, append: bool = False) -> None: ...
+    def list_dir(self, path: Path, recursive: bool = False) -> list[FileEntry]: ...
+    def stat(self, path: Path) -> FileStat: ...
+
+class ShellExecutor(Protocol):
+    def run(self, request: ShellRequest) -> ShellResult: ...
+    def run_background(self, request: ShellRequest) -> BackgroundHandle: ...
+```
+
+加默认 `LocalFileSystem` / `LocalShellExecutor`,**对外行为完全等价于今天直接调用 `open()` / `subprocess.Popen` 的逻辑**。
+
+`Agentao.__init__` 新增 `filesystem=None`、`shell=None` 参数,None 时装 local 默认。`ReadFileTool` / `WriteFileTool` / `EditTool` / `ShellTool` 改走 capability —— CLI / ACP / 测试零差异。
+
+依赖:无。
+
+### PR 3 — Factory 出现 + 各子系统去 fallback(拆成 3a / 3b 两个 PR)
+
+把"factory 出现"和"删除 fallback"拆成两步,降低 review 风险。语义最终形态不变 —— 中间态不长期保留,3b 紧跟 3a 合并即可。
+
+#### PR 3a — Factory 出现 + CLI/ACP 切到 factory(1 周,**新增** + 各子系统接受可选必传参数,fallback 暂留)
+
+新增 `agentao/embedding/factory.py::build_from_environment(working_directory: Path | None = None) -> Agentao`,内部按今天 CLI 的语义负责:
+
+- `load_dotenv()` + 读 `LLM_PROVIDER` / `*_API_KEY` / `*_BASE_URL` / `*_MODEL` → 构造 LLM 配置
+- `working_directory or Path.cwd()`(在 factory 里 fallback 一次,resolve 为绝对路径)
+- 加载 `<wd>/.agentao/permissions.json` + `~/.agentao/permissions.json` → 构造 `PermissionEngine`
+- 加载 `<wd>/.agentao/mcp.json` + `~/.agentao/mcp.json` → 构造 MCP server config dict
+- 计算 memory roots(`<wd>/.agentao` + `~/.agentao`)
+- 加载 replay config / sandbox config / bg store path
+- 用所有这些已构造对象显式调用 `Agentao(...)`
+
+**3a 不删除子系统的 fallback** —— `LLMClient` 仍然能读 env,`MemoryManager` 仍然能 fallback `Path.home()`,`PermissionEngine` / `load_mcp_config` 仍然能 fallback `Path.cwd()`。但 factory 永远显式传入,不再触发 fallback 路径。
+
+**同 PR 改动:** CLI 入口 `cli.py` 和 ACP 的 `session_new.py` / `session_load.py` 切到 factory;现有测试零变化(因为 CLI 的运行轨迹仍然等价)。
+
+回归定位:行为差异都集中在"factory 内 vs CLI 内"哪边读盘,fallback 仍在,任何线上事故都能回滚到旧 CLI 路径。
+
+依赖:可基于 PR 2,但不强依赖。
+
+#### PR 3b — 收紧:删除 core fallback,参数必传(几天,**纯收紧** + 删代码)
+
+- `LLMClient.__init__` 删掉 `os.getenv` 那一段(`agentao/llm/client.py:108-127`),`api_key` / `base_url` / `model` / `temperature` 必传
+- `MemoryManager.__init__` 删掉 `Path.home()` fallback,两个 root 必传
+- `PermissionEngine.__init__` 删掉 `Path.cwd()` fallback,`project_root` 必传
+- `load_mcp_config()` 删掉 `Path.cwd()` fallback,`project_root` 必传
+- 同步收紧测试:任何直接 `LLMClient()` / `PermissionEngine()` / `MemoryManager()` 的测试改成显式传参
+
+**因为 3a 已经让 factory 显式传入所有这些值,3b 删除 fallback 不会触发任何运行路径变化** —— 这就是拆 PR 的全部价值:3b 是"删代码 + 紧测试",回归窗口很小。
+
+依赖:**强依赖 PR 3a**。两个 PR 之间不要留长期中间态 —— 3a merge 后尽快 ship 3b。
+
+### PR 4 — Async chat surface(1 周)
+
+- `Agentao` 新增 `async def arun(user_message, ...) -> str`(把 `_chat_inner` / `ChatLoopRunner.run` 用 thread executor 桥接)
+- 旧 `chat()` 保留,内部成为 `asyncio.run(self.arun(...))` 的 sync wrapper(或继续走 sync 路径,看测试覆盖)
+- 不引入 `AsyncTransport`;runtime 内部仍然 sync,这是 Codex 推荐的"小一号"async 边界
+
+依赖:无,但建议在 PR 3 之后(否则 async API 还是会摸到 env)。
+
+### PR 5 — `working_directory` 必传(拆成 5a soft deprecation + 5b hard break)
+
+PR 5 不能纯硬破。证据:`Agentao` 在 `agentao/__init__.py:19` 通过 `__all__` 暴露为 public API;README、`docs/MODEL_SWITCHING.md`、`docs/LOGGING.md`、`docs/features/CHATAGENT_MD_FEATURE.md` 多处把 `Agentao()` 写成推荐用法;repo 内 `examples/data-workbench/`、`examples/batch-scheduler/` 都是 `from agentao import Agentao` + `Agentao(...)` 的真实下游;PyPI 已发布(`pyproject.toml` 有完整发布元数据 + GitHub repo)。直接 hard break 等于让 README 抄作业的用户拿到 `TypeError`。
+
+成本极低的折中:soft deprecation 在 0.2.16(patch),然后 hard break 在 0.3.0(minor,标准 SemVer breaking)。
+
+#### PR 5a — Soft deprecation + 内部下游迁移(~3-4 天,与 PR 3b 同 release 或紧随)
+
+**Agentao 改动(~5 行):**
+```python
+# agentao/agent.py
+def __init__(self, ..., working_directory: Optional[Path] = None, ...):
+    if working_directory is None:
+        warnings.warn(
+            "Agentao() without working_directory= is deprecated and will be "
+            "required in 0.3.0. Pass an explicit Path, or use "
+            "agentao.embedding.build_from_environment() for CLI-style "
+            "auto-detection of cwd/.env/.agentao/.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+    # 现状不变:lazy fallback 仍生效
+```
+
+**同 PR 内部下游迁移:**
+- `examples/data-workbench/src/workbench.py`、`examples/batch-scheduler/src/daily_digest.py` 改成显式 `Agentao(working_directory=Path(__file__).parent)` 或 `build_from_environment()`
+- README.md / README.zh.md / docs/MODEL_SWITCHING.md / docs/LOGGING.md / docs/features/CHATAGENT_MD_FEATURE.md 的 `Agentao()` 例子全部改成显式形式 + 加迁移 note
+- 测试代码 `test_multi_turn.py` / `test_skills_prompt.py` / `test_skill_integration.py` 改成显式 `working_directory=tmp_path`(消除内部 DeprecationWarning 噪音)
+- CHANGELOG 写明 0.3.0 将做 hard break
+
+依赖:可在 PR 3a 之后任何时候做(不需要 PR 3b 落地);建议与 PR 3b 同 release 让 0.2.16 同时具备 factory + 警告。
+
+#### PR 5b — Hard break(minor bump,0.3.0)
+
+- 删除 PR 5a 那 5 行 `warnings.warn`
+- `Agentao.__init__(*, working_directory: Path)` 改成强制 keyword-only 必传
+- 删除 `working_directory` property 的 `Path.cwd()` 分支(`agent.py:291-306`)
+- factory 在内部处理 `None → Path.cwd()` 的兜底,然后**显式**传给 `Agentao`
+- 跑 `pytest tests/` 全套确认所有测试已显式传参(应该已经在 5a 完成)
+- CHANGELOG 标记 BREAKING
+
+依赖:**强依赖 PR 3b 和 PR 5a**(其他子系统已无 cwd fallback 才改 Agentao 才有意义;deprecation 已经在 0.2.16 patch release 走过一轮)。
+
+**不允许跨过 0.3.0 之后还保留 deprecation** —— 拖更长会让"in-place 清理"形同虚设,deprecation 永远成为"事实兼容承诺"。
+
+### PR 6+ — 推到后面的项
+
+- **MemoryStore protocol** —— 等 PR 5 落地后再做。protocol 化要先把 public API 钉死,工程量大于 fs/shell。
+- **MCPRegistry / PermissionRegistry protocol** —— 同上。
+- **Replay / Sandbox / BgStore 接受 None 默认禁用** —— 嵌入 host 友好;PR 3 已经分离了构造路径,这步只是把"None 时跳过"的语义 ship 出去。
+
+---
+
+## 五、关键文件清单(后续实施会动到的)
+
+| 文件 | 类型 | PR |
+|---|---|---|
+| `agentao/transport/events.py` | 改 | PR 1A |
+| `agentao/transport/sdk.py`、`agentao/acp/transport.py` | 改(序列化输出 schema_version) | PR 1A |
+| `agentao/llm/client.py:89-194` | 改(logger 注入) | PR 1B |
+| `agentao/agent.py:131-137` | 改(透传 logger 参数) | PR 1B |
+| `agentao/capabilities/{filesystem,shell}.py` | 新 | PR 2 |
+| `agentao/tools/file_ops.py`、`agentao/tools/shell.py` | 改(走 capability) | PR 2 |
+| `agentao/tools/base.py` | 可能改(让 tool 拿到 capability handle) | PR 2 |
+| `agentao/agent.py:216-289` | 改(默认装 local capability) | PR 2 |
+| `agentao/embedding/factory.py` | 新(env / dotenv / home / cwd 全部上提到这里) | PR 3a |
+| `agentao/cli.py`、`agentao/acp/session_new.py`、`agentao/acp/session_load.py` | 改(切到 factory,旧 fallback 暂留) | PR 3a |
+| `agentao/llm/client.py:108-130` | 改(去 `os.getenv`,参数必传) | PR 3b |
+| `agentao/memory/manager.py` | 改(去 `Path.home()` fallback,roots 必传) | PR 3b |
+| `agentao/permissions.py:190-201` | 改(去 `Path.cwd()` fallback) | PR 3b |
+| `agentao/mcp/config.py:84-86` | 改(去 `Path.cwd()` fallback) | PR 3b |
+| `agentao/agent.py:459-477` | 改(加 `arun`,`chat` 退化为 sync wrapper) | PR 4 |
+| `agentao/agent.py:46-112`(`__init__` 入口) | 改(`working_directory=None` 时 `warnings.warn`) | PR 5a |
+| `examples/data-workbench/src/workbench.py:21`、`examples/batch-scheduler/src/daily_digest.py:21` | 改(显式 `working_directory=` 或 `build_from_environment()`) | PR 5a |
+| `README.md:747`、`README.zh.md:739`、`docs/MODEL_SWITCHING.md`、`docs/LOGGING.md`、`docs/features/CHATAGENT_MD_FEATURE.md` | 改(`Agentao()` 例子全部显式) | PR 5a |
+| `tests/test_multi_turn.py`、`tests/test_skills_prompt.py`、`tests/test_skill_integration.py` | 改(显式 `working_directory=tmp_path`) | PR 5a |
+| `agentao/agent.py:46-112` + `:291-306` | 改(删 deprecation warn + 必传 + 删 `Path.cwd()` 分支) | PR 5b |
+
+---
+
+## 六、验证计划(每个 PR 独立)
+
+**PR 1A**:`pytest tests/` 全绿(已有的 transport / event 测试覆盖 schema 字段);新增一个 `test_event_schema_version.py` 断言 `AgentEvent().schema_version == 1`;ACP wire trace 中能看到 `schema_version` 字段。
+
+**PR 1B**:`pytest tests/` 全绿;新增测试断言 `LLMClient(logger=mock_logger)` 不会触动 `getLogger("agentao")` 的 handlers;ACP 反复 `set_model` 后 file handler 不会重复创建/丢失(可以查 log 文件是否仍在写入)。
+
+**PR 2**:`pytest tests/test_*.py` 全绿(因为默认 LocalFS / LocalShell 行为等价);手动跑 `./run.sh` 确认 read/write/edit/shell 工作正常;新增 `test_filesystem_capability_swap.py` 用 in-memory fake 验证 tool 能被换底层。
+
+**PR 3a**:`pytest tests/` 全绿;CLI / ACP 启动行为应当完全等价于今天(因为 factory 用同一套 env / cwd / home 语义);新增 `test_factory_build_from_environment.py` 在 tmpdir 模拟 `.env` + `.agentao/` + `~/.agentao/` 走完整 factory 流。
+
+**PR 3b**:`pytest tests/` 全绿(关键 —— 任何直接 `LLMClient()` / `PermissionEngine()` / `MemoryManager()` 的测试要补齐参数);新增 `test_agent_pure_injection.py` 不走 factory,纯注入构造 `Agentao` 跑一次 chat 验证嵌入路径;CLI/ACP 行为不应有任何变化(因为 3a 已经让 factory 显式传入)。
+
+**PR 4**:`pytest tests/` 全绿;新增 `test_async_chat.py` 用 `asyncio.run(agent.arun(...))` 调一次 chat;旧 `chat()` 行为(包括 cancellation、replay、max_iterations)保持不变。
+
+**PR 5a**:`pytest -W error::DeprecationWarning tests/` —— 让 warning 升级成 error 验证内部代码已经全部迁移完毕(任何遗漏的 `Agentao()` 调用会被精确定位);手动跑 `./run.sh` 不应触发 warning;`python examples/data-workbench/src/workbench.py` 不应触发 warning;CHANGELOG 写明 0.3.0 将 hard break。
+
+**PR 5b**:`pytest tests/` 全绿(应当自然通过,因为 5a 已经清理过);CHANGELOG 标记 BREAKING + minor bump 到 0.3.0;手动跑 `./run.sh` 确认 CLI 启动、`/clear`、`cd` 后 cwd 行为符合预期(CLI 在 factory 里做 `Path.cwd()`,因此每次启动 capture 一次)。
+
+---
+
+## 七、Remaining open questions
+
+主要决策已锁(见顶部 "Decisions locked in")。剩余两个待定:
+
+1. **AGENTAO.md 的处理** —— 现在 `_load_project_instructions` 直接从 `working_directory` 读。in-place 路线下,这个文件读取可以保留在 `Agentao` 里(因为它必然依赖 workspace),但不应该 fallback `Path.cwd()`。PR 3 同步迁过去即可;无需额外讨论 —— 列在这里只是提醒实施时不要漏。
+
+2. ~~PR 5(workspace 必传)的发布时机~~ **已确认:0.2.16 patch 走 soft deprecation,0.3.0 minor 做 hard break(标准 SemVer breaking)。** 拆成 PR 5a(soft + 内部下游迁移,在 0.2.16 与 PR 3b 同 release)+ PR 5b(hard break,0.3.0)。详见第四节 PR 5。决策证据:`Agentao` 在 `agentao/__init__.py:19` 是 `__all__` 暴露的 public API;README + 多处 docs + 自带 `examples/data-workbench` 与 `examples/batch-scheduler` 都直接 `from agentao import Agentao` + `Agentao()`,PyPI 已发布。Hard break 会让 README 抄作业的下游拿到 `TypeError`,而 soft deprecation 的代价仅 ~5 行 `warnings.warn`,不延误清理目标。
+

--- a/tests/test_acp_transport.py
+++ b/tests/test_acp_transport.py
@@ -81,6 +81,7 @@ def test_llm_text_maps_to_agent_message_chunk(transport):
     assert upd == {
         "sessionUpdate": "agent_message_chunk",
         "content": {"type": "text", "text": "Hello"},
+        "schema_version": 1,
     }
 
 
@@ -111,6 +112,7 @@ def test_thinking_maps_to_agent_thought_chunk(transport):
     assert upd == {
         "sessionUpdate": "agent_thought_chunk",
         "content": {"type": "text", "text": "Let me check..."},
+        "schema_version": 1,
     }
 
 
@@ -138,6 +140,7 @@ def test_tool_start_maps_to_tool_call(transport):
         "kind": "read",
         "status": "pending",
         "rawInput": {"file_path": "/tmp/x"},
+        "schema_version": 1,
     }
 
 
@@ -188,6 +191,7 @@ def test_tool_output_maps_to_tool_call_update_in_progress(transport):
         "content": [
             {"type": "content", "content": {"type": "text", "text": "line 1\n"}}
         ],
+        "schema_version": 1,
     }
 
 
@@ -214,6 +218,7 @@ def test_tool_complete_ok_maps_to_completed(transport):
         "sessionUpdate": "tool_call_update",
         "toolCallId": "u",
         "status": "completed",
+        "schema_version": 1,
     }
 
 

--- a/tests/test_agentao_md.py
+++ b/tests/test_agentao_md.py
@@ -16,7 +16,7 @@ def test_agentao_md_loading():
         # Import and create agent
         from agentao.agent import Agentao
 
-        agent = Agentao()
+        agent = Agentao(working_directory=Path.cwd())
 
         # Check that project instructions were loaded
         assert agent.project_instructions is not None, "AGENTAO.md should be loaded"
@@ -49,7 +49,10 @@ def test_agentao_md_missing():
 
             from agentao.agent import Agentao
 
-            agent = Agentao()
+            # Pass an explicit working_directory that does not contain
+            # AGENTAO.md so the missing-file branch exercises the same
+            # absent-file path the test name describes.
+            agent = Agentao(working_directory=Path('/nonexistent/path'))
 
             # Should handle missing file gracefully
             assert agent.project_instructions is None, "Should be None when file doesn't exist"

--- a/tests/test_async_chat.py
+++ b/tests/test_async_chat.py
@@ -1,0 +1,65 @@
+"""Issue #12 — ``Agentao.arun()`` bridges sync chat into async hosts."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock, Mock, patch
+
+
+def _make_agent(tmp_path):
+    with patch("agentao.agent.LLMClient") as mock_llm_cls, \
+         patch("agentao.tooling.mcp_tools.load_mcp_config", return_value={}), \
+         patch("agentao.tooling.mcp_tools.McpClientManager"):
+        mock_llm = Mock()
+        mock_llm.logger = Mock()
+        mock_llm.model = "gpt-test"
+        mock_llm_cls.return_value = mock_llm
+
+        from agentao.agent import Agentao
+        return Agentao(working_directory=tmp_path)
+
+
+def test_arun_dispatches_to_chat(tmp_path):
+    agent = _make_agent(tmp_path)
+    fake_response = MagicMock()
+    fake_response.choices[0].message.tool_calls = None
+    fake_response.choices[0].message.content = "ok"
+    fake_response.choices[0].message.reasoning_content = None
+    agent._llm_call = Mock(return_value=fake_response)
+
+    result = asyncio.run(agent.arun("hi"))
+    assert result == "ok"
+    assert any(m["role"] == "user" for m in agent.messages)
+
+
+def test_arun_does_not_block_event_loop(tmp_path):
+    """`arun` must hand the sync work to a thread so the loop stays alive."""
+    agent = _make_agent(tmp_path)
+
+    side_thread_seen = []
+
+    def _fake_chat(*args, **kwargs):
+        import threading
+        side_thread_seen.append(threading.current_thread().name)
+        return "done"
+
+    agent.chat = _fake_chat  # type: ignore[assignment]
+
+    async def _run():
+        # Schedule another task — if arun runs sync on the loop thread,
+        # this co-task wouldn't get a chance to record before arun returns.
+        marker = []
+
+        async def _record():
+            await asyncio.sleep(0)
+            marker.append("co")
+
+        result, _ = await asyncio.gather(agent.arun("hi"), _record())
+        return result, marker
+
+    result, marker = asyncio.run(_run())
+    assert result == "done"
+    assert marker == ["co"]
+    # The chat call landed on a different thread than the loop's main thread.
+    assert side_thread_seen and side_thread_seen[0] != "MainThread"

--- a/tests/test_async_chat.py
+++ b/tests/test_async_chat.py
@@ -63,3 +63,38 @@ def test_arun_does_not_block_event_loop(tmp_path):
     assert marker == ["co"]
     # The chat call landed on a different thread than the loop's main thread.
     assert side_thread_seen and side_thread_seen[0] != "MainThread"
+
+
+def test_arun_propagates_async_cancellation_to_token(tmp_path):
+    """asyncio cancellation must signal the chat() token so the worker stops."""
+    agent = _make_agent(tmp_path)
+
+    seen_tokens = []
+    started = asyncio.Event()
+    main_loop = None
+
+    def _fake_chat(user_message, max_iterations, cancellation_token):
+        seen_tokens.append(cancellation_token)
+        # Signal the loop that we're inside the executor, then block until
+        # the token is cancelled (mirrors how the real chat loop polls).
+        main_loop.call_soon_threadsafe(started.set)
+        cancellation_token._event.wait(timeout=2.0)
+        return "should-not-return"
+
+    agent.chat = _fake_chat  # type: ignore[assignment]
+
+    async def _run():
+        nonlocal main_loop
+        main_loop = asyncio.get_running_loop()
+        task = asyncio.create_task(agent.arun("hi"))
+        await started.wait()
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.run(_run())
+    assert seen_tokens, "chat was never invoked"
+    assert seen_tokens[0].is_cancelled
+    assert seen_tokens[0].reason == "async-cancel"

--- a/tests/test_clear_resets_confirm.py
+++ b/tests/test_clear_resets_confirm.py
@@ -7,7 +7,7 @@ def test_clear_resets_confirmation():
     """Test that clear command resets allow_all_tools to False."""
 
     with patch('agentao.cli.app.load_dotenv'), patch('agentao.cli.subcommands._load_and_register_plugins'):
-        with patch('agentao.cli.app.Agentao') as mock_agent_class:
+        with patch('agentao.cli.app.build_from_environment') as mock_agent_class:
             # Mock the agent instance
             mock_agent = Mock()
             mock_agent_class.return_value = mock_agent
@@ -33,7 +33,7 @@ def test_clear_command_flow():
     """Test the full flow of clear command with confirmation reset."""
 
     with patch('agentao.cli.app.load_dotenv'), patch('agentao.cli.subcommands._load_and_register_plugins'):
-        with patch('agentao.cli.app.Agentao') as mock_agent_class:
+        with patch('agentao.cli.app.build_from_environment') as mock_agent_class:
             mock_agent = Mock()
             mock_agent_class.return_value = mock_agent
 
@@ -59,7 +59,7 @@ def test_clear_vs_reset_confirm():
     """Test that both /clear and /reset-confirm reset confirmation."""
 
     with patch('agentao.cli.app.load_dotenv'), patch('agentao.cli.subcommands._load_and_register_plugins'):
-        with patch('agentao.cli.app.Agentao') as mock_agent_class:
+        with patch('agentao.cli.app.build_from_environment') as mock_agent_class:
             mock_agent = Mock()
             mock_agent_class.return_value = mock_agent
 
@@ -87,7 +87,7 @@ def test_initial_state():
     """Test that CLI starts with allow_all_tools = False."""
 
     with patch('agentao.cli.app.load_dotenv'), patch('agentao.cli.subcommands._load_and_register_plugins'):
-        with patch('agentao.cli.app.Agentao') as mock_agent_class:
+        with patch('agentao.cli.app.build_from_environment') as mock_agent_class:
             mock_agent = Mock()
             mock_agent_class.return_value = mock_agent
 
@@ -103,7 +103,7 @@ def test_clear_makes_sense():
     """Test the logical flow: clear should reset everything to initial state."""
 
     with patch('agentao.cli.app.load_dotenv'), patch('agentao.cli.subcommands._load_and_register_plugins'):
-        with patch('agentao.cli.app.Agentao') as mock_agent_class:
+        with patch('agentao.cli.app.build_from_environment') as mock_agent_class:
             mock_agent = Mock()
             mock_agent_class.return_value = mock_agent
 

--- a/tests/test_date_in_prompt.py
+++ b/tests/test_date_in_prompt.py
@@ -2,6 +2,7 @@
 
 import re
 from datetime import datetime
+from pathlib import Path
 from unittest.mock import Mock, patch, MagicMock
 
 
@@ -12,7 +13,7 @@ def _make_agent():
         mock_llm.model = "gpt-4"
         mock_llm_class.return_value = mock_llm
         from agentao.agent import Agentao
-        return Agentao()
+        return Agentao(working_directory=Path.cwd())
 
 
 def test_date_not_in_system_prompt():

--- a/tests/test_event_schema_version.py
+++ b/tests/test_event_schema_version.py
@@ -1,0 +1,165 @@
+"""Tests for ``AgentEvent.schema_version`` and the wire-payload contract.
+
+Issue #7 introduced a versioned wire payload for runtime events. These
+tests cover the three guarantees:
+
+1. The default ``schema_version`` is ``1`` on a freshly constructed
+   :class:`AgentEvent`, regardless of the event type or whether ``data``
+   was supplied.
+2. :meth:`AgentEvent.to_dict` produces the canonical three-key
+   ``{"type", "schema_version", "data"}`` wire shape with the enum
+   coerced to its string value.
+3. ACP ``session/update`` notifications carry the field through to
+   the actual wire payload an ACP client would observe.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Tuple
+
+import pytest
+
+from agentao.acp.protocol import METHOD_SESSION_UPDATE
+from agentao.acp.transport import ACPTransport
+from agentao.transport.events import AgentEvent, EventType
+
+
+# ---------------------------------------------------------------------------
+# Field defaults
+# ---------------------------------------------------------------------------
+
+
+def test_default_schema_version_is_one_on_concrete_event():
+    """Acceptance criterion: ``AgentEvent(...).schema_version == 1``."""
+    assert AgentEvent(EventType.TURN_START).schema_version == 1
+
+
+def test_default_schema_version_independent_of_event_type():
+    for etype in EventType:
+        assert AgentEvent(etype).schema_version == 1, etype
+
+
+def test_schema_version_can_be_overridden_explicitly():
+    # Future schema bumps will pass a higher integer through the
+    # ``schema_version=`` kwarg. Constructing an event with the
+    # next-version number must not be rejected by the dataclass.
+    evt = AgentEvent(EventType.LLM_TEXT, {"chunk": "hi"}, schema_version=2)
+    assert evt.schema_version == 2
+
+
+# ---------------------------------------------------------------------------
+# to_dict() wire-payload shape
+# ---------------------------------------------------------------------------
+
+
+def test_to_dict_emits_three_key_shape():
+    evt = AgentEvent(EventType.LLM_TEXT, {"chunk": "hello"})
+    payload = evt.to_dict()
+    assert set(payload.keys()) == {"type", "schema_version", "data"}
+
+
+def test_to_dict_renders_event_type_as_string_value():
+    """``type`` must be the underlying enum string so the dict is JSON-native."""
+    evt = AgentEvent(EventType.TOOL_START, {"tool": "read_file", "call_id": "x"})
+    payload = evt.to_dict()
+    assert payload["type"] == "tool_start"
+    assert payload["schema_version"] == 1
+    assert payload["data"] == {"tool": "read_file", "call_id": "x"}
+
+
+def test_to_dict_preserves_data_payload_verbatim():
+    data = {"agent": "investigator", "turns": 5, "nested": {"k": [1, 2, 3]}}
+    evt = AgentEvent(EventType.AGENT_END, data)
+    payload = evt.to_dict()
+    assert payload["data"] == data
+
+
+def test_to_dict_round_trips_through_json():
+    """The wire form must encode under ``json.dumps`` without an extra hook."""
+    import json
+
+    evt = AgentEvent(EventType.THINKING, {"text": "let me think"})
+    encoded = json.dumps(evt.to_dict())
+    parsed = json.loads(encoded)
+    assert parsed == {
+        "type": "thinking",
+        "schema_version": 1,
+        "data": {"text": "let me think"},
+    }
+
+
+# ---------------------------------------------------------------------------
+# ACP wire payload carries schema_version
+# ---------------------------------------------------------------------------
+
+
+class _RecordingServer:
+    """Stand-in for AcpServer that captures (method, params) tuples."""
+
+    def __init__(self) -> None:
+        self.notifications: List[Tuple[str, Dict[str, Any]]] = []
+
+    def write_notification(self, method: str, params: Dict[str, Any]) -> None:
+        self.notifications.append((method, params))
+
+
+@pytest.fixture
+def acp_pair():
+    server = _RecordingServer()
+    return ACPTransport(server=server, session_id="sess_v"), server
+
+
+def test_acp_emit_stamps_schema_version_on_update(acp_pair):
+    transport, server = acp_pair
+    transport.emit(AgentEvent(EventType.LLM_TEXT, {"chunk": "hi"}))
+
+    assert len(server.notifications) == 1
+    method, params = server.notifications[0]
+    assert method == METHOD_SESSION_UPDATE
+    update = params["update"]
+    assert update["schema_version"] == 1
+    # The ACP-shaped fields still need to be present alongside.
+    assert update["sessionUpdate"] == "agent_message_chunk"
+
+
+def test_acp_emit_forwards_custom_schema_version(acp_pair):
+    """A future v2 event must surface the bumped version on the wire."""
+    transport, server = acp_pair
+    transport.emit(
+        AgentEvent(EventType.LLM_TEXT, {"chunk": "hi"}, schema_version=2)
+    )
+    update = server.notifications[0][1]["update"]
+    assert update["schema_version"] == 2
+
+
+def test_acp_emit_stamps_schema_version_on_every_notification(acp_pair):
+    transport, server = acp_pair
+    transport.emit(AgentEvent(EventType.LLM_TEXT, {"chunk": "a"}))
+    transport.emit(AgentEvent(EventType.THINKING, {"text": "b"}))
+    transport.emit(
+        AgentEvent(
+            EventType.TOOL_START,
+            {"tool": "read_file", "call_id": "u", "args": {}},
+        )
+    )
+    transport.emit(
+        AgentEvent(
+            EventType.TOOL_COMPLETE,
+            {"tool": "read_file", "call_id": "u", "status": "ok"},
+        )
+    )
+
+    assert len(server.notifications) == 4
+    for _, params in server.notifications:
+        assert params["update"]["schema_version"] == 1
+
+
+def test_acp_silent_events_do_not_emit_anything(acp_pair):
+    """TURN_START and TOOL_CONFIRMATION must remain silent — the
+    schema_version stamp must not synthesize a notification for them."""
+    transport, server = acp_pair
+    transport.emit(AgentEvent(EventType.TURN_START))
+    transport.emit(
+        AgentEvent(EventType.TOOL_CONFIRMATION, {"tool": "bash", "args": {}})
+    )
+    assert server.notifications == []

--- a/tests/test_factory_build_from_environment.py
+++ b/tests/test_factory_build_from_environment.py
@@ -1,0 +1,92 @@
+"""Issue #10 — ``build_from_environment()`` is the single env / disk read site.
+
+The factory wraps the implicit reads (``.env``, ``LLM_PROVIDER``,
+``working_directory or Path.cwd()``, ``.agentao/permissions.json``,
+``.agentao/mcp.json``, memory roots) into one explicit call so the
+agent constructor itself never has to.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from agentao.embedding import build_from_environment
+
+
+def test_factory_freezes_working_directory(tmp_path, monkeypatch):
+    """A path passed in is the path the agent reports — no Path.cwd() leak."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://api.example.com/v1")
+    monkeypatch.setenv("OPENAI_MODEL", "gpt-test")
+
+    with patch("agentao.agent.LLMClient") as mock_llm_cls:
+        mock_llm = Mock()
+        mock_llm.logger = Mock()
+        mock_llm.model = "gpt-test"
+        mock_llm.api_key = "test-key"
+        mock_llm.base_url = "https://api.example.com/v1"
+        mock_llm.temperature = 0.2
+        mock_llm_cls.return_value = mock_llm
+
+        agent = build_from_environment(working_directory=tmp_path)
+
+    assert agent.working_directory == tmp_path.resolve()
+
+
+def test_factory_routes_provider_env_to_constructor(tmp_path, monkeypatch):
+    """LLM_PROVIDER + provider-prefixed env vars are picked up here, not by Agentao."""
+    monkeypatch.setenv("LLM_PROVIDER", "DEEPSEEK")
+    monkeypatch.setenv("DEEPSEEK_API_KEY", "deep-key")
+    monkeypatch.setenv("DEEPSEEK_BASE_URL", "https://api.deepseek.com/v1")
+    monkeypatch.setenv("DEEPSEEK_MODEL", "deepseek-chat")
+
+    captured = {}
+
+    with patch("agentao.agent.LLMClient") as mock_llm_cls:
+        mock_llm = Mock()
+        mock_llm.logger = Mock()
+        mock_llm.model = "deepseek-chat"
+        mock_llm.api_key = "deep-key"
+        mock_llm.base_url = "https://api.deepseek.com/v1"
+        mock_llm.temperature = 0.2
+        mock_llm_cls.return_value = mock_llm
+
+        def _capture(*args, **kwargs):
+            captured.update(kwargs)
+            return mock_llm
+
+        mock_llm_cls.side_effect = _capture
+
+        build_from_environment(working_directory=tmp_path)
+
+    assert captured.get("api_key") == "deep-key"
+    assert captured.get("model") == "deepseek-chat"
+
+
+def test_factory_overrides_win_over_discovered(tmp_path, monkeypatch):
+    """Caller-supplied kwargs take priority over factory-discovered values."""
+    monkeypatch.setenv("OPENAI_API_KEY", "discovered")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://api.example.com/v1")
+    monkeypatch.setenv("OPENAI_MODEL", "discovered-model")
+
+    captured = {}
+
+    with patch("agentao.agent.LLMClient") as mock_llm_cls:
+        mock_llm = Mock()
+        mock_llm.logger = Mock()
+        mock_llm.model = "explicit-model"
+        mock_llm.api_key = "discovered"
+        mock_llm.base_url = "https://api.example.com/v1"
+        mock_llm.temperature = 0.2
+        mock_llm_cls.return_value = mock_llm
+
+        def _capture(*args, **kwargs):
+            captured.update(kwargs)
+            return mock_llm
+
+        mock_llm_cls.side_effect = _capture
+
+        build_from_environment(working_directory=tmp_path, model="explicit-model")
+
+    assert captured.get("model") == "explicit-model"

--- a/tests/test_filesystem_capability_swap.py
+++ b/tests/test_filesystem_capability_swap.py
@@ -1,0 +1,159 @@
+"""Issue #9 — file/search tools route reads/writes through an injected FileSystem.
+
+A swappable :class:`agentao.capabilities.FileSystem` means embedded hosts
+can redirect tool IO through Docker exec, virtual filesystems, or audit
+proxies without monkey-patching ``open()`` / ``Path``. The tests below
+confirm the wire-up: a fake FS captures every call the tool routes
+through it, and the default tools never touch the real disk when one is
+injected.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List
+
+import pytest
+
+from agentao.capabilities import FileEntry, FileStat, FileSystem
+from agentao.tools.file_ops import (
+    EditTool,
+    ReadFileTool,
+    ReadFolderTool,
+    WriteFileTool,
+)
+from agentao.tools.search import FindFilesTool, SearchTextTool
+
+
+class FakeFS:
+    """Minimal in-memory :class:`FileSystem` used to assert call routing."""
+
+    def __init__(self, files: Dict[str, str] | None = None):
+        self._files: Dict[str, bytes] = {
+            k: v.encode("utf-8") for k, v in (files or {}).items()
+        }
+        self.calls: List[str] = []
+
+    def read_bytes(self, path: Path) -> bytes:
+        self.calls.append(f"read_bytes:{path}")
+        if str(path) not in self._files:
+            raise FileNotFoundError(str(path))
+        return self._files[str(path)]
+
+    def read_partial(self, path: Path, n: int) -> bytes:
+        self.calls.append(f"read_partial:{path}:{n}")
+        if str(path) not in self._files:
+            raise FileNotFoundError(str(path))
+        return self._files[str(path)][:n]
+
+    def open_text(self, path: Path):
+        self.calls.append(f"open_text:{path}")
+        if str(path) not in self._files:
+            raise FileNotFoundError(str(path))
+        text = self._files[str(path)].decode("utf-8")
+        for line in text.splitlines(keepends=True):
+            yield line
+
+    def write_text(self, path: Path, data: str, *, append: bool = False) -> None:
+        self.calls.append(f"write_text:{path}:append={append}")
+        if append and str(path) in self._files:
+            self._files[str(path)] = self._files[str(path)] + data.encode("utf-8")
+        else:
+            self._files[str(path)] = data.encode("utf-8")
+
+    def list_dir(self, path: Path) -> List[FileEntry]:
+        self.calls.append(f"list_dir:{path}")
+        return [
+            FileEntry(name="a.txt", is_dir=False, is_file=True, size=3),
+            FileEntry(name="sub", is_dir=True, is_file=False, size=0),
+        ]
+
+    def glob(self, base: Path, pattern: str, *, recursive: bool):
+        self.calls.append(f"glob:{base}:{pattern}:recursive={recursive}")
+        return [base / "a.txt"]
+
+    def stat(self, path: Path) -> FileStat:
+        self.calls.append(f"stat:{path}")
+        size = len(self._files.get(str(path), b""))
+        return FileStat(size=size, mtime=0.0, is_dir=False, is_file=True)
+
+    def exists(self, path: Path) -> bool:
+        s = str(path)
+        if s in self._files or s.endswith("/dir"):
+            return True
+        # Treat any prefix path of a known file as an existing directory.
+        return any(f.startswith(s + "/") or f == s for f in self._files)
+
+    def is_dir(self, path: Path) -> bool:
+        s = str(path)
+        if s.endswith("/dir"):
+            return True
+        if s in self._files:
+            return False
+        return any(f.startswith(s + "/") for f in self._files)
+
+    def is_file(self, path: Path) -> bool:
+        return str(path) in self._files
+
+
+def test_read_file_routes_through_fake_fs(tmp_path):
+    fs = FakeFS({str(tmp_path / "hi.txt"): "hello\nworld\n"})
+    tool = ReadFileTool()
+    tool.filesystem = fs
+    tool.working_directory = tmp_path
+
+    out = tool.execute(file_path="hi.txt")
+
+    assert "hello" in out
+    # ReadFileTool sniffs for binary then streams the text; both routes
+    # must land on the injected FS.
+    assert any(c.startswith("read_partial:") for c in fs.calls), fs.calls
+    assert any(c.startswith("open_text:") for c in fs.calls), fs.calls
+
+
+def test_write_and_edit_route_through_fake_fs(tmp_path):
+    fs = FakeFS()
+    write_tool = WriteFileTool()
+    write_tool.filesystem = fs
+    write_tool.working_directory = tmp_path
+    write_tool.execute(file_path="out.txt", content="abc\n")
+    assert any("write_text" in c for c in fs.calls), fs.calls
+
+    fs2 = FakeFS({str(tmp_path / "x.txt"): "hello world\n"})
+    edit = EditTool()
+    edit.filesystem = fs2
+    edit.working_directory = tmp_path
+    edit.execute(file_path="x.txt", old_text="hello", new_text="goodbye")
+    assert any("read_bytes" in c for c in fs2.calls)
+    assert any("write_text" in c for c in fs2.calls)
+
+
+def test_glob_and_search_route_through_fake_fs(tmp_path):
+    fs = FakeFS({str(tmp_path / "a.txt"): "needle in haystack\n"})
+    glob_tool = FindFilesTool()
+    glob_tool.filesystem = fs
+    glob_tool.working_directory = tmp_path
+    glob_tool.execute(pattern="*.txt")
+    assert any(c.startswith("glob:") for c in fs.calls)
+
+    fs2 = FakeFS({str(tmp_path / "a.txt"): "needle in haystack\n"})
+    search_tool = SearchTextTool()
+    search_tool.filesystem = fs2
+    search_tool.working_directory = tmp_path
+    # Force the python-fallback path: pretend we're not in a git repo so
+    # the tool doesn't shell out to git grep (which would bypass the FS).
+    search_tool._is_git_repo = lambda d: False  # type: ignore[assignment]
+    out = search_tool.execute(pattern="needle", directory=str(tmp_path))
+    assert "needle" in out
+
+
+def test_list_directory_routes_through_fake_fs(tmp_path):
+    fs = FakeFS()
+    tool = ReadFolderTool()
+    tool.filesystem = fs
+    tool.working_directory = tmp_path
+    # Use a directory that FakeFS reports as existing:
+    out = tool.execute(directory_path=str(tmp_path) + "/dir")
+    assert "a.txt" in out
+    assert "sub" in out
+    assert any(c.startswith("list_dir:") for c in fs.calls)

--- a/tests/test_llm_client_logger_injection.py
+++ b/tests/test_llm_client_logger_injection.py
@@ -1,0 +1,208 @@
+"""Tests for ``LLMClient`` logger ownership inversion (Issue #8).
+
+Embedded hosts that bring their own logging stack must be able to
+construct an :class:`LLMClient` without having the ``agentao`` package
+root logger mutated underneath them. The contract:
+
+- ``LLMClient(logger=injected)`` → ``self.logger`` is the injected one;
+  ``logging.getLogger("agentao")`` level and handler list are untouched.
+- ``LLMClient(log_file=None)`` → no file handler is attached, regardless
+  of logger injection.
+- ``LLMClient()`` (default) → existing CLI behavior is preserved:
+  package root level set to DEBUG and a marker-tagged file handler
+  attached.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from typing import Iterable
+from unittest.mock import MagicMock
+
+import pytest
+
+from agentao.llm.client import LLMClient
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_pkg_logger():
+    """Snapshot and restore the ``agentao`` package logger between tests.
+
+    Without this, a test that mutates the package root would leak state
+    into subsequent tests in the same process.
+    """
+    pkg = logging.getLogger("agentao")
+    saved_level = pkg.level
+    saved_handlers = list(pkg.handlers)
+    pkg.handlers = []
+    pkg.setLevel(logging.NOTSET)
+    yield pkg
+    for h in pkg.handlers:
+        try:
+            h.close()
+        except Exception:
+            pass
+    pkg.handlers = saved_handlers
+    pkg.setLevel(saved_level)
+
+
+def _marker_handlers(pkg: logging.Logger) -> Iterable[logging.Handler]:
+    return [h for h in pkg.handlers if getattr(h, "_agentao_llm_file_handler", False)]
+
+
+# ---------------------------------------------------------------------------
+# Logger injection skips package-root mutation
+# ---------------------------------------------------------------------------
+
+
+def test_injected_logger_is_used_as_self_logger(_reset_pkg_logger):
+    injected = logging.getLogger("host.app.embedded")
+    client = LLMClient(
+        api_key="test-key",
+        base_url="https://api.example.com/v1",
+        model="gpt-test",
+        logger=injected,
+    )
+    assert client.logger is injected
+
+
+def test_injected_logger_does_not_set_package_root_level(_reset_pkg_logger):
+    pkg = _reset_pkg_logger
+    pkg_level_before = pkg.level
+
+    LLMClient(
+        api_key="test-key",
+        base_url="https://api.example.com/v1",
+        model="gpt-test",
+        logger=MagicMock(spec=logging.Logger),
+    )
+
+    assert pkg.level == pkg_level_before, (
+        "package root level must remain untouched when logger is injected"
+    )
+
+
+def test_injected_logger_does_not_attach_handlers_to_package_root(
+    _reset_pkg_logger, tmp_path
+):
+    pkg = _reset_pkg_logger
+    handlers_before = list(pkg.handlers)
+
+    LLMClient(
+        api_key="test-key",
+        base_url="https://api.example.com/v1",
+        model="gpt-test",
+        log_file=str(tmp_path / "host_owned.log"),
+        logger=MagicMock(spec=logging.Logger),
+    )
+
+    assert pkg.handlers == handlers_before, (
+        "package root handler list must remain untouched when logger is injected"
+    )
+
+
+def test_injected_logger_preserves_outsider_handlers(_reset_pkg_logger):
+    """A host's own stderr handler must survive LLMClient construction."""
+    pkg = _reset_pkg_logger
+    external = logging.StreamHandler(sys.stderr)
+    pkg.addHandler(external)
+    handlers_before = list(pkg.handlers)
+
+    LLMClient(
+        api_key="test-key",
+        base_url="https://api.example.com/v1",
+        model="gpt-test",
+        logger=MagicMock(spec=logging.Logger),
+    )
+
+    assert pkg.handlers == handlers_before
+    assert external in pkg.handlers
+
+
+def test_repeated_injected_construction_is_idempotent_against_root(
+    _reset_pkg_logger,
+):
+    """Reconstructing with logger= must remain a no-op against the root.
+
+    Repeated model swaps in ACP mode rebuild the LLMClient every time;
+    embedded hosts cannot afford a slow leak of handler state.
+    """
+    pkg = _reset_pkg_logger
+    handlers_before = list(pkg.handlers)
+    level_before = pkg.level
+
+    for _ in range(5):
+        LLMClient(
+            api_key="test-key",
+            base_url="https://api.example.com/v1",
+            model="gpt-test",
+            logger=MagicMock(spec=logging.Logger),
+        )
+
+    assert pkg.handlers == handlers_before
+    assert pkg.level == level_before
+
+
+# ---------------------------------------------------------------------------
+# log_file=None → no file handler
+# ---------------------------------------------------------------------------
+
+
+def test_log_file_none_does_not_attach_file_handler(_reset_pkg_logger):
+    pkg = _reset_pkg_logger
+    LLMClient(
+        api_key="test-key",
+        base_url="https://api.example.com/v1",
+        model="gpt-test",
+        log_file=None,
+    )
+    assert list(_marker_handlers(pkg)) == [], (
+        "log_file=None must skip the file handler"
+    )
+
+
+def test_log_file_none_with_injected_logger_is_zero_side_effect(_reset_pkg_logger):
+    """Acceptance criterion: ``LLMClient(log_file=None, logger=mock)``
+    is a clean construction with no package-root side effects."""
+    pkg = _reset_pkg_logger
+    handlers_before = list(pkg.handlers)
+    level_before = pkg.level
+
+    LLMClient(
+        api_key="test-key",
+        base_url="https://api.example.com/v1",
+        model="gpt-test",
+        log_file=None,
+        logger=MagicMock(spec=logging.Logger),
+    )
+
+    assert pkg.handlers == handlers_before
+    assert pkg.level == level_before
+
+
+# ---------------------------------------------------------------------------
+# Default behavior (no logger, default log_file) is preserved
+# ---------------------------------------------------------------------------
+
+
+def test_default_construction_takes_ownership_of_package_root(
+    _reset_pkg_logger, tmp_path
+):
+    pkg = _reset_pkg_logger
+    LLMClient(
+        api_key="test-key",
+        base_url="https://api.example.com/v1",
+        model="gpt-test",
+        log_file=str(tmp_path / "agentao.log"),
+    )
+
+    # Existing CLI invariant: package-root level is DEBUG and exactly
+    # one marker-tagged file handler was attached.
+    assert pkg.level == logging.DEBUG
+    assert len(list(_marker_handlers(pkg))) == 1

--- a/tests/test_mcp_manager_injection.py
+++ b/tests/test_mcp_manager_injection.py
@@ -1,0 +1,48 @@
+"""Injected ``mcp_manager`` must register its tools on the agent."""
+
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+from mcp.types import Tool as McpToolDef
+
+
+def _make_tool_def(name: str) -> McpToolDef:
+    return McpToolDef(
+        name=name,
+        description=f"fake tool {name}",
+        inputSchema={"type": "object", "properties": {}, "required": []},
+    )
+
+
+def test_injected_mcp_manager_tools_are_registered(tmp_path):
+    """Host-injected manager: tools must appear in ``agent.tools``."""
+    fake_client = Mock()
+    fake_client.is_trusted = True
+
+    fake_manager = Mock()
+    fake_manager.get_all_tools.return_value = [
+        ("alpha", _make_tool_def("ping")),
+        ("alpha", _make_tool_def("pong")),
+    ]
+    fake_manager.get_client.return_value = fake_client
+    fake_manager.clients = {"alpha": fake_client}
+    fake_manager.call_tool = Mock(return_value="ok")
+
+    with patch("agentao.agent.LLMClient") as mock_llm_cls:
+        mock_llm = Mock()
+        mock_llm.logger = Mock()
+        mock_llm.model = "gpt-test"
+        mock_llm_cls.return_value = mock_llm
+
+        from agentao.agent import Agentao
+        agent = Agentao(
+            working_directory=tmp_path,
+            mcp_manager=fake_manager,
+        )
+
+    assert "mcp_alpha_ping" in agent.tools.tools
+    assert "mcp_alpha_pong" in agent.tools.tools
+    # Host owns lifecycle: we stored the manager but never called connect.
+    assert agent.mcp_manager is fake_manager
+    fake_manager.connect_all.assert_not_called()

--- a/tests/test_memory_injection.py
+++ b/tests/test_memory_injection.py
@@ -24,7 +24,7 @@ def _agent_with_temp_memory():
             from agentao.memory import MemoryManager
             from agentao.tools.memory import SaveMemoryTool
 
-            agent = Agentao()
+            agent = Agentao(working_directory=Path(tmpdir))
             # Override manager with isolated temp dirs
             agent.memory_manager = MemoryManager(
                 project_root=tmp_proj, global_root=tmp_global

--- a/tests/test_memory_renderer.py
+++ b/tests/test_memory_renderer.py
@@ -353,7 +353,7 @@ class TestIntegration:
                 from agentao.memory import MemoryManager
                 from agentao.tools.memory import SaveMemoryTool
 
-                agent = Agentao()
+                agent = Agentao(working_directory=Path(tmpdir))
                 agent.memory_manager = MemoryManager(
                     project_root=tmp_proj, global_root=tmp_global
                 )
@@ -388,7 +388,7 @@ class TestIntegration:
                 from agentao.agent import Agentao
                 from agentao.memory import MemoryManager
 
-                agent = Agentao()
+                agent = Agentao(working_directory=Path(tmpdir))
                 agent.memory_manager = MemoryManager(
                     project_root=tmp_proj, global_root=tmp_global
                 )
@@ -421,7 +421,7 @@ class TestExtractContextHints:
             mock_llm_cls.return_value = mock_llm
 
             from agentao.agent import Agentao
-            return Agentao()
+            return Agentao(working_directory=Path(tmpdir))
 
     def test_extracts_paths_from_string_content(self, tmp_path):
         agent = self._make_agent(tmp_path)

--- a/tests/test_model_command.py
+++ b/tests/test_model_command.py
@@ -8,6 +8,7 @@ Set ``AGENTAO_TEST_LIVE_MODELS=1`` to force live mode explicitly.
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import pytest
 
@@ -46,7 +47,7 @@ def _build_agent() -> Agentao:
     """
     os.environ.setdefault("LLM_PROVIDER", "OPENAI")
     os.environ.setdefault("OPENAI_API_KEY", _FAKE_KEY)
-    return Agentao()
+    return Agentao(working_directory=Path.cwd())
 
 
 def test_model_switching_flow(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_multi_turn.py
+++ b/tests/test_multi_turn.py
@@ -1,6 +1,7 @@
 """Test multi-turn tool calls."""
 
 import os
+from pathlib import Path
 
 from dotenv import load_dotenv
 
@@ -22,6 +23,7 @@ def test_multi_turn_tool_calls():
         api_key=os.getenv("OPENAI_API_KEY"),
         base_url=os.getenv("OPENAI_BASE_URL"),
         model=os.getenv("OPENAI_MODEL"),
+        working_directory=Path.cwd(),
     )
 
     print("Testing multi-turn tool calls...")

--- a/tests/test_per_session_cwd.py
+++ b/tests/test_per_session_cwd.py
@@ -61,10 +61,21 @@ def stub_llm_env(monkeypatch):
 
 
 def _make_agent(working_directory=None, stub_llm_env=None):
-    """Construct a real Agentao instance without invoking the API."""
+    """Construct a real Agentao instance without invoking the API.
+
+    These tests deliberately exercise the legacy ``working_directory=None``
+    default to assert the lazy-cwd-read behavior, so we suppress the
+    Issue 13 ``DeprecationWarning`` here. The same warning is asserted
+    explicitly in ``tests/test_factory_build_from_environment.py`` and
+    the new injection-path tests.
+    """
+    import warnings
+
     from agentao.agent import Agentao
 
-    return Agentao(working_directory=working_directory)
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        return Agentao(working_directory=working_directory)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_plan_mode_prompt.py
+++ b/tests/test_plan_mode_prompt.py
@@ -1,5 +1,6 @@
 """Regression tests for plan mode system prompt constraints."""
 
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 from agentao.plan import PlanPhase
@@ -11,7 +12,7 @@ def _make_agent():
         mock_llm_client.return_value.model = "gpt-4"
         from agentao.agent import Agentao
 
-        return Agentao()
+        return Agentao(working_directory=Path.cwd())
 
 
 def _activate_plan(agent):

--- a/tests/test_project_instructions_injection.py
+++ b/tests/test_project_instructions_injection.py
@@ -1,0 +1,44 @@
+"""Issue #11 — injected ``project_instructions`` skips the AGENTAO.md disk read."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+
+def test_injected_project_instructions_used_verbatim(tmp_path):
+    with patch("agentao.agent.LLMClient") as mock_llm_cls, \
+         patch("agentao.tooling.mcp_tools.load_mcp_config", return_value={}), \
+         patch("agentao.tooling.mcp_tools.McpClientManager"), \
+         patch("agentao.agent.load_project_instructions") as mock_load:
+        mock_llm_cls.return_value.logger = Mock()
+        mock_llm_cls.return_value.model = "gpt-test"
+
+        from agentao.agent import Agentao
+
+        agent = Agentao(
+            working_directory=tmp_path,
+            project_instructions="HOST OVERRIDE",
+        )
+
+    assert agent.project_instructions == "HOST OVERRIDE"
+    # The disk-reading helper must NOT have been called when an
+    # explicit instructions string was injected.
+    mock_load.assert_not_called()
+
+
+def test_no_injection_falls_back_to_disk_read(tmp_path):
+    """When no override is supplied, the agent loads AGENTAO.md from disk."""
+    with patch("agentao.agent.LLMClient") as mock_llm_cls, \
+         patch("agentao.tooling.mcp_tools.load_mcp_config", return_value={}), \
+         patch("agentao.tooling.mcp_tools.McpClientManager"), \
+         patch("agentao.agent.load_project_instructions", return_value="from disk") as mock_load:
+        mock_llm_cls.return_value.logger = Mock()
+        mock_llm_cls.return_value.model = "gpt-test"
+
+        from agentao.agent import Agentao
+
+        agent = Agentao(working_directory=tmp_path)
+
+    assert agent.project_instructions == "from disk"
+    mock_load.assert_called_once()

--- a/tests/test_prompt_diagnostics.py
+++ b/tests/test_prompt_diagnostics.py
@@ -21,6 +21,8 @@ def _make_agent(**kwargs):
     Mirrors the helper in tests/test_system_prompt_sections.py — keeps
     the LLMClient stubbed so we don't need real credentials.
     """
+    from pathlib import Path
+    kwargs.setdefault("working_directory", Path.cwd())
     with patch("agentao.agent.LLMClient") as mock_llm_client:
         mock_llm_client.return_value.logger = Mock()
         mock_llm_client.return_value.model = "gpt-4"

--- a/tests/test_reliability_prompt.py
+++ b/tests/test_reliability_prompt.py
@@ -1,5 +1,6 @@
 """Test that reliability principles are present in the system prompt."""
 
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 
@@ -8,7 +9,10 @@ def _make_agent(thinking_callback=None):
         mock_llm_client.return_value.logger = Mock()
         mock_llm_client.return_value.model = "gpt-4"
         from agentao.agent import Agentao
-        agent = Agentao(thinking_callback=thinking_callback)
+        agent = Agentao(
+            thinking_callback=thinking_callback,
+            working_directory=Path.cwd(),
+        )
     return agent
 
 

--- a/tests/test_shell_capability_swap.py
+++ b/tests/test_shell_capability_swap.py
@@ -1,0 +1,62 @@
+"""Issue #9 — ShellTool routes through an injected ShellExecutor.
+
+A fake executor records every shell invocation so embedded hosts that
+need to redirect commands through Docker exec or a remote runner can do
+so without monkey-patching ``subprocess``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import List
+
+from agentao.capabilities import (
+    BackgroundHandle,
+    ShellRequest,
+    ShellResult,
+)
+from agentao.tools.shell import ShellTool
+
+
+class FakeExecutor:
+    def __init__(self):
+        self.calls: List[ShellRequest] = []
+
+    def run(self, request: ShellRequest) -> ShellResult:
+        self.calls.append(request)
+        return ShellResult(returncode=0, stdout=b"hello\n", stderr=b"")
+
+    def run_background(self, request: ShellRequest) -> BackgroundHandle:
+        self.calls.append(request)
+        return BackgroundHandle(
+            pid=4242, pgid=4242, command=request.command, cwd=request.cwd,
+        )
+
+
+def test_foreground_shell_routes_through_executor(tmp_path):
+    fake = FakeExecutor()
+    tool = ShellTool()
+    tool.shell = fake
+    tool.working_directory = tmp_path
+
+    out = tool.execute(command="echo hello", working_directory=str(tmp_path))
+
+    assert fake.calls, "executor should have been invoked"
+    assert fake.calls[0].command == "echo hello"
+    assert "hello" in out
+
+
+def test_background_shell_routes_through_executor(tmp_path):
+    fake = FakeExecutor()
+    tool = ShellTool()
+    tool.shell = fake
+    tool.working_directory = tmp_path
+
+    out = tool.execute(
+        command="sleep 100",
+        is_background=True,
+        working_directory=str(tmp_path),
+    )
+
+    assert fake.calls
+    assert "PID: 4242" in out

--- a/tests/test_skill_integration.py
+++ b/tests/test_skill_integration.py
@@ -2,13 +2,15 @@
 """Test skill integration with Agentao."""
 
 import os
+from pathlib import Path
+
 from agentao import Agentao
 
 
 def test_skill_with_resources():
     """Test that agent can access skill resources."""
     # Create agent
-    agent = Agentao()
+    agent = Agentao(working_directory=Path.cwd())
 
     print("=" * 70)
     print("Testing Skill Resource Access")

--- a/tests/test_skill_manager_injection.py
+++ b/tests/test_skill_manager_injection.py
@@ -1,0 +1,38 @@
+"""Issue #11 — injected ``skill_manager`` skips auto-discovery.
+
+When a host pre-builds its own :class:`SkillManager`, the agent must
+use it verbatim without scanning project / bundled skill directories.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+
+def test_injected_skill_manager_used_verbatim(tmp_path):
+    sentinel = object()
+    fake_manager = Mock()
+    fake_manager.available_skills = {"sentinel": sentinel}
+    fake_manager.active_skills = {}
+    fake_manager.disabled_skills = set()
+    fake_manager.get_active_skills = Mock(return_value={})
+
+    with patch("agentao.agent.LLMClient") as mock_llm_cls, \
+         patch("agentao.tooling.mcp_tools.load_mcp_config", return_value={}), \
+         patch("agentao.tooling.mcp_tools.McpClientManager"), \
+         patch("agentao.agent.SkillManager") as mock_default_cls:
+        mock_llm_cls.return_value.logger = Mock()
+        mock_llm_cls.return_value.model = "gpt-test"
+
+        from agentao.agent import Agentao
+
+        agent = Agentao(
+            working_directory=tmp_path,
+            skill_manager=fake_manager,
+        )
+
+    assert agent.skill_manager is fake_manager
+    # The default constructor must NOT have been called when an
+    # explicit instance was injected.
+    mock_default_cls.assert_not_called()

--- a/tests/test_skills_prompt.py
+++ b/tests/test_skills_prompt.py
@@ -1,6 +1,7 @@
 """Test that skills are included in system prompt."""
 
 import os
+from pathlib import Path
 
 from dotenv import load_dotenv
 
@@ -15,6 +16,7 @@ def test_skills_in_system_prompt():
         api_key=os.getenv("OPENAI_API_KEY"),
         base_url=os.getenv("OPENAI_BASE_URL"),
         model=os.getenv("OPENAI_MODEL"),
+        working_directory=Path.cwd(),
     )
 
     print("Testing Skills in System Prompt")

--- a/tests/test_system_prompt_sections.py
+++ b/tests/test_system_prompt_sections.py
@@ -5,6 +5,7 @@ discriminating phrases for each new behavioral clause introduced in
 SYSTEM_PROMPT_REDESIGN_PLAN.md.
 """
 
+from pathlib import Path
 from unittest.mock import Mock, patch
 
 from agentao.plan import PlanPhase
@@ -15,7 +16,10 @@ def _make_agent(thinking_callback=None):
         mock_llm_client.return_value.logger = Mock()
         mock_llm_client.return_value.model = "gpt-4"
         from agentao.agent import Agentao
-        return Agentao(thinking_callback=thinking_callback)
+        return Agentao(
+            thinking_callback=thinking_callback,
+            working_directory=Path.cwd(),
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_tool_confirmation.py
+++ b/tests/test_tool_confirmation.py
@@ -1,5 +1,6 @@
 """Test tool confirmation feature."""
 
+from pathlib import Path
 from unittest.mock import Mock, patch
 from agentao.tools import ShellTool, WebFetchTool, WebSearchTool, ReadFileTool
 
@@ -40,7 +41,10 @@ def test_agent_with_confirmation_callback():
         confirmation_callback = Mock(return_value=True)
 
         # Create agent with confirmation callback
-        agent = Agentao(confirmation_callback=confirmation_callback)
+        agent = Agentao(
+            confirmation_callback=confirmation_callback,
+            working_directory=Path.cwd(),
+        )
 
         assert agent.confirmation_callback is not None, "Confirmation callback should be set"
         print("✅ Agent accepts confirmation callback")
@@ -71,7 +75,10 @@ def test_confirmation_callback_signature():
         from agentao.agent import Agentao
 
         # Create agent with callback
-        agent = Agentao(confirmation_callback=sample_callback)
+        agent = Agentao(
+            confirmation_callback=sample_callback,
+            working_directory=Path.cwd(),
+        )
 
         # Test callback
         result = agent.confirmation_callback("test_tool", "Test tool description", {"arg1": "value1"})
@@ -91,7 +98,7 @@ def test_no_confirmation_callback():
         from agentao.agent import Agentao
 
         # Create agent without callback
-        agent = Agentao()
+        agent = Agentao(working_directory=Path.cwd())
 
         assert agent.confirmation_callback is None, "Confirmation callback should be None"
         print("✅ Agent works without confirmation callback")


### PR DESCRIPTION
## Summary

Repositions Agentao as an embedded agent runtime — hosts can drop it into their own apps without the implicit cwd/env/`.agentao/` side effects the CLI relies on. Closes #9, #10, #11, #12, #13.

- **Capability protocols** (`agentao.capabilities`) — `FileSystem` / `ShellExecutor` `Protocol`s plus byte-equivalent `LocalFileSystem` / `LocalShellExecutor` defaults. File, search, and shell tools route IO through them, so embedded hosts can swap in Docker exec, virtual filesystems, audit proxies, or remote runners without monkey-patching `subprocess` / `pathlib`.
- **Embedding factory** (`agentao.embedding.build_from_environment`) — captures every implicit `.env` / `.agentao/permissions.json` / `.agentao/mcp.json` / cwd read in one place. CLI and ACP route through it so subsystem fallbacks become dead code from their perspective.
- **Explicit injections in `Agentao.__init__`** — `llm_client`, `logger`, `memory_manager`, `skill_manager`, `project_instructions`, `mcp_manager`, `filesystem`, `shell`. When `skill_manager` or `project_instructions` is injected, the auto-discovery / disk-read paths are skipped. Mutually-exclusive raw kwargs (`llm_client` vs `api_key/base_url/model/temperature`, `mcp_manager` vs `extra_mcp_servers`) raise `ValueError`.
- **Async surface** (`Agentao.arun`) — bridges sync `chat()` through `loop.run_in_executor`. Async hosts can `await agent.arun(...)` without their own thread bridge; cancellation, replay, and `max_iterations` behave identically across both surfaces.
- **Sub-agent env hygiene** — `agentao/agents/tools.py` no longer re-reads provider env vars; children inherit the parent's resolved LLM config.

### Deprecation

`Agentao()` without `working_directory=` now emits a `DeprecationWarning` and will become a `TypeError` in 0.3.0. Pass an explicit `Path`, or use `agentao.embedding.build_from_environment()` for CLI-style auto-discovery.

### Developer-guide updates

- `developer-guide/{en,zh}/part-2/2-constructor-reference.md` — injection kwargs, factory, `arun()`, capability protocols.
- `developer-guide/{en,zh}/appendix/a-api-reference.md` — new public exports, capability protocol bodies, mutual-exclusion rules.

A scheduled follow-up agent (2026-05-11) will open a second PR updating `part-6/4-multi-tenant-fs.md` and `appendix/e-migration.md` with the capability-injection isolation pattern and the 0.3.0 hard-break migration recipe.

## Test plan

- [x] `uv run python -m pytest tests/` → **2061 passed, 1 skipped** (skip = live-network model check)
- [x] `uv run python -m pytest tests/ -W error::DeprecationWarning` → clean (no internal warning leakage)
- [x] CLI smoke: `./run.sh` boots — banner renders, model loads, command surface ready (verified 2026-04-27 with stub `OPENAI_*` env)
- [x] ACP smoke: `agentao --acp --stdio` handshakes — `initialize` negotiates `protocolVersion: 1` and `session/new` returns a `sessionId`
- [x] Manual: `Agentao(filesystem=FakeFS(), shell=FakeShell(), working_directory=tmp)` round-trips a chat with mocked LLM — `read_file` tool calls `FakeFS.is_file` / `read_partial` / `open_text` (capability injection routes correctly, no real disk access)
- [x] Manual: `await agent.arun("hi")` from a FastAPI handler returns the same string as sync `agent.chat("hi")` under the same mocked LLM

🤖 Generated with [Claude Code](https://claude.com/claude-code)