### PR TITLE
chore: bump to 0.4.1.dev0

### DIFF
--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.0"
+__version__ = "0.4.1.dev0"
 
 # Lazy exports via PEP 562 module __getattr__.
 #


### PR DESCRIPTION
## Summary

Open the 0.4.1 dev cycle. 0.4.0 shipped clean to PyPI (release run
`25210184340`); the `[Unreleased]` section in `CHANGELOG.md` is empty
and ready to receive the next round of work.

- `agentao/__init__.py`: `__version__` → `0.4.1.dev0`

PEP 440 format normalized from the user's request `0.4.1-dev` to
`0.4.1.dev0` to match the existing convention
(`0.3.1.dev0` / `0.3.2.dev0` / `0.4.0.dev0`).

## Test plan

- [x] One-line version bump; CI matrix on this PR exercises it across
      Python 3.10/3.11/3.12 + the smoke + examples jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)