### PR TITLE
fix(ci): publish workflow installs [cli,web,i18n] extras before tests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -50,8 +50,15 @@ jobs:
       - name: Install Python 3.12
         run: uv python install 3.12
 
-      - name: Install dependencies
-        run: uv sync --python 3.12
+      - name: Install dependencies (with cli/web/i18n extras for CLI-dependent unit tests)
+        # Mirrors the same install matrix used by .github/workflows/ci.yml's
+        # Test job. After P0.9 the bundled CLI deps live in `[cli]`;
+        # tests/test_menu_confirmation.py, test_readchar_confirmation.py,
+        # test_cli_dashboard.py, test_skill_crystallize_enhancement.py, etc.
+        # all import from agentao.cli or read prompt_toolkit/readchar at
+        # collect time. Without these extras the test step fails before
+        # build/publish run.
+        run: uv sync --python 3.12 --extra cli --extra web --extra i18n
 
       - name: Run tests in CI offline mode
         env:


### PR DESCRIPTION
## Summary

The 0.4.0 release tag fired the Publish workflow, which **failed in
18 seconds** at the "Run tests in CI offline mode" step with
`ModuleNotFoundError: No module named 'prompt_toolkit'` /
`ModuleNotFoundError: No module named 'readchar'`. **PyPI did not
receive the 0.4.0 wheel.**

Root cause: the publish workflow's Install dependencies step was
`uv sync --python 3.12` — no extras. After P0.9 (#20) the existing
default test surface (`tests/test_menu_confirmation.py`,
`tests/test_readchar_confirmation.py`, `tests/test_cli_dashboard.py`,
`tests/test_skill_crystallize_enhancement.py`, …) imports from
`agentao.cli` and reads `prompt_toolkit` / `readchar` at collect time.
Without `[cli]` those imports fail before build / twine / publish
steps run.

I fixed the equivalent issue in `.github/workflows/ci.yml`'s Test job
in `dbf529c` (round-2 of the Codex review). That fix unblocked PR
validation but missed the post-tag publish path that runs the same
step.

## Fix

Mirror the same `--extra cli --extra web --extra i18n` install matrix
already in `ci.yml`:

```yaml
- name: Install dependencies (with cli/web/i18n extras for CLI-dependent unit tests)
  run: uv sync --python 3.12 --extra cli --extra web --extra i18n
```

## Post-merge plan

Once this lands on `main`:

1. `gh workflow run publish.yml --ref main` to re-trigger the publish
   pipeline against the fixed workflow file. The validation step
   (`if: github.event_name == 'release'`) is skipped on
   `workflow_dispatch`, but `agentao/__init__.py` is already
   `__version__ = "0.4.0"` on main — the build will produce the
   correct wheel name and the trusted-publisher OIDC step will push
   to PyPI.
2. Verify `pip install agentao==0.4.0` resolves against PyPI.

The GitHub Release for v0.4.0 already exists; PyPI is the only
remaining artifact gap.

## Test plan

- [x] CI matrix on this PR runs the publish workflow's tests step
      against the same `--extra cli,web,i18n` install (validates the
      fix end-to-end before merging)
- [ ] After merge: `gh workflow run publish.yml` succeeds end-to-end
- [ ] After publish: `pip index versions agentao` lists `0.4.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)