### PR TITLE
chore: bump to 0.4.6.dev0

### DIFF
--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.5"
+__version__ = "0.4.6.dev0"
 
 
 def _ensure_utf8() -> None:


### PR DESCRIPTION
Post-release bump for the 0.4.6 development cycle. Mirrors #30 (`chore: bump to 0.4.5.dev0`).

`v0.4.5` was tagged at 11339e2 and the GitHub Release published at https://github.com/jin-bo/agentao/releases/tag/v0.4.5 (PyPI workflow triggered via `on: release:`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)