### PR TITLE
docs(developer-guide): capability-injection isolation + 0.3.0 migration recipe

### DIFF
--- a/developer-guide/en/appendix/e-migration.md
+++ b/developer-guide/en/appendix/e-migration.md
@@ -156,6 +156,57 @@ Notes:
 3. **Mixing user + project memory** — keep tenant isolation as the default (see [6.4](/en/part-6/4-multi-tenant-fs)); user-scope is for single-user setups only.
 4. **Leaving confirmations off** — other frameworks often default to "ask everything". Agentao lets you allow-list; use it, but only after you've audited the tool's blast radius.
 
+## E.9 Migrating from 0.2.x to 0.3.0
+
+`working_directory=` is now a required keyword argument. The `DeprecationWarning` emitted by 0.2.16 when the argument was omitted has been replaced by a `TypeError` raised at construction time — there is no longer a `Path.cwd()` lazy fallback.
+
+### Recipe 1 — Pass an explicit `Path` (simplest)
+
+```python
+from pathlib import Path
+from agentao import Agentao
+
+agent = Agentao(working_directory=Path("/srv/agent-workdir"), ...)
+```
+
+This is the right fix for the vast majority of call sites. Resolve the path before passing it so the frozen value is always absolute.
+
+### Recipe 2 — Use `build_from_environment()` for CLI-style auto-discovery
+
+```python
+from pathlib import Path
+from agentao.embedding import build_from_environment
+
+agent = build_from_environment(working_directory=Path("/srv/agent-workdir"))
+```
+
+`build_from_environment` reads `.env`, discovers `.agentao/` config files, and wires the full CLI-equivalent defaults (user-scope memory, MCP file config, sandbox, replay). Pass `working_directory=` explicitly; if omitted, the factory falls back to `Path.cwd()` — acceptable for CLI entry points, not for embedded hosts.
+
+### Recipe 3 — Tests that exercised the legacy lazy-cwd default
+
+In 0.2.x, tests that intentionally called `Agentao()` without `working_directory=` suppressed the warning with:
+
+```python
+import warnings
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    agent = Agentao(...)   # legacy lazy-cwd
+```
+
+In 0.3.0, the same call raises `TypeError`. Update those tests to either:
+
+- Pass `working_directory=tmp_path` (the standard fix — this is what `tests/test_per_session_cwd.py::_make_agent` does in the current test suite).
+- Assert the hard break with `pytest.raises(TypeError)` if the test is specifically verifying that the no-args form is rejected.
+
+### Local check
+
+```bash
+pytest -W error::DeprecationWarning tests/
+```
+
+This turns every `DeprecationWarning` into a test failure, surfacing any remaining call sites that still emit the 0.2.x warning before they silently break in 0.3.0.
+
 ---
 
 End of appendix.

