### PR TITLE
chore(release): cut 0.4.0 — Path A first break (dep split + friendly errors)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,22 +7,14 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
-> **Migration heads-up — 0.4.0 break approaching.** `pip install agentao`
-> will shrink to an embedding-only core (7 packages). `rich` /
-> `prompt-toolkit` / `readchar` / `pygments` move to `[cli]`;
-> `beautifulsoup4` to `[web]`; `jieba` to `[i18n]`. The public Python API
-> is unchanged. CLI users want `pip install 'agentao[cli]'`. The
-> zero-behaviour-change upgrade line is `pip install 'agentao[full]'`.
-> Full guide: [`docs/migration/0.3.x-to-0.4.0.md`](docs/migration/0.3.x-to-0.4.0.md).
+## [0.4.0] — 2026-05-01
 
-Targeting **0.4.0** — the single break release of the Path A P0 plan
+The single break release of the Path A P0 plan
 (see `docs/design/path-a-roadmap.md` §3.2). The break is a packaging
-change only; no public Python API is renamed, removed, or signature-
+change only — no public Python API is renamed, removed, or signature-
 changed. The "no-change" upgrade line is `pip install 'agentao[full]'`,
-which reproduces the 0.3.x bundled closure exactly.
-
-Pre-tag protocol per §13.1 (T-7 dress rehearsal) and §13.2 (pre-announce)
-must complete before the tag.
+which reproduces the 0.3.x bundled closure exactly (CI-enforced against
+a 122-package baseline).
 
 ### Breaking changes
 
@@ -67,16 +59,51 @@ must complete before the tag.
 
   Implementation: `agentao/cli/__init__.py` defines `entrypoint()`
   inline (no module-level imports of rich / prompt_toolkit / readchar /
-  pygments) so the module load itself stays free of CLI deps; the
-  first heavy import is wrapped in try/except. All other public names
-  in `agentao.cli` lazy-load via PEP 562 `__getattr__`. Three new
-  slow-marked tests in `tests/test_cli_missing_dep_message.py` cover
-  the friendly-message path, the post-`[cli]` boot path, and the
-  no-trace-leak invariant.
+  pygments) so the module load itself stays free of CLI deps; every
+  `[cli]` dep is preflighted via `importlib.util.find_spec` so a
+  partial install (rich present, prompt_toolkit missing) still hits
+  the friendly path instead of leaking a "Fatal error" from
+  `entrypoints.run_init_wizard`'s broad `except Exception`. All other
+  public names in `agentao.cli` lazy-load via PEP 562 `__getattr__`.
+  Slow-marked tests in `tests/test_cli_missing_dep_message.py` cover
+  the friendly-message path, the post-`[cli]` boot path, the
+  no-trace-leak invariant, and the partial-install regression.
 
 - **`docs/migration/0.3.x-to-0.4.0.md`** — full migration guide with
   install matrix, dependency map, common project-shape recipes, and
   a `[full]` fallback for any path the migration may have missed.
+
+### Changed
+
+- **Web tools omitted from the registry without `[web]`** —
+  `WebFetchTool` and `WebSearchTool` register only when
+  `beautifulsoup4` is importable. In a core install the model never
+  sees `web_fetch` / `web_search` in its tool schema (vs. the previous
+  behaviour of registering them and failing at execute time with an
+  opaque ImportError). Mirrors the existing `bg_store is not None`
+  pattern that already conditionally registers the background-agent
+  tools.
+
+- **Memory recall degrades gracefully without `[i18n]`** —
+  `MemoryRetriever.tokenize()` skips the jieba code path entirely
+  when the query has no CJK characters (cheap regex check). On a
+  CJK-bearing query in a `[i18n]`-less install, `_cjk_segment()`
+  returns an empty set with a one-time warning pointing at
+  `pip install 'agentao[i18n]'` instead of silently failing.
+
+- **CI test environment installs `[cli,web,i18n]`** — the existing
+  unit-test surface imports `from agentao.cli import AgentaoCLI`,
+  the web-fetch tool, and the jieba memory path. The default `Test`
+  matrix job now installs those three extras so the suite still
+  resolves in the core-split world. The core-only contract is
+  independently validated by the smoke job and
+  `tests/test_dependency_split.py`.
+
+- **Shared test helper `tests/support/wheel.py`** — `REPO_ROOT`,
+  `find_wheel()`, `require_wheel()`, and `make_venv()` centralized
+  out of the venv-creation pattern that was duplicated across
+  `test_clean_install_smoke.py`, `test_dependency_split.py`, and
+  `test_cli_missing_dep_message.py`.
 
 ## [0.3.4] — 2026-05-01
 

