### PR TITLE
chore: bump to 0.4.7.dev0

### DIFF
--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.6"
+__version__ = "0.4.7.dev0"
 
 
 def _ensure_utf8() -> None:


### PR DESCRIPTION
## Summary

Open the next dev cycle now that 0.4.6 has shipped. Mirrors the
established post-release pattern from #30 (`bump to 0.4.5.dev0`).

## Test plan

- [x] one-line `__version__` change in `agentao/__init__.py`
- [x] no other files touched
- [x] CI gates will run (mypy / pytest / schema drift / examples)

🤖 Generated with [Claude Code](https://claude.com/claude-code)