--- a/developer-guide/en/part-6/4-multi-tenant-fs.md
+++ b/developer-guide/en/part-6/4-multi-tenant-fs.md
@@ -120,18 +120,34 @@ agent._memory_manager = MemoryManager(
 
 Even with `working_directory` isolated, `~/.agentao/memory.db` is **process-global** — two tenants' agents read/write the same user-level memory DB.
 
-**Solution A · Disable user-level**:
+**Solution A · Capability injection** (preferred for multi-tenant in-process):
 
 ```python
-agent._memory_manager = MemoryManager(
-    project_store=SQLiteMemoryStore.open_or_memory(
-        workdir / ".agentao" / "memory.db"
+from pathlib import Path
+from agentao import Agentao
+from agentao.memory import MemoryManager, SQLiteMemoryStore
+
+agent = Agentao(
+    working_directory=tenant_dir,
+    filesystem=YourTenantFS(),          # agentao.capabilities.FileSystem impl
+    memory_manager=MemoryManager(
+        project_store=SQLiteMemoryStore.open_or_memory(
+            tenant_dir / ".agentao" / "memory.db"
+        ),
+        # user_store=None disables the process-global ~/.agentao/memory.db
     ),
-    # user_store=None — no cross-project memory
 )
 ```
 
-**Solution B · Change HOME per tenant**:
+Constructor injection replaces private attribute mutation (`agent._memory_manager = …`) — inject once at construction, no shared mutable state between tenants.
+
+The `FileSystem` Protocol (`agentao.capabilities.FileSystem`) covers all file and search tool IO. Any compliant implementation works as a drop-in: a Docker-exec remote that delegates reads/writes into a container, an in-memory virtual filesystem for test isolation, or an audit proxy that logs every access before delegating to the real disk — without changing any tool code.
+
+**Solution B · One process per tenant** (strongest isolation, highest cost):
+
+Use ACP — each tenant gets its own Agentao subprocess. Cleanest isolation; most resource-intensive.
+
+**Solution C · Mutate HOME per tenant** (discouraged):
 
 ```python
 import os
@@ -139,11 +155,7 @@ os.environ["HOME"] = f"/data/tenant-{tenant.id}/home"
 agent = Agentao(working_directory=...)
 ```
 
-Affects the whole process's `Path.home()` — only works with **one tenant per process** (ACP subprocess model).
-
-**Solution C · One process per tenant**:
-
-Use ACP — each tenant gets its own Agentao subprocess. Cleanest isolation, highest cost.
+Affects the whole process's `Path.home()` — only works with one tenant per process (ACP subprocess model). **Do not use in multi-tenant in-process deployments.**
 
 ## Write boundaries
 
@@ -202,6 +214,20 @@ agent = Agentao(
 ```
 
 `agent.close()` disconnects MCP subprocesses on shutdown.
+
+If the host owns the MCP lifecycle entirely — managing server startup order, shared transport pools, or custom auth — pass a fully-built `McpClientManager` via `mcp_manager=` instead:
+
+```python
+from agentao.mcp import McpClientManager
+
+manager = McpClientManager(...)   # built and connected by the host
+agent = Agentao(
+    working_directory=workdir,
+    mcp_manager=manager,           # agent does not start/stop subprocesses
+)
+```
+
+`mcp_manager=` and `extra_mcp_servers=` are mutually exclusive; passing both raises `ValueError`.
 
 ## Warm state: logs & temp files
 

--- a/developer-guide/zh/appendix/e-migration.md
+++ b/developer-guide/zh/appendix/e-migration.md
@@ -156,6 +156,57 @@ Week 3 之前的裸字符串形式不再接受。`AcpClientConfig.from_dict` / `
 3. **把用户和项目记忆混用** —— 默认就是租户隔离（见 [6.4](/zh/part-6/4-multi-tenant-fs)）；user 作用域仅限单用户场景
 4. **不开确认** —— 其他框架常常默认"什么都问"。Agentao 让你白名单——请在审过工具的爆炸半径之后再白名单
 
+## E.9 从 0.2.x 迁移到 0.3.0
+
+`working_directory=` 现在是必填关键字参数。0.2.16 在省略该参数时发出的 `DeprecationWarning` 已被替换为构造时直接抛出的 `TypeError`——不再有 `Path.cwd()` 懒惰回退。
+
+### 方案一——传入显式 `Path`（最简单）
+
+```python
+from pathlib import Path
+from agentao import Agentao
+
+agent = Agentao(working_directory=Path("/srv/agent-workdir"), ...)
+```
+
+绝大多数调用点只需这一处修改。传入前先解析为绝对路径，冻结值才始终可预期。
+
+### 方案二——用 `build_from_environment()` 进行 CLI 式自动发现
+
+```python
+from pathlib import Path
+from agentao.embedding import build_from_environment
+
+agent = build_from_environment(working_directory=Path("/srv/agent-workdir"))
+```
+
+`build_from_environment` 会读取 `.env`、发现 `.agentao/` 配置文件，并连接完整的 CLI 等价默认值（用户级记忆、MCP 文件配置、沙箱、回放）。显式传入 `working_directory=`；若省略，工厂回退到 `Path.cwd()`——CLI 入口点可接受，嵌入式宿主不应依赖此行为。
+
+### 方案三——曾测试懒惰 cwd 默认行为的测试
+
+在 0.2.x 中，有意不传 `working_directory=` 的测试会用以下方式压制警告：
+
+```python
+import warnings
+
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore", DeprecationWarning)
+    agent = Agentao(...)   # 懒惰 cwd 行为
+```
+
+在 0.3.0 中，相同的调用会抛 `TypeError`。将这些测试改为：
+
+- 传入 `working_directory=tmp_path`（标准修法——当前测试套件的 `tests/test_per_session_cwd.py::_make_agent` 即采用此方式）。
+- 若测试本身就是为了验证无参形式被拒绝，改用 `pytest.raises(TypeError)` 断言硬中断。
+
+### 本地检查命令
+
+```bash
+pytest -W error::DeprecationWarning tests/
+```
+
+此命令将所有 `DeprecationWarning` 转为测试失败，在 0.3.0 静默破坏之前暴露仍在发出 0.2.x 警告的调用点。
+
 ---
 
 附录至此结束。

--- a/developer-guide/zh/part-6/4-multi-tenant-fs.md
+++ b/developer-guide/zh/part-6/4-multi-tenant-fs.md
@@ -121,18 +121,34 @@ agent._memory_manager = MemoryManager(
 
 即便 `working_directory` 隔离好了，`~/.agentao/memory.db` 是**进程级共享**的——两个租户的 Agent 会读写同一个用户级记忆库。
 
-**解决方案 A · 禁用用户级**：
+**解决方案 A · 能力注入**（多租户进程内首选）：
 
 ```python
-agent._memory_manager = MemoryManager(
-    project_store=SQLiteMemoryStore.open_or_memory(
-        workdir / ".agentao" / "memory.db"
+from pathlib import Path
+from agentao import Agentao
+from agentao.memory import MemoryManager, SQLiteMemoryStore
+
+agent = Agentao(
+    working_directory=tenant_dir,
+    filesystem=YourTenantFS(),          # agentao.capabilities.FileSystem 实现
+    memory_manager=MemoryManager(
+        project_store=SQLiteMemoryStore.open_or_memory(
+            tenant_dir / ".agentao" / "memory.db"
+        ),
+        # user_store=None 禁用进程级共享的 ~/.agentao/memory.db
     ),
-    # user_store=None — 完全不用用户级
 )
 ```
 
-**解决方案 B · 按租户改 HOME**：
+构造器注入取代私有属性变更（`agent._memory_manager = …`）——在构造时一次性注入，租户之间无共享可变状态。
+
+`FileSystem` 协议（`agentao.capabilities.FileSystem`）涵盖所有文件和搜索工具的 IO。任何符合协议的实现都可以直接替换：把读写委托给容器的 Docker-exec 后端、用于测试隔离的内存虚拟文件系统、或在委托给真实磁盘前记录每次访问的审计代理——无需修改任何工具代码。
+
+**解决方案 B · 每租户独立进程**（隔离最强，成本最高）：
+
+用 ACP 模式，每租户起一个 Agentao 子进程。进程级隔离最干净，资源开销最大。
+
+**解决方案 C · 按租户改 HOME**（不推荐）：
 
 ```python
 import os
@@ -140,11 +156,7 @@ os.environ["HOME"] = f"/data/tenant-{tenant.id}/home"
 agent = Agentao(working_directory=...)
 ```
 
-影响整个进程的 `Path.home()`——只在**每进程一租户**时适用（ACP 子进程模型）。
-
-**解决方案 C · 每租户独立进程**：
-
-用 ACP 模式，每租户起一个 Agentao 子进程。进程级隔离最干净，但成本最高。
+影响整个进程的 `Path.home()`——只在每进程一租户时适用（ACP 子进程模型）。**多租户进程内部署中切勿使用。**
 
 ## 文件系统写入边界
 
@@ -201,6 +213,20 @@ agent = Agentao(
 ```
 
 Agent 关闭时 `agent.close()` 会自动 disconnect MCP 子进程。
+
+如果宿主需要完全掌控 MCP 生命周期——管理服务器启动顺序、共享传输连接池或自定义认证——可以通过 `mcp_manager=` 注入一个已构建好的 `McpClientManager`，而非使用 `extra_mcp_servers=` 的字典合并模式：
+
+```python
+from agentao.mcp import McpClientManager
+
+manager = McpClientManager(...)   # 由宿主构建并连接
+agent = Agentao(
+    working_directory=workdir,
+    mcp_manager=manager,           # agent 不启动/停止子进程
+)
+```
+
+`mcp_manager=` 与 `extra_mcp_servers=` 互斥，同时传入会抛 `ValueError`。
 
 ## 温度数据：日志与临时文件
 


### PR DESCRIPTION
Follow-up documentation for the embedded-harness epic (issues #9, #10, #11, #12, #13).

## Changes

- **`en/part-6/4-multi-tenant-fs.md`** — Rewrites the "user-level memory trap" solutions section. "Capability injection" (`Agentao(filesystem=..., memory_manager=..., ...)`) is now Solution A (preferred in-process pattern), with a paragraph explaining the `agentao.capabilities.FileSystem` Protocol and its Docker-exec / virtual-FS / audit-proxy backends. ACP (one-process-per-tenant) is promoted to Solution B with "strongest isolation, highest cost" framing. `HOME=` mutation is demoted to Solution C with a "discouraged" warning. Adds a `mcp_manager=` injection note to the MCP cross-tenant section alongside the existing `extra_mcp_servers=` pattern.

- **`zh/part-6/4-multi-tenant-fs.md`** — ZH mirror of the above.

- **`en/appendix/e-migration.md`** — Appends new section "E.9 Migrating from 0.2.x to 0.3.0" covering the `working_directory=` DeprecationWarning → TypeError change, three migration recipes (explicit `Path`, `build_from_environment()`, test-suite updates), and the `pytest -W error::DeprecationWarning` local check.

- **`zh/appendix/e-migration.md`** — ZH mirror of the above.

## Notes for reviewer

- The task brief described `tests/test_per_session_cwd.py::_make_agent` as using `warnings.catch_warnings()` + `warnings.simplefilter('ignore', DeprecationWarning)`. The current code does not — `_make_agent` simply passes `working_directory=working_directory` since the 0.3.0 hard break is already in place. The migration recipe in E.9 cites `_make_agent` as the template for the updated pattern (pass the arg explicitly), which matches the actual file. If the intended citation was to a now-deleted pre-0.3.0 version of that function, a reviewer should clarify so the recipe text can be adjusted.

- The task brief used `MemoryManager(project_root=..., global_root=None)` in the example snippet. The actual constructor signature is `MemoryManager(project_store=SQLiteMemoryStore.open_or_memory(...), user_store=None)`. The correct API is used in the documentation.

---
_Generated by [Claude Code](https://claude.ai/code/session_015nvAMze3nRqidyuQEkKgf4)_