--- a/README.md
+++ b/README.md
@@ -518,11 +518,6 @@ Agentao is built around three foundational principles:
 
 ## Installation
 
-> **Heads-up: 0.4.0 break approaching.** Bare `pip install agentao` will
-> install the embedding-only core. CLI users want `pip install 'agentao[cli]'`;
-> for the 0.3.x bundled closure use `pip install 'agentao[full]'`.
-> Migration guide: [`docs/migration/0.3.x-to-0.4.0.md`](docs/migration/0.3.x-to-0.4.0.md).
-
 If your goal is simply "get Agentao running", read this section together with [Minimum Viable Configuration](#minimum-viable-configuration). If you're contributing to the codebase, you can jump to [For contributors (source install)](#for-contributors-source-install).
 
 ### Prerequisites

--- a/README.zh.md
+++ b/README.zh.md
@@ -512,11 +512,6 @@ Agentao 围绕三个基础原则构建：
 
 ## 安装
 
-> **预告：0.4.0 break 即将到来。** 裸装 `pip install agentao` 将只装嵌入核心。
-> CLI 用户用 `pip install 'agentao[cli]'`；要 0.3.x 等价闭包用
-> `pip install 'agentao[full]'`。完整迁移指南：
-> [`docs/migration/0.3.x-to-0.4.0.md`](docs/migration/0.3.x-to-0.4.0.md)。
-
 如果你的目标只是“先把 Agentao 跑起来”，这一节和[最小可运行配置](#最小可运行配置)一起看就够了。如果你是准备参与代码贡献，可以直接跳到[贡献者 / 源码安装](#贡献者--源码安装)。
 
 ### 前置条件

--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.0.dev0"
+__version__ = "0.4.0"
 
 # Lazy exports via PEP 562 module __getattr__.
 #


### PR DESCRIPTION
## Summary

Release-cut PR for **0.4.0** — the single break in the entire Path A P0
plan. The break is a **packaging change only**; no public Python API is
renamed, removed, or signature-changed.

The actual work (P0.9 dep split + P0.10 friendly error + Codex-round
follow-ups + simplify pass + doc sync) merged via PR #20. This PR is
just version + CHANGELOG mechanics:

- `agentao/__init__.py`: `__version__` → `0.4.0`
- `CHANGELOG.md`: `[Unreleased]` → `[0.4.0] — 2026-05-01`; new empty
  `[Unreleased]` opened above; entries restructured into
  Breaking changes / Added / Changed
- `README.md` + `README.zh.md`: drop the "0.4.0 break approaching"
  banner (the install matrix below it is now reality, not warning)

## Migration matrix (recap)

| You are… | Install line |
|---|---|
| Embedding host (Python `from agentao import Agentao`) | `pip install agentao` |
| CLI user (`agentao` console script) | `pip install 'agentao[cli]'` |
| Want zero behaviour change from 0.3.x | `pip install 'agentao[full]'` |

Full guide: [`docs/migration/0.3.x-to-0.4.0.md`](docs/migration/0.3.x-to-0.4.0.md).

## Local pre-tag verification

- [x] `mypy --strict --package agentao.harness` clean
- [x] Main suite: 2266 passed (with `[cli,web,i18n]` dev install)
- [x] Slow suite: 9/9 passed — closure equivalence with 0.3.x `[full]`,
      core-only construct + extras absence + partial CLI install
- [x] `uv build` produces `agentao-0.4.0-{whl,tar.gz}` cleanly
- [x] §13.2 pre-announce banners already posted in CHANGELOG /
      README / `docs/releases/v0.3.3.md` / GitHub release v0.3.4

## Post-merge plan

After this PR is merged into `main`:

1. Tag `v0.4.0` on the merged commit and push the tag
2. Create the GitHub Release (with the `[0.4.0]` CHANGELOG body) —
   this triggers `.github/workflows/publish.yml` (`on: release: types:
   [published]`) which validates `__version__` matches the tag and
   publishes to PyPI

🤖 Generated with [Claude Code](https://claude.com/claude-code)