### PR TITLE
docs(guide): refresh kanban blueprint source paths for package splits

### DIFF
--- a/developer-guide/en/part-7/7-kanban-multiagent.md
+++ b/developer-guide/en/part-7/7-kanban-multiagent.md
@@ -71,17 +71,17 @@ Rather than mirror code that will drift, here's the reading order that maps each
 | Read this in the kanban repo | What agentao surface it exercises | Reference here |
 |---|---|---|
 | `kanban/agents.py` + `kanban/defaults/*.md` | Sub-agent definition format (Markdown + YAML frontmatter) | [§3.1 Plugin model](/en/part-3/), [§6.x sub-agents](/en/part-6/) |
-| `kanban/orchestrator.py` | Single-writer state machine over agent results | [§4.7 Host contract](/en/part-4/7-host-contract) |
+| `kanban/orchestrator/` | Single-writer state machine over agent results | [§4.7 Host contract](/en/part-4/7-host-contract) |
 | `kanban/executors/multi_backend.py` + `agent_profiles.yaml` | Per-role routing between in-process sub-agent and external ACP CLI | [§3.3 Host-client architecture](/en/part-3/3-host-client-architecture), [§3.2 Agentao as ACP server](/en/part-3/2-agentao-as-server) |
-| `kanban/daemon.py` + `runtime/claims/*.json` | Multi-worker concurrency over a single board (O_EXCL CAS lease) | [§6.7 Resource & concurrency](/en/part-6/7-resource-concurrency) |
+| `kanban/daemon/` + `runtime/claims/*.json` | Multi-worker concurrency over a single board (O_EXCL CAS lease) | [§6.7 Resource & concurrency](/en/part-6/7-resource-concurrency) |
 | `workspace/worktrees/<card>/` machinery | Per-task sandbox isolation in a real codebase | [§6.x sandboxing](/en/part-6/) |
-| `kanban/mcp.py` (`kanban-mcp`) | Exposing the board as MCP tools to Claude Code / Codex | [§5 MCP](/en/part-5/) |
+| `kanban/mcp/` (`kanban-mcp`) | Exposing the board as MCP tools to Claude Code / Codex | [§5 MCP](/en/part-5/) |
 | `workspace/raw/<card>/<role>-<ts>.md` | Transcript + structured event capture for post-hoc audit | [§6 observability](/en/part-6/6-observability) |
 
 ## Minimal mental model (the 30-second version)
 
 ```python
-# pseudo-code — the actual code is in kanban/orchestrator.py
+# pseudo-code — the actual code is in kanban/orchestrator/
 while True:
     card = board.next_ready()              # uses WIP, deps, priority
     if not card:

--- a/developer-guide/zh/part-7/7-kanban-multiagent.md
+++ b/developer-guide/zh/part-7/7-kanban-multiagent.md
@@ -71,17 +71,17 @@
 | 在 kanban 仓库里读 | 用到的 agentao 接口 | 本指南对应章节 |
 |---|---|---|
 | `kanban/agents.py` + `kanban/defaults/*.md` | Sub-agent 定义格式（Markdown + YAML frontmatter） | [§3.1 插件模型](/zh/part-3/)、[§6.x sub-agent](/zh/part-6/) |
-| `kanban/orchestrator.py` | 基于 agent result 的单写者状态机 | [§4.7 宿主合约](/zh/part-4/7-host-contract) |
+| `kanban/orchestrator/` | 基于 agent result 的单写者状态机 | [§4.7 宿主合约](/zh/part-4/7-host-contract) |
 | `kanban/executors/multi_backend.py` + `agent_profiles.yaml` | 角色路由：进程内 sub-agent vs. 外部 ACP CLI | [§3.3 Host-client 架构](/zh/part-3/3-host-client-architecture)、[§3.2 Agentao 作为 ACP server](/zh/part-3/2-agentao-as-server) |
-| `kanban/daemon.py` + `runtime/claims/*.json` | 同一块板上的多 worker 并发（O_EXCL CAS 租约） | [§6.7 资源与并发](/zh/part-6/7-resource-concurrency) |
+| `kanban/daemon/` + `runtime/claims/*.json` | 同一块板上的多 worker 并发（O_EXCL CAS 租约） | [§6.7 资源与并发](/zh/part-6/7-resource-concurrency) |
 | `workspace/worktrees/<card>/` 机制 | 真实代码库里的"每任务沙箱" | [§6.x 沙箱](/zh/part-6/) |
-| `kanban/mcp.py`（`kanban-mcp`） | 把看板暴露为 Claude Code / Codex 的 MCP 工具 | [§5 MCP](/zh/part-5/) |
+| `kanban/mcp/`（`kanban-mcp`） | 把看板暴露为 Claude Code / Codex 的 MCP 工具 | [§5 MCP](/zh/part-5/) |
 | `workspace/raw/<card>/<role>-<ts>.md` | 事后审计用的 transcript + 结构化事件 | [§6 可观测性](/zh/part-6/6-observability) |
 
 ## 30 秒心智模型
 
 ```python
-# 伪代码 —— 真实代码在 kanban/orchestrator.py
+# 伪代码 —— 真实代码在 kanban/orchestrator/
 while True:
     card = board.next_ready()              # 看 WIP、依赖、优先级
     if not card:


### PR DESCRIPTION
`orchestrator` / `daemon` / `mcp` are now packages in `agentao-kanban`, not single modules. Updates the "study in order" table and the 30-second-model pseudocode comment in both `en` and `zh` `part-7/7-kanban-multiagent.md`.

Rest of the chapter was reviewed against the current kanban repo and is still accurate — the remaining churn there (web-UI features, module→package refactors) is the "operational scaffolding" the chapter intentionally doesn't mirror.

🤖 Generated with [Claude Code](https://claude.com/claude-code)