### PR TITLE
docs(developer-guide): §7.6 WeChat bot blueprint (ilink-style)

### DIFF
--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -5,7 +5,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.2"
+__version__ = "0.4.3.dev0"
 
 # Lazy exports via PEP 562 module __getattr__.
 #

--- a/developer-guide/.vitepress/config.mts
+++ b/developer-guide/.vitepress/config.mts
@@ -104,6 +104,7 @@ const zhSidebar = [
       { text: '7.3 工单自动化', link: '/zh/part-7/3-ticket-automation' },
       { text: '7.4 数据分析工作台', link: '/zh/part-7/4-data-workbench' },
       { text: '7.5 批处理与定时任务', link: '/zh/part-7/5-batch-scheduler' },
+      { text: '7.6 微信智能机器人', link: '/zh/part-7/6-wechat-bot' },
     ],
   },
   {
@@ -219,6 +220,7 @@ const enSidebar = [
       { text: '7.3 Ticket Automation', link: '/en/part-7/3-ticket-automation' },
       { text: '7.4 Data Workbench', link: '/en/part-7/4-data-workbench' },
       { text: '7.5 Batch & Scheduler', link: '/en/part-7/5-batch-scheduler' },
+      { text: '7.6 WeChat Intelligent Bot', link: '/en/part-7/6-wechat-bot' },
     ],
   },
   {

--- a/developer-guide/en/part-7/5-batch-scheduler.md
+++ b/developer-guide/en/part-7/5-batch-scheduler.md
@@ -232,16 +232,4 @@ uv sync && uv run python -m src.daily_digest
 
 ---
 
-## End of Part 7 — and of the guide's main arc
-
-You now have:
-
-- Two embedding paths ([Part 2](/en/part-2/) SDK, [Part 3](/en/part-3/) ACP)
-- Event + UI integration ([Part 4](/en/part-4/))
-- Six extension points ([Part 5](/en/part-5/))
-- Security + production deployment ([Part 6](/en/part-6/))
-- Five real-world blueprints (this part)
-
-The appendices — full API reference, config key index, ACP message fields, error codes, migration notes, FAQ, glossary — are what you'll reach for as you build. They follow.
-
-→ Appendices (coming soon)
+→ [7.6 WeChat Intelligent Bot](./6-wechat-bot)

--- a/developer-guide/en/part-7/6-wechat-bot.md
+++ b/developer-guide/en/part-7/6-wechat-bot.md
@@ -1,0 +1,271 @@
+# 7.6 Blueprint F · WeChat Intelligent Bot (ilink-style)
+
+::: tip ⚡ Runnable end-to-end
+**Outcome** — a long-polling daemon that runs one Agentao turn per inbound WeChat message (DM or group) and posts the reply back to the same contact. The contact id selects a permission preset (allowlist → workspace-write; everyone else → read-only).
+**Stack** — Python · `asyncio` long-poll · bring-your-own ilink / wechaty / itchat client behind a `WeChatClient` Protocol · fresh `Agentao` per message · `llm_client_factory` test seam.
+**Source** — [`examples/wechat-bot/`](https://github.com/jin-bo/agentao/tree/main/examples/wechat-bot)
+**Run** — `uv sync`, then feed the daemon any client speaking the ilink-style protocol.
+:::
+
+**Scenario**: you already have a personal WeChat account (a phone, or a server running an ilink / wechaty / itchat bridge) and you want to add "natural-language conversation + tool execution" to it. **This is *not* the Official Account / Enterprise WeChat platform** — that path uses an official webhook (signature verification, 5-second ACK, 48-hour customer-service window) and is not what this blueprint covers. We're building a personal-account bot that long-polls a local/remote bot HTTP API, modeled after [`Wechat-ggGitHub/wechat-claude-code`](https://github.com/Wechat-ggGitHub/wechat-claude-code) (same shape, TypeScript with the Claude Code SDK; this is the Python + Agentao version).
+
+## Who & why
+
+- **Product shape**: single-process long-polling daemon; no public ingress required
+- **Users**: yourself, your team, or members of a group chat — the "bot" feels like a WeChat friend that does work
+- **Pain**: the Official Account platform is heavyweight (ICP filing, business verification, 5-second ACK, 48h window). A personal-account bot is simply "an assistant glued to your WeChat" — read messages in, run an agent, send the reply back
+
+## ilink-style ≠ Official Account webhook
+
+::: warning Don't pick the wrong rail
+The two tracks are **architecturally very different**. Don't conflate them:
+
+| Dimension | ilink-style personal-account bot (this blueprint) | Official Account / Enterprise WeChat |
+|-----------|---------------------------------------------------|---------------------------------------|
+| Trigger | Daemon **long-polls** the bot's HTTP endpoint | WeChat servers **call back** your public webhook |
+| 5-second window | **None** — you pull, you reply when you're done | Yes; must ACK first, push asynchronously |
+| Signature / AES | Client-dependent; usually plain | Required; AES-CBC in secure mode |
+| 48-hour customer-service window | **None** | Yes |
+| User ID | wxid (DM) / `<id>@chatroom` (group) | OpenID / UnionID |
+| ICP filing / verification | Not required | Required |
+
+If you want the **former** (assistant glued to your own account, internal tools, team automation), keep reading.
+If you want the **latter** (consumer-facing brand Official Account, customer service), this blueprint doesn't apply — consult the WeChat Official Platform docs.
+:::
+
+## Architecture
+
+```
+WeChat phone / bridge client (ilink, wechaty, itchat, …)
+       │ exposes a bot API (HTTP / ws)
+       ▼
+Python daemon (single asyncio process)
+       │
+       ├─ run_polling_loop(WeChatClient)
+       │    while not stop:
+       │      msgs = await client.fetch_messages()
+       │      for m in msgs:
+       │          await handle_message(...)
+       │
+       └─ handle_message(text, contact_id, send)
+            ├─ tempdir = mkdtemp("agentao-wechat-")
+            ├─ engine = make_permission_engine_for_contact(contact_id)
+            │     allowlist hit → WORKSPACE_WRITE
+            │     otherwise    → READ_ONLY
+            ├─ agent = Agentao(working_directory=tempdir,
+            │                  llm_client=llm_client_factory(),
+            │                  permission_engine=engine)
+            ├─ reply = await agent.arun(text)
+            ├─ agent.close() + rmtree(tempdir)
+            └─ await send(contact_id=contact_id, text=reply)
+```
+
+## Key code
+
+> All snippets come from [`examples/wechat-bot/src/bot.py`](https://github.com/jin-bo/agentao/tree/main/examples/wechat-bot/src/bot.py) — the whole module is under 170 lines.
+
+### 1 · The client Protocol — fits ilink, wechaty, itchat alike
+
+```python
+class WeChatMessage(Protocol):
+    text: str
+    contact_id: str          # wxid or <id>@chatroom
+    message_id: str
+
+class WeChatClient(Protocol):
+    async def fetch_messages(self) -> list[WeChatMessage]: ...
+    async def send_message(self, *, contact_id: str, text: str) -> None: ...
+```
+
+The single most copy-worthy idea: **bot logic only ever talks to the Protocol**. Use ilink today, swap to wechaty tomorrow, hand-roll an HTTP-hooks client next week — **the daemon doesn't change a line**. Streaming previews, QR-code login, rate-limit retry, reconnect — all transport concerns — **stay in the concrete client**.
+
+### 2 · Contact → permission mode
+
+```python
+WRITE_ALLOWLIST_CONTACTS: frozenset[str] = frozenset(
+    {"wxid_owner_self", "ROOM_devops@chatroom"}
+)
+
+def make_permission_engine_for_contact(
+    contact_id: str, *, project_root: Path
+) -> PermissionEngine:
+    engine = PermissionEngine(project_root=project_root)
+    mode = (
+        PermissionMode.WORKSPACE_WRITE
+        if contact_id in WRITE_ALLOWLIST_CONTACTS
+        else PermissionMode.READ_ONLY
+    )
+    engine.set_mode(mode)
+    return engine
+```
+
+DM wxids and group `@chatroom` ids share the same field, so they can live in the **same allowlist**. In production, load the allowlist from config / a database — never hard-code.
+
+### 3 · One message → one turn
+
+```python
+async def handle_message(
+    *,
+    text: str,
+    contact_id: str,
+    send: Callable[..., Awaitable[Any]],
+    llm_client_factory: Callable[[], LLMClient] = make_llm_client,
+) -> str:
+    work_dir = Path(tempfile.mkdtemp(prefix="agentao-wechat-"))
+    agent = Agentao(
+        working_directory=work_dir,
+        llm_client=llm_client_factory(),
+        permission_engine=make_permission_engine_for_contact(
+            contact_id, project_root=work_dir
+        ),
+    )
+    try:
+        reply = await agent.arun(text)
+    finally:
+        agent.close()
+        shutil.rmtree(work_dir, ignore_errors=True)   # close() does NOT delete tempdir
+    await send(contact_id=contact_id, text=reply)
+    return reply
+```
+
+Trade-offs baked in:
+
+- **Fresh agent per message** — simple, well-isolated; for higher throughput, pool by `contact_id`
+- **Tempdir must be `rmtree`d explicitly** — `agent.close()` releases handles but leaves the directory; without this the daemon leaks one tempdir per inbound message
+- **`llm_client_factory` is the test seam** — production reads env, smoke tests inject a `MagicMock`; no `if testing` branches anywhere
+
+### 4 · The long-poll loop
+
+```python
+async def run_polling_loop(
+    client: WeChatClient,
+    *,
+    poll_interval_s: float = 1.0,
+    stop_event: Optional[asyncio.Event] = None,
+    llm_client_factory: Callable[[], LLMClient] = make_llm_client,
+) -> None:
+    stop = stop_event or asyncio.Event()
+    while not stop.is_set():
+        messages = await client.fetch_messages()
+        for msg in messages:
+            await handle_message(
+                text=msg.text,
+                contact_id=msg.contact_id,
+                send=client.send_message,
+                llm_client_factory=llm_client_factory,
+            )
+        if stop.is_set():
+            break
+        try:
+            await asyncio.wait_for(stop.wait(), timeout=poll_interval_s)
+        except asyncio.TimeoutError:
+            continue
+```
+
+`stop_event` is the graceful-shutdown hook — tests fire it from a `FakeWeChatClient` once its queue drains so the loop exits cleanly. In production, wire it to SIGTERM.
+
+## Offline smoke test — runs without WeChat
+
+The other point worth stealing from this example: **`llm_client_factory` + the client Protocol** make the entire pipeline runnable in CI with zero external dependencies.
+
+```python
+# tests/test_smoke.py (excerpt)
+class _FakeWeChatClient:
+    """In-memory client: yields a queued batch, then sets stop_event to exit."""
+    async def fetch_messages(self) -> list[_Msg]:
+        if self._queued:
+            batch, self._queued = self._queued, []
+            return batch
+        self._stop.set()
+        return []
+    async def send_message(self, *, contact_id: str, text: str) -> None:
+        self.sent.append({"contact_id": contact_id, "text": text})
+
+async def test_run_polling_loop_processes_one_batch_then_exits() -> None:
+    stop = asyncio.Event()
+    client = _FakeWeChatClient(
+        queued=[
+            _Msg(text="ping",    contact_id="wxid_a", message_id="1"),
+            _Msg(text="status?", contact_id="wxid_b", message_id="2"),
+        ],
+        stop=stop,
+    )
+    with patch("agentao.agent.Agentao._llm_call",
+               lambda self, msgs, tools, token: _fake_response("ok")):
+        await run_polling_loop(client, stop_event=stop, llm_client_factory=_fake_llm)
+    assert client.sent == [
+        {"contact_id": "wxid_a", "text": "ok"},
+        {"contact_id": "wxid_b", "text": "ok"},
+    ]
+```
+
+```bash
+cd examples/wechat-bot
+uv sync --extra dev
+uv run pytest tests/ -v   # no WeChat, no API key, no network
+```
+
+## Want streaming previews? Wire `Agentao.events()`
+
+The reference repo (`wechat-claude-code`) streams partial LLM output back to the chat as a "typing…" preview. To do that on Agentao, replace the `agent.arun(text)` shot with a subscription to `agent.events()` and forward `LLM_TEXT` increments to `client.send_message` on a "every N chars / every M ms" cadence (see [§4 Event Streams](/en/part-4/)). Most ilink-style clients enforce a per-message rate limit and will throttle aggressive streaming — **1.5 seconds per chunk is a safe default**.
+
+## ⚠️ Pitfalls
+
+::: warning Day-2 bugs from real ilink-style WeChat bots
+Each row below is a real production incident. Skim them before you ship — fixes are cheap *now* and expensive *later*.
+:::
+
+| Day-2 bug | Root cause | Fix |
+|-----------|------------|-----|
+| `/tmp` filled up | `agent.close()` doesn't remove the tempdir; one leak per message | Explicit `shutil.rmtree(work_dir, ignore_errors=True)` (already in the example) |
+| Two replies in the same group come back out of order | Switching to parallel processing without serializing per `contact_id` | Bucket by `contact_id` and hold an `asyncio.Lock` per bucket |
+| Group messages get replies even without `@bot` | Personal-account bots receive every group message by default | Filter `@<self>` either in the client adapter or at the top of `handle_message` |
+| Identity spoofing | Granting `WORKSPACE_WRITE` based on `contact_id` alone | Add a second factor (passphrase, signed command envelope) — `contact_id` is a transport identifier, not an auth credential |
+| 5,000-char LLM output blows past the per-message cap | ilink-style clients impose per-message limits (often 1024–4096 bytes) | Chunk on the way out of `handle_message`, or hard-cap output length in the skill |
+| Group-chat flood (agent loops) | `max_iterations` unbounded; agent has a tool that itself sends messages | Hard-cap `agent.arun`; keep "outbound = daemon only" — don't give tools the ability to send messages |
+| Bridge client gets banned / disconnected | `fetch_messages` returns 401 or a network error, not an empty batch | Loud alert + reconnect with backoff on exceptions; never `try/except: pass` |
+| Test fixtures pass while production breaks | Protocol changed in tests but the real client wasn't updated | Add a contract test in `tests/` that pins the `fetch_messages` / `send_message` signatures |
+| API key shows up in logs | `LLMClient` construction printed in trace | Apply the secrets scrubber from [6.5](/en/part-6/5-secrets-injection) |
+
+## Going further: a long-lived agent per contact
+
+The example **builds a fresh agent per message** — simple and easy to reclaim. If you need:
+
+- multi-turn memory across messages
+- a shared working directory (so the agent can edit a file in the third message that it created in the first)
+
+… cache `_agents: dict[str, Agentao]` keyed by `contact_id`, **pair it with an `asyncio.Lock` per key** to serialize, and add LRU + idle timeout (e.g. close the agent and delete its working directory after 30 min of silence). This is the most common evolution from "per-message isolation" to "per-contact session" — but the **multi-tenant security calculus** changes too; see [§6.4 Multi-Tenant & FS](/en/part-6/4-multi-tenant-fs).
+
+## Runnable code
+
+The full project lives in-repo at [`examples/wechat-bot/`](https://github.com/jin-bo/agentao/tree/main/examples/wechat-bot):
+
+```bash
+cd examples/wechat-bot
+uv sync --extra dev
+uv run pytest tests/ -v          # offline smoke
+
+# Real run (bring your own ilink / wechaty / itchat client)
+OPENAI_API_KEY=sk-... uv run python -c "
+import asyncio
+from src.bot import run_polling_loop
+from your_wechat_client import IlinkClient   # your concrete ilink client
+asyncio.run(run_polling_loop(IlinkClient()))
+"
+```
+
+---
+
+## End of Part 7 — and of the guide's main arc
+
+You now have:
+
+- Two embedding paths ([Part 2](/en/part-2/) SDK, [Part 3](/en/part-3/) ACP)
+- Event + UI integration ([Part 4](/en/part-4/))
+- Six extension points ([Part 5](/en/part-5/))
+- Security + production deployment ([Part 6](/en/part-6/))
+- Six real-world blueprints (this part)
+
+The appendices — full API reference, config key index, ACP message fields, error codes, migration notes, FAQ, glossary — are what you'll reach for as you build. They follow.
+
+→ Appendices (coming soon)

--- a/developer-guide/en/part-7/index.md
+++ b/developer-guide/en/part-7/index.md
@@ -15,9 +15,10 @@ Each blueprint answers the same four questions:
 - **Ticket automation** — async handler reading from a queue; `prompt_once` style, no streaming UI · [§7.3](/en/part-7/3-ticket-automation), [G.4](/en/appendix/g-glossary#g-4-integration-patterns)
 - **Data workbench** — interactive analyst session with shell + sandbox + skills · [§7.4](/en/part-7/4-data-workbench)
 - **Batch scheduler** — cron-driven `prompt_once` for offline / nightly jobs; no end-user · [§7.5](/en/part-7/5-batch-scheduler), [G.4](/en/appendix/g-glossary#g-4-integration-patterns)
+- **WeChat intelligent bot (ilink-style)** — long-polling personal-account bot API; one agent per message; contact-scoped permissions · [§7.6](/en/part-7/6-wechat-bot)
 :::
 
-## The five blueprints
+## The six blueprints
 
 | # | Blueprint | Integration mode | Star extensions |
 |---|-----------|-------------------|------------------|
@@ -26,6 +27,7 @@ Each blueprint answers the same four questions:
 | [7.3](./3-ticket-automation) | Customer-support / ticket automation | In-process SDK | Custom tools hitting CRM |
 | [7.4](./4-data-workbench) | Data analyst workbench | In-process SDK | Shell + sandbox + custom skill |
 | [7.5](./5-batch-scheduler) | Offline batch / scheduled jobs | `prompt_once` | Skills + cron |
+| [7.6](./6-wechat-bot) | WeChat intelligent bot (ilink-style) | `asyncio` long-poll daemon | `WeChatClient` Protocol + contact-scoped permissions |
 
 ## How to read this part
 

--- a/developer-guide/zh/part-7/5-batch-scheduler.md
+++ b/developer-guide/zh/part-7/5-batch-scheduler.md
@@ -232,16 +232,4 @@ uv sync && uv run python -m src.daily_digest
 
 ---
 
-## Part 7 结束——也是主干内容的终点
-
-到这里你已经拥有：
-
-- 两条嵌入路径（[Part 2](/zh/part-2/) SDK、[Part 3](/zh/part-3/) ACP）
-- 事件 + UI 集成（[Part 4](/zh/part-4/)）
-- 六个扩展点（[Part 5](/zh/part-5/)）
-- 安全 + 生产部署（[Part 6](/zh/part-6/)）
-- 五个真实蓝图（本部分）
-
-接下来的附录——完整 API 参考、配置键索引、ACP 消息字段、错误码、框架迁移、FAQ、术语表——是落地过程中常翻的查询手册，紧随其后。
-
-→ 附录（即将推出）
+→ [7.6 微信智能机器人](./6-wechat-bot)

--- a/developer-guide/zh/part-7/6-wechat-bot.md
+++ b/developer-guide/zh/part-7/6-wechat-bot.md
@@ -1,0 +1,271 @@
+# 7.6 蓝图 F · 微信智能机器人（ilink-style）
+
+::: tip ⚡ 端到端可跑
+**产出** —— 一个长轮询守护进程，把每条进来的微信消息（私聊或群消息）跑一次 Agentao，把回复发回同一个联系人；联系人 ID 决定权限预设（白名单 → workspace-write；其余 → read-only）。
+**技术栈** —— Python · `asyncio` 长轮询 · 自带的 ilink / wechaty / itchat 客户端通过 `WeChatClient` Protocol 接入 · 每条消息一个新 `Agentao` 实例 · `llm_client_factory` 测试钩子。
+**源代码** —— [`examples/wechat-bot/`](https://github.com/jin-bo/agentao/tree/main/examples/wechat-bot)
+**运行** —— `uv sync` 然后用任何一个能讲 ilink-style 协议的客户端去喂这个 daemon
+:::
+
+**场景**：你已经有个微信号（一台手机 / 一台服务器跑着 ilink、wechaty、itchat 之类的桥接客户端），想给这个号加上"自然语言对话 + 工具执行"的能力。**这不是公众号 / 企业微信开放平台**——那条路要走 §7.6 之外的官方 webhook 通道；本蓝图走的是个人号 bot API（长轮询一个本地/远程 HTTP 接口），形态参考 [`Wechat-ggGitHub/wechat-claude-code`](https://github.com/Wechat-ggGitHub/wechat-claude-code)（同一个形状的 TypeScript 版本，挂的是 Claude Code SDK；这里是 Python + Agentao）。
+
+## 谁 & 为什么
+
+- **产品形态**：单进程长轮询守护进程；不需要公网入口
+- **用户**：自己 / 团队同事 / 群里的人；你把"机器人"当作一个会做事的微信好友用
+- **痛点**：公众号开放平台门槛高（备案、ICP、企业认证、5 秒响应、48h 客服窗口），个人号 bot 本质是"挂在自己微信上的助手"——要做的只是把消息接进来、跑 agent、把回复发回去
+
+## ilink-style ≠ 公众号 webhook
+
+::: warning 别走错路线
+两条线**架构差异极大**，不要混用：
+
+| 维度 | ilink-style 个人号 bot（本蓝图） | 公众号 / 企业微信开放平台 |
+|------|----------------------------------|---------------------------|
+| 触发方式 | 守护进程**长轮询** bot 的 HTTP 接口 | 微信服务器**回调**到你的公网 webhook |
+| 5 秒响应窗口 | **没有**——你拉，啥时候答完啥时候发 | 有，必须先 ACK 再异步推 |
+| 签名 / AES 加密 | 看具体客户端，多数明文 | 必须验签；安全模式下 AES-CBC |
+| 48 小时客服窗口 | **没有** | 有 |
+| 用户 ID | wxid（私聊）/ `<id>@chatroom`（群） | OpenID / UnionID |
+| 备案 / 认证 | 不需要 | 需要 |
+
+如果你做的是**前者**（自己挂个号给自己用 / 给团队用 / 做内部小工具），继续读。
+如果你做的是**后者**（面向公众的商家公众号 / 客服号），这本蓝图不适用——查微信公众平台官方文档。
+:::
+
+## 架构
+
+```
+微信手机 / 桥接客户端（ilink、wechaty、itchat、…）
+       │ 暴露一个 bot API（HTTP / ws）
+       ▼
+Python daemon（一个 asyncio 进程）
+       │
+       ├─ run_polling_loop(WeChatClient)
+       │    while not stop:
+       │      msgs = await client.fetch_messages()
+       │      for m in msgs:
+       │          await handle_message(...)
+       │
+       └─ handle_message(text, contact_id, send)
+            ├─ tempdir = mkdtemp("agentao-wechat-")
+            ├─ engine = make_permission_engine_for_contact(contact_id)
+            │     allowlist 命中 → WORKSPACE_WRITE
+            │     其余        → READ_ONLY
+            ├─ agent = Agentao(working_directory=tempdir,
+            │                  llm_client=llm_client_factory(),
+            │                  permission_engine=engine)
+            ├─ reply = await agent.arun(text)
+            ├─ agent.close() + rmtree(tempdir)
+            └─ await send(contact_id=contact_id, text=reply)
+```
+
+## 关键代码
+
+> 所有片段都来自 [`examples/wechat-bot/src/bot.py`](https://github.com/jin-bo/agentao/tree/main/examples/wechat-bot/src/bot.py)，整段不到 170 行。
+
+### 1 · 客户端 Protocol——把 ilink / wechaty / itchat 都收进来
+
+```python
+class WeChatMessage(Protocol):
+    text: str
+    contact_id: str          # wxid 或 <id>@chatroom
+    message_id: str
+
+class WeChatClient(Protocol):
+    async def fetch_messages(self) -> list[WeChatMessage]: ...
+    async def send_message(self, *, contact_id: str, text: str) -> None: ...
+```
+
+这是这套设计最值得抄走的一点：**bot 逻辑只认 Protocol**。你今天用 ilink，明天换 wechaty，下周自己拿 HTTP hooks 拼一个，**daemon 不用改一行**。流式预览、扫码登录、限流重试、断线重连——这些 transport 关心的事情，**留给具体客户端去实现**。
+
+### 2 · 联系人 → 权限模式
+
+```python
+WRITE_ALLOWLIST_CONTACTS: frozenset[str] = frozenset(
+    {"wxid_owner_self", "ROOM_devops@chatroom"}
+)
+
+def make_permission_engine_for_contact(
+    contact_id: str, *, project_root: Path
+) -> PermissionEngine:
+    engine = PermissionEngine(project_root=project_root)
+    mode = (
+        PermissionMode.WORKSPACE_WRITE
+        if contact_id in WRITE_ALLOWLIST_CONTACTS
+        else PermissionMode.READ_ONLY
+    )
+    engine.set_mode(mode)
+    return engine
+```
+
+私聊 wxid 和群 `@chatroom` 同一个字段进来，可以**混在同一个白名单**里。生产里这套白名单要从配置 / 数据库读，不能写死。
+
+### 3 · 一条消息 → 一次 turn
+
+```python
+async def handle_message(
+    *,
+    text: str,
+    contact_id: str,
+    send: Callable[..., Awaitable[Any]],
+    llm_client_factory: Callable[[], LLMClient] = make_llm_client,
+) -> str:
+    work_dir = Path(tempfile.mkdtemp(prefix="agentao-wechat-"))
+    agent = Agentao(
+        working_directory=work_dir,
+        llm_client=llm_client_factory(),
+        permission_engine=make_permission_engine_for_contact(
+            contact_id, project_root=work_dir
+        ),
+    )
+    try:
+        reply = await agent.arun(text)
+    finally:
+        agent.close()
+        shutil.rmtree(work_dir, ignore_errors=True)   # close() 不会删 tempdir
+    await send(contact_id=contact_id, text=reply)
+    return reply
+```
+
+设计取舍：
+
+- **每条消息一个新 agent**——简单、隔离好；高吞吐场景可以按 `contact_id` 做 agent 池
+- **tempdir 必须显式 `rmtree`**——`agent.close()` 释放 handle 但不删工作目录，不清理就每条消息漏一个 tempdir
+- **`llm_client_factory` 是测试钩子**——生产读 env，单测注入 `MagicMock`，不需要在代码里加 `if testing` 分支
+
+### 4 · 长轮询主循环
+
+```python
+async def run_polling_loop(
+    client: WeChatClient,
+    *,
+    poll_interval_s: float = 1.0,
+    stop_event: Optional[asyncio.Event] = None,
+    llm_client_factory: Callable[[], LLMClient] = make_llm_client,
+) -> None:
+    stop = stop_event or asyncio.Event()
+    while not stop.is_set():
+        messages = await client.fetch_messages()
+        for msg in messages:
+            await handle_message(
+                text=msg.text,
+                contact_id=msg.contact_id,
+                send=client.send_message,
+                llm_client_factory=llm_client_factory,
+            )
+        if stop.is_set():
+            break
+        try:
+            await asyncio.wait_for(stop.wait(), timeout=poll_interval_s)
+        except asyncio.TimeoutError:
+            continue
+```
+
+`stop_event` 是优雅关闭钩子——测试里 `FakeWeChatClient` 把队列抽干后就 set 它，让循环干净退出。生产里挂到 SIGTERM 上同样有效。
+
+## 离线 smoke test —— 不用真微信也能跑
+
+这套例子的另一个优点：**`llm_client_factory` + 客户端 Protocol** 让整条链路在 CI 里跑，零外部依赖。
+
+```python
+# tests/test_smoke.py 节选
+class _FakeWeChatClient:
+    """In-memory 客户端：吐一批消息后 set stop_event 退出。"""
+    async def fetch_messages(self) -> list[_Msg]:
+        if self._queued:
+            batch, self._queued = self._queued, []
+            return batch
+        self._stop.set()
+        return []
+    async def send_message(self, *, contact_id: str, text: str) -> None:
+        self.sent.append({"contact_id": contact_id, "text": text})
+
+async def test_run_polling_loop_processes_one_batch_then_exits() -> None:
+    stop = asyncio.Event()
+    client = _FakeWeChatClient(
+        queued=[
+            _Msg(text="ping",    contact_id="wxid_a", message_id="1"),
+            _Msg(text="status?", contact_id="wxid_b", message_id="2"),
+        ],
+        stop=stop,
+    )
+    with patch("agentao.agent.Agentao._llm_call",
+               lambda self, msgs, tools, token: _fake_response("ok")):
+        await run_polling_loop(client, stop_event=stop, llm_client_factory=_fake_llm)
+    assert client.sent == [
+        {"contact_id": "wxid_a", "text": "ok"},
+        {"contact_id": "wxid_b", "text": "ok"},
+    ]
+```
+
+```bash
+cd examples/wechat-bot
+uv sync --extra dev
+uv run pytest tests/ -v   # 没微信、没 API key、没网络
+```
+
+## 想要流式预览？接 `Agentao.events()`
+
+参考 repo（`wechat-claude-code`）会把 LLM 输出的中间片段当成"打字中"实时回到聊天里。在 Agentao 这边，把 `agent.arun(text)` 换成订阅 `agent.events()` 流，把 `LLM_TEXT` 增量按"每 N 字符 / 每 M 毫秒"刷给 `client.send_message` 即可（事件契约见 [§4 事件流](/zh/part-4/)）。多数 ilink 客户端有单条消息频率限制，刷得太快会被截断——保守值是 **1.5 秒一段**。
+
+## ⚠️ 陷阱
+
+::: warning ilink-style 微信 bot 真实部署中的 Day-2 bug
+下面每一行都是真实生产事故。**上线前先扫一遍**——现在改便宜，事后查代价大。
+:::
+
+| 上线第二天的 bug | 根因 | 修法 |
+|------------------|------|------|
+| `/tmp` 占满 | `agent.close()` 不删 tempdir，每条消息漏一个目录 | 显式 `shutil.rmtree(work_dir, ignore_errors=True)`，示例已有 |
+| 同一群里两条消息回复乱序 | `for msg in messages` 串行没问题，但你改并行后没按 `contact_id` 串行 | 想并行就**按 `contact_id` 分桶 + 每桶一把 `asyncio.Lock`** |
+| 群消息里没 @ 自己也回复 | 个人号 bot 默认收所有群消息 | 客户端层面或 `handle_message` 入口先过滤 `@<self>` 才进 agent |
+| 假冒身份 | 仅凭 `contact_id` 就给 `WORKSPACE_WRITE` | 二次验证（口令、签名后的指令包）；`contact_id` 是 transport 标识，不是身份认证 |
+| LLM 输出 5000 字撑爆单条消息 | 不同 ilink 客户端有单条上限（多见 1024–4096 字节） | `handle_message` 出口分块；或者技能里硬约束输出长度 |
+| 群里突然刷屏（agent 死循环） | `max_iterations` 没限；agent 又触发了能发消息的工具 | `agent.arun` 设硬上限；坚持"出口只在 daemon 这一处"，不要让工具直接发消息 |
+| 桥接客户端（ilink / wechaty / 微信号本身）被风控掉线 | 长轮询返回的不是空，是 401/网络错 | `fetch_messages` 抛异常时**响亮告警 + 重连退避**；不要 `try/except: pass` |
+| 测试时改了 Protocol 但生产客户端没跟上 | 加了字段没同步给真实 ilink 客户端 | 在 `tests/` 里加一个 contract test，强迫 `WeChatClient` 实现保留 `fetch_messages` / `send_message` 这两个签名 |
+| API key 进日志 | `LLMClient` 构造时被打到 trace | 走 [6.5](/zh/part-6/5-secrets-injection) 的 secrets scrubber |
+
+## 进阶：每个联系人一个常驻 agent
+
+例子里**每条消息新建一个 agent**，简单、好回收。如果你需要：
+
+- 跨消息的对话上下文（多轮记忆）
+- 共享的工作目录（agent 在第一条消息里写的文件，第三条消息能继续编辑）
+
+把 `_agents: dict[str, Agentao]` 缓存按 `contact_id` 留下来即可——同时**配一把 `asyncio.Lock` 防并发**，并加 LRU + 空闲超时（比如 30 分钟没消息就关 agent + 删工作目录）。这是从"每消息隔离"切到"每联系人会话"的最常见演进，但**多租户安全**就要重新算账了——参考 [§6.4 多租户隔离](/zh/part-6/4-multi-tenant-fs)。
+
+## 可运行代码
+
+完整项目就在主仓 [`examples/wechat-bot/`](https://github.com/jin-bo/agentao/tree/main/examples/wechat-bot)：
+
+```bash
+cd examples/wechat-bot
+uv sync --extra dev
+uv run pytest tests/ -v          # 离线 smoke
+
+# 真跑（需要自带 ilink / wechaty / itchat 客户端）
+OPENAI_API_KEY=sk-... uv run python -c "
+import asyncio
+from src.bot import run_polling_loop
+from your_wechat_client import IlinkClient   # 你自己的 ilink 客户端
+asyncio.run(run_polling_loop(IlinkClient()))
+"
+```
+
+---
+
+## Part 7 结束——也是主干内容的终点
+
+到这里你已经拥有：
+
+- 两条嵌入路径（[Part 2](/zh/part-2/) SDK、[Part 3](/zh/part-3/) ACP）
+- 事件 + UI 集成（[Part 4](/zh/part-4/)）
+- 六个扩展点（[Part 5](/zh/part-5/)）
+- 安全 + 生产部署（[Part 6](/zh/part-6/)）
+- 六个真实蓝图（本部分）
+
+接下来的附录——完整 API 参考、配置键索引、ACP 消息字段、错误码、框架迁移、FAQ、术语表——是落地过程中常翻的查询手册，紧随其后。
+
+→ 附录（即将推出）

--- a/developer-guide/zh/part-7/index.md
+++ b/developer-guide/zh/part-7/index.md
@@ -15,9 +15,10 @@
 - **工单自动化** —— 从队列读消息的异步处理器；`prompt_once` 形式，无流式 UI · [§7.3](/zh/part-7/3-ticket-automation)、[G.4](/zh/appendix/g-glossary#g-4-集成模式)
 - **数据工作台** —— 给分析师的交互会话；Shell + 沙箱 + 技能组合 · [§7.4](/zh/part-7/4-data-workbench)
 - **批处理调度** —— cron 驱动的 `prompt_once`，跑离线/夜间任务，没有终端用户 · [§7.5](/zh/part-7/5-batch-scheduler)、[G.4](/zh/appendix/g-glossary#g-4-集成模式)
+- **微信智能机器人（ilink-style）** —— 长轮询个人号 bot API；每条消息一个 agent；联系人级权限 · [§7.6](/zh/part-7/6-wechat-bot)
 :::
 
-## 五个蓝图
+## 六个蓝图
 
 | # | 蓝图 | 集成模式 | 明星扩展点 |
 |---|------|----------|------------|
@@ -26,6 +27,7 @@
 | [7.3](./3-ticket-automation) | 客服 / 工单自动化 | 进程内 SDK | 打通 CRM 的自定义工具 |
 | [7.4](./4-data-workbench) | 数据分析工作台 | 进程内 SDK | Shell + 沙箱 + 自定义技能 |
 | [7.5](./5-batch-scheduler) | 离线批处理 / 定时任务 | `prompt_once` | 技能 + 调度器 |
+| [7.6](./6-wechat-bot) | 微信智能机器人（ilink-style） | `asyncio` 长轮询 daemon | `WeChatClient` Protocol + 联系人级权限 |
 
 ## 如何阅读本部分
 


### PR DESCRIPTION
## Summary

- Adds §7.6 to the developer guide (EN + ZH): a sixth Part 7 blueprint mirrored to `examples/wechat-bot/` — a long-polling daemon that runs one Agentao turn per inbound WeChat message, with a `WeChatClient` Protocol that fits ilink / wechaty / itchat alike, and contact-scoped permission presets (allowlist → `WORKSPACE_WRITE`, otherwise `READ_ONLY`).
- Up-front contrast table draws a hard line between this personal-account / ilink-style path and the Official Account / Enterprise WeChat webhook track so readers don't conflate them.
- Wires the new section into both sidebars and Part 7 indexes (EN + ZH); shifts the "End of Part 7" wrap-up from §7.5 to §7.6.
- Also pulled along the prior `chore: bump to 0.4.3.dev0` commit since direct push to `main` is blocked — happy to split if you'd prefer two PRs.

## Commits in this PR

- `e1e0814` docs(developer-guide): add §7.6 WeChat bot blueprint (ilink-style)
- `60bb152` chore: bump to 0.4.3.dev0

## Test plan

- [ ] `cd developer-guide && npm run docs:build` succeeds
- [ ] §7.6 renders in EN sidebar at `/en/part-7/6-wechat-bot`
- [ ] §7.6 renders in ZH sidebar at `/zh/part-7/6-wechat-bot`
- [ ] §7.5 → §7.6 forward link works in both languages
- [ ] Internal links in §7.6 (§4, §6.4, §6.5) resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)