### PR TITLE
docs: kanban-tasks skill gallery entry + test_per_session_cwd docstring refresh

### DIFF
--- a/examples/skills/README.md
+++ b/examples/skills/README.md
@@ -17,6 +17,7 @@ A skill is just a directory with a `SKILL.md` (YAML frontmatter + instructions) 
 | [`zootopia-ppt/`](./zootopia-ppt/) | Turn a presentation script into a PPT-ready image set in **anthropomorphic-animal 3D-animation** style. Three steps: outline → per-slide image prompts → batched image generation via `scripts/image_gen_ppt*.py`. | "make this deck in Zootopia / 3D-animation style" | `TENSORLAB_API_KEY` (default backend) — or `GEMINI_API_KEY` / `QWEN_API_KEY` / OpenRouter key for the alt backends |
 | [`pro-ppt/`](./pro-ppt/) | Same pipeline, **editorial-premium business** style (light-grey base + gold accents + deep navy, McKinsey/Apple-Keynote vibe). **Reuses** `zootopia-ppt/scripts/image_gen_ppt.py`, so install both together. | "make this deck in a premium / consulting / editorial style" | Same as `zootopia-ppt` |
 | [`ocr/`](./ocr/) | One-shot OCR on an image file via Qwen-VL (`scripts/ocr.py`). | "OCR this screenshot / extract text from this image" | `QWEN_API_KEY` + `QWEN_BASE_URL` in `.env` |
+| [`kanban-tasks/`](./kanban-tasks/) | Drive an `agentao-kanban` board: break a request into atomic cards, push them through `INBOX → READY → DOING → REVIEW → DONE`, start/stop the daemon + Web UI, locate artifacts. Compound triggers like "启动 kanban" / "停止 kanban" map to one-shot scripts. | "看板 / kanban / 拆任务 / task board / dispatcher / 启动 kanban …" | `agentao-kanban` installed in the project venv (`uv run kanban …`); a writable cwd for `.kanban/` + `workspace/board/` |
 
 ## Install
 

--- a/examples/skills/README.zh.md
+++ b/examples/skills/README.zh.md
@@ -17,6 +17,7 @@
 | [`zootopia-ppt/`](./zootopia-ppt/) | 把演讲稿转成「**拟人化动物 · 3D 动画电影**」风格的整套 PPT 配图。三步走：理解讲稿 → 逐页生成图像提示词 → 调用 `scripts/image_gen_ppt*.py` 批量出图。 | "用疯狂动物城 / 3D 动画电影风格做这份演示" | `TENSORLAB_API_KEY`（默认后端）；或 `GEMINI_API_KEY` / `QWEN_API_KEY` / OpenRouter key 走备选后端 |
 | [`pro-ppt/`](./pro-ppt/) | 同一套流程的「**高端商务编辑**」风变体（极浅灰主色 + 金色点缀 + 深蓝灰背景，麦肯锡 / Apple Keynote 调性）。**复用** `zootopia-ppt/scripts/image_gen_ppt.py`，请一起安装。 | "做一份高级感 / 咨询风 / 编辑风的 PPT" | 同 `zootopia-ppt` |
 | [`ocr/`](./ocr/) | 用 Qwen-VL 做一次性图片 OCR（`scripts/ocr.py`）。 | "把这张截图里的文字提出来 / OCR 这张图" | `.env` 里配 `QWEN_API_KEY` + `QWEN_BASE_URL` |
+| [`kanban-tasks/`](./kanban-tasks/) | 驱动 `agentao-kanban` 看板：把需求拆成原子卡片，推它们走 `INBOX → READY → DOING → REVIEW → DONE`，启停 daemon + Web UI，定位产物。"启动 kanban" / "停止 kanban" 等复合短语对应一键脚本。 | "看板 / kanban / 拆任务 / task board / dispatcher / 启动 kanban …" | 项目 venv 里装好 `agentao-kanban`（统一走 `uv run kanban …`）；cwd 可写以便落 `.kanban/` 和 `workspace/board/` |
 
 ## 安装
 

--- a/examples/skills/kanban-tasks/SKILL.md
+++ b/examples/skills/kanban-tasks/SKILL.md
@@ -1,0 +1,514 @@
+---
+name: kanban-tasks
+description: >
+  使用 agentao-kanban 看板进行任务管理（拆任务 / 状态流转 / 后台服务 / 看产物）。
+  本技能负责：① 初始化 .kanban/ 项目 ② 把需求拆成原子卡片入板
+  ③ 推动状态流转 INBOX → READY → DOING → REVIEW → DONE
+  ④ 启停 daemon 与 Web UI ⑤ 察看卡片状态与产物。
+  触发关键词（中/英）：看板 / kanban / 任务管理 / task board / 拆任务 / 任务卡 / 排期 / WIP /
+  dispatcher / orchestrator。
+  复合触发短语（一键启停）：
+    • "启动 kanban"      → daemon（mock 执行器，后台）+ Web UI（自动开浏览器）
+    • "启动 kanban 真跑" → daemon（--executor agentao，真调 sub-agent）+ Web UI
+    • "停止 kanban"      → 先停 Web UI，再停 daemon
+---
+
+# Kanban 任务管理 · 操作指南
+
+底层是本仓库虚拟环境中以 editable 模式安装的 `agentao-kanban`（console scripts: `kanban`, `kanban-mcp`）。
+所有命令必须用 `uv run kanban …`，不要直接 `python -m kanban`，也不要 `pip install`。
+
+## 心智模型（先看这里再动手）
+
+- **状态机**：卡片在 `INBOX → READY → DOING → REVIEW → DONE` 中流转，外加旁路状态 `BLOCKED`。
+  唯一合法的状态写入者是 orchestrator；CLI 的 `move` 是给人/Claude 用的运营手段。
+- **板的位置**：`kanban init` 会在当前目录创建 `.kanban/`（项目根标记）和 `workspace/board/`（卡片
+  与事件文件）。从该目录或任意子目录运行 `kanban …` 都能自动找回这块板，**不要带 `--board`**。
+- **执行器**：默认 `mock`（离线状态机，CI 安全），加 `--executor agentao` 才会真正调用四个角色
+  sub-agent。除非用户明确要求"真跑"，**默认保持 mock**。
+- **写锁**：所有写命令尊重 `.daemon.lock`。daemon 跑着的时候不要再用 `--force` 写卡（仅应急）。
+- **工作区铁律**：板一旦由 `kanban init` 落到 `workspace/board/`，就不要把卡片相关材料散落到仓库根；
+  生成的笔记/数据按 `AGENTAO.md §Workspace` 入 `workspace/docs/`、`workspace/data/` 等。
+
+## 前置自检（开工前一次）
+
+```bash
+uv run kanban --help >/dev/null    # 确认 CLI 可用
+uv run kanban doctor               # 板 + 环境体检（无板时会提示先 init）
+```
+
+如果 `doctor` 报 stale lock / 缺失目录，运行 `uv run kanban doctor --fix`。
+
+## 工作流
+
+### Step 1 — 把用户的需求拆成原子卡片
+
+在动 CLI 之前，**先在对话中用一个简短表格列出你打算建的卡**，让用户确认或调整：
+
+| # | title | goal | priority | depends_on | acceptance(关键 1-3 条) |
+|---|---|---|---|---|---|
+
+拆卡原则（按本项目 `AGENTAO.md` 的 Code Review 思路：Survey → Classify → Prescribe → Verify）：
+
+1. **原子性**：一张卡 = 一个可独立完成、可独立验证的产出。"重构 X 模块"不是卡，"把 X.foo 拆成两个
+   纯函数并迁移调用点"才是卡。
+2. **依赖显式化**：只有真依赖（B 必须等 A 的产出）才用 `--depends`。同主题不等于依赖。
+3. **acceptance 是验收凭据**：每张卡至少 1 条 `acceptance`，写成可被人/CI 直接判定通过/失败的语句
+   （"`uv run pytest tests/foo` 全绿"、"`workspace/reports/x.md` 存在且包含章节 …"）。
+4. **优先级保守用**：默认 `MEDIUM`。`CRITICAL` 仅留给阻断其他卡或线上故障类。
+
+### Step 2 — 初始化（仅当 `.kanban/` 不存在）
+
+```bash
+uv run kanban init                 # 干净起步：建 .kanban/ + workspace/board/
+# 或带示例卡先看效果：
+uv run kanban init --demo
+```
+
+如果用户说"先看看 kanban 怎么跑"，跑：
+
+```bash
+uv run kanban init --demo
+uv run kanban demo                 # 把 4 张示例卡推到 DONE
+uv run kanban list
+```
+
+### Step 3 — 建卡
+
+每张卡用一条命令；`--acceptance` 与 `--depends` 可重复：
+
+```bash
+uv run kanban card add \
+  --title "把 ingest.py 拆成 reader/parser 两个纯函数" \
+  --goal  "降低 ingest.py 圈复杂度并允许独立单测" \
+  --priority MEDIUM \
+  --acceptance "uv run pytest tests/ingest 全绿" \
+  --acceptance "ingest.py 中无对全局状态的读写"
+```
+
+记下输出里的 `card_id`。后续 `--depends <card_id>` 即指向它。
+
+补充上下文 / 验收（可选，但建卡时建议立即补全；注意 `--path` 是命名参数，不是位置参数）：
+
+```bash
+# context（可重复加；--kind 默认 required）
+uv run kanban card context add  <card_id> --path path/to/ref.py:42-88 \
+    [--kind required|optional] [--note "..."]
+uv run kanban card context list <card_id>
+uv run kanban card context rm   <card_id> --path path/to/ref.py:42-88
+
+# acceptance（add 追加 / edit 进 $EDITOR / rm 按 1-based 索引 / clear 清空）
+uv run kanban card acceptance add   <card_id> --item "uv run pytest tests/foo 全绿"
+uv run kanban card acceptance edit  <card_id>
+uv run kanban card acceptance list  <card_id>
+uv run kanban card acceptance rm    <card_id> 2
+```
+
+### Step 4 — 入队与跟进
+
+```bash
+uv run kanban list                 # 看全板（按状态分组）
+uv run kanban show <card_id>       # 看单卡（含 context_refs / acceptance）
+uv run kanban move <card_id> ready # 入待办
+uv run kanban events <card_id>     # 看这张卡的事件流
+```
+
+被卡住时显式记录原因，不要直接放着不动（`reason` 是**位置参数**，不是 `--reason`；
+`requeue` / `unblock` 的 `--to` 默认 `inbox`）：
+
+```bash
+uv run kanban block   <card_id> "等用户确认 schema"
+uv run kanban unblock <card_id> [--to ready]    # 默认回 inbox
+uv run kanban requeue <card_id> [--to ready] [--note "失败现场已修"]
+```
+
+### Step 5 — 推动执行（默认离线安全）
+
+两种节奏，按需选一种：
+
+```bash
+# A) 一步一步走，便于讲解：
+uv run kanban tick
+
+# B) 一直跑到 idle（全部进 DONE 或全部 BLOCKED 时停）：
+uv run kanban run
+```
+
+需要常驻 dispatcher（多卡并行 / 真 sub-agent）或浏览器看板时，见
+**「后台服务（daemon & web UI）」**一节。
+
+**只有用户明确要"真跑"时才加 `--executor agentao`**，例如：
+`uv run kanban --executor agentao run`。否则一律保持默认 mock。
+
+### Step 6 — 复盘
+
+执行结束后按 **「察看卡片状态 / 产物」** 一节系统回看：先 `kanban events <id>` 看事件流，
+再 `kanban traces <id> --latest` 看 agent 原始响应，必要时启动 Web UI（见
+**「后台服务（daemon & web UI）」**）做可视化浏览。
+
+> ⚠️ `kanban traces` 必须带 `<card_id>`（位置参数）；没有"列全部 trace"的子命令。
+> 要全板复盘，遍历各卡或直接看 `<board>/traces/`。
+
+把可分享的复盘写到 `workspace/reports/`，把临时数据放 `workspace/data/`。
+
+## 后台服务（daemon & web UI）
+
+两个常驻进程，**职责互不重叠**：
+
+| 服务 | 进程职责 | 是否写板 | 默认端口 |
+|---|---|---|---|
+| `kanban daemon` | 调度 + 执行卡片，按 `.daemon.lock` 串行写板 | 是 | — |
+| `kanban web` | 读板渲染浏览器看板 | 否（除非加 `--enable-writes`） | 8000 |
+
+约定（让启停脚本是幂等的）：
+
+- PID / 日志统一放在 board 目录下：
+  - daemon → 由 CLI 自己管理 `<board>/.daemon.lock` 与 `<board>/daemon.log`。
+  - web → 我们手动管 `<board>/.web.pid` 与 `<board>/web.log`。
+- 默认 board 路径 `workspace/board/`；若用户在其他目录 `kanban init`，把下方命令里的
+  `workspace/board` 替换为实际 `<board>`，或先 `cd` 到 `.kanban/` 所在目录再执行。
+
+### 一键启停（"启动 kanban" / "启动 kanban 真跑" / "停止 kanban"）
+
+复合触发短语，**优先于**单独启停 daemon / web UI 的子节：
+
+| 用户说 | 动作（按顺序） |
+|---|---|
+| **"启动 kanban"** | ① `daemon --detach`（默认 mock 执行器） ② Web UI 后台启动 + 探活 + 自动开浏览器 |
+| **"启动 kanban 真跑"** | ① `--executor agentao daemon --detach`（**真调** sub-agent） ② Web UI 同上 |
+| **"停止 kanban"** | ① 停 Web UI（避免它再轮询已经撤掉的板） ② `daemon stop` |
+
+启停脚本（`BOARD/PORT/URL` 共用，三段是同一组变量）：
+
+```bash
+BOARD=workspace/board
+PORT=8000
+URL="http://127.0.0.1:${PORT}/"
+```
+
+**▶ 启动 kanban（mock 执行器）**
+
+```bash
+# 1) Daemon — 后台 fork
+uv run kanban daemon --detach
+
+# 2) Web UI — 后台启动，幂等，端口就绪后自动开浏览器
+if [ -f "$BOARD/.web.pid" ] && kill -0 "$(cat "$BOARD/.web.pid")" 2>/dev/null; then
+  echo "web already running (pid $(cat "$BOARD/.web.pid"))"
+else
+  nohup uv run kanban web --host 127.0.0.1 --port "$PORT" \
+    > "$BOARD/web.log" 2>&1 &
+  echo $! > "$BOARD/.web.pid"
+fi
+for _ in $(seq 1 30); do
+  curl -fsS "$URL" >/dev/null 2>&1 && break
+  sleep 0.5
+done
+open "$URL"   # macOS;Linux 用 xdg-open;WSL 用 wslview
+
+# 3) 验证
+uv run kanban daemon status
+uv run kanban list
+```
+
+**▶ 启动 kanban 真跑**（与上完全一致，**只把第 1) 步换掉**；要先和用户确认）
+
+```bash
+# 1) Daemon — 真调四个角色 sub-agent
+uv run kanban --executor agentao daemon --detach
+# 2)、3) 同 "启动 kanban"
+```
+
+> 触发"真跑"前的检查清单：
+> - 用户**已明确**要真跑（不要从"启动 kanban"擅自升级到 `--executor agentao`）；
+> - 板里有 `READY`/`INBOX` 的卡，且 acceptance / context 写齐；
+> - 知晓真跑会消耗 LLM 配额、会真改 worktree 内文件。
+
+**▶ 停止 kanban**
+
+```bash
+# 1) 先停 Web UI（幂等）
+if [ -f "$BOARD/.web.pid" ]; then
+  PID=$(cat "$BOARD/.web.pid")
+  kill "$PID" 2>/dev/null && \
+    for _ in $(seq 1 10); do kill -0 "$PID" 2>/dev/null || break; sleep 0.2; done
+  kill -0 "$PID" 2>/dev/null && kill -9 "$PID" 2>/dev/null
+  rm -f "$BOARD/.web.pid"
+  echo "web: stopped"
+else
+  echo "web: not running"
+fi
+
+# 2) 再停 daemon
+uv run kanban daemon stop || echo "daemon: not running"
+```
+
+> 注意：执行器（mock vs `agentao`）由**启动 daemon 时**决定，重启 daemon 才能切换。
+> 想从 mock 切到真跑，必须 "停止 kanban" → "启动 kanban 真跑"。
+
+### Daemon · 启 / 停 / 体检
+
+```bash
+# 后台启动（fork 出去；CLI 自带 --detach）
+uv run kanban daemon --detach
+
+# 状态：running / stale / stopped
+uv run kanban daemon status
+
+# 跟踪日志
+uv run kanban daemon logs -f
+
+# 优雅停止（SIGTERM 给 .daemon.lock 里记录的 pid）
+uv run kanban daemon stop
+
+# 极少数情况下 daemon 已死但 lock 残留：
+uv run kanban doctor --fix
+```
+
+并发 / 多 worker / 真 sub-agent 等高级用法（按需加，**默认不加**）：
+
+```bash
+# 多 worker（一个 scheduler + 多个 worker）
+uv run kanban daemon --detach --role scheduler --max-claims 4
+uv run kanban daemon --detach --role worker --worker-id w1
+uv run kanban daemon --detach --role worker --worker-id w2
+
+# 真跑（调用四个角色 sub-agent，需用户明确同意）
+uv run kanban --executor agentao daemon --detach
+```
+
+### Web UI · 启 / 停（启动后自动打开浏览器）
+
+`kanban web` 自身没有 `--detach`，所以由我们用 `nohup` 后台化并自管 PID。
+启动后用 `curl` 探活，端口起来后再 `open` 浏览器，保证用户落地不是空白页。
+
+**启动（推荐：默认只读、loopback、自动开浏览器）：**
+
+```bash
+BOARD=workspace/board
+PORT=8000
+URL="http://127.0.0.1:${PORT}/"
+
+# 已经在跑就直接开浏览器，避免端口冲突
+if [ -f "$BOARD/.web.pid" ] && kill -0 "$(cat "$BOARD/.web.pid")" 2>/dev/null; then
+  echo "web already running (pid $(cat "$BOARD/.web.pid"))"
+else
+  nohup uv run kanban web --host 127.0.0.1 --port "$PORT" \
+    > "$BOARD/web.log" 2>&1 &
+  echo $! > "$BOARD/.web.pid"
+fi
+
+# 等端口就绪（最多 ~15s），就绪后开浏览器
+for _ in $(seq 1 30); do
+  curl -fsS "$URL" >/dev/null 2>&1 && break
+  sleep 0.5
+done
+open "$URL"   # macOS;Linux 用 xdg-open;WSL 用 wslview
+```
+
+**状态：**
+
+```bash
+BOARD=workspace/board
+if [ -f "$BOARD/.web.pid" ] && kill -0 "$(cat "$BOARD/.web.pid")" 2>/dev/null; then
+  echo "web: running pid=$(cat "$BOARD/.web.pid")  log=$BOARD/web.log"
+else
+  echo "web: not running"
+  [ -f "$BOARD/.web.pid" ] && rm "$BOARD/.web.pid"   # 清掉残留 pid
+fi
+```
+
+**停止（幂等）：**
+
+```bash
+BOARD=workspace/board
+if [ -f "$BOARD/.web.pid" ]; then
+  PID=$(cat "$BOARD/.web.pid")
+  kill "$PID" 2>/dev/null && \
+    for _ in $(seq 1 10); do kill -0 "$PID" 2>/dev/null || break; sleep 0.2; done
+  kill -0 "$PID" 2>/dev/null && kill -9 "$PID" 2>/dev/null   # 兜底强杀
+  rm -f "$BOARD/.web.pid"
+  echo "web: stopped"
+else
+  echo "web: not running"
+fi
+```
+
+**写入模式（仅在用户明确要"用浏览器建卡"时再开）：**
+
+```bash
+# 只在 loopback 上开放 POST /api/cards
+nohup uv run kanban web --host 127.0.0.1 --port 8000 --enable-writes \
+  > workspace/board/web.log 2>&1 &
+echo $! > workspace/board/.web.pid
+```
+
+绑非 loopback（远端访问）时还要加 `--allow-remote-writes`，且**必须**和用户确认后再做——
+那等于把板的写入面暴露到网络上。
+
+### 常见坑（后台服务专属）
+
+- **端口被占**：`lsof -nP -iTCP:8000 -sTCP:LISTEN`。换端口（`--port 8765`）或杀掉占用进程。
+- **`web` 起来但浏览器空白**：通常是探活早于路由就绪。把 `seq 1 30` 调到 `seq 1 60`，或先
+  `tail workspace/board/web.log` 看启动日志。
+- **`.web.pid` 指向已死进程**：`status` 块里的 `kill -0` 检查会发现并清理；如果你跳过了脚本，
+  手动 `rm workspace/board/.web.pid`。
+- **daemon 写不动板**：先 `kanban daemon status`；若 `stale` 用 `kanban doctor --fix`；如果只是
+  本地误锁，`kanban --force …` 仅作应急。
+- **同时跑 daemon + web**：完全 OK，两者职责不冲突；web 默认只读，daemon 才写。
+
+## 察看卡片状态 / 产物
+
+把"卡现在什么状态"和"卡到底产出了什么"分开看。两类问题对应不同的入口。
+
+### A. 状态视图
+
+| 想看什么 | 命令 | 备注 |
+|---|---|---|
+| 全板按状态分组 | `uv run kanban list` | 无 `--json` |
+| 单卡详情（goal / priority / depends / context_refs / acceptance / status） | `uv run kanban show <id>` | 加 `--json` 喂下游 |
+| 结构化事件流（含状态迁移、claim、artifact 快照） | `uv run kanban events <id>` | `--role planner\|worker\|reviewer\|verifier` 过滤；`--limit N`；`--json` |
+| 活跃执行 claim（v0.1.2 并发） | `uv run kanban claims [<id>]` | `--json` |
+| 在线 worker（多 worker 模式） | `uv run kanban workers` | — |
+| 看 acceptance / context 是否齐全 | `uv run kanban card acceptance list <id>` / `card context list <id>` | — |
+
+最常用的三连：
+
+```bash
+uv run kanban show   <id>                 # 这张卡是什么、配置齐了吗
+uv run kanban events <id> --limit 20      # 最近发生了什么
+uv run kanban claims <id>                 # 现在谁在跑（如有）
+```
+
+### B. 产物视图（"这张卡到底产出了什么"）
+
+产物分布在 **4 个位置**，按卡的当前状态决定先去哪里看：
+
+| 卡的状态 | 产物在哪 | 怎么看 |
+|---|---|---|
+| **DOING**（worktree 在线） | `workspace/worktrees/<card-id>/`（分支 `kanban/<card-id>`） | `uv run kanban worktree list`<br>`uv run kanban worktree diff <id>` |
+| **DONE / BLOCKED**（worktree 已 detach） | `workspace/raw/<card-id>/artifacts-<ts>/` | `ls -dt workspace/raw/<id>/artifacts-*/ \| head -1` |
+| 任意状态：agent 原始响应 | `<board>/traces/...` | `uv run kanban traces <id> [--latest] [--role …]` |
+| 任意状态：结构化事件 | `<board>/events.log` | `uv run kanban events <id>` |
+
+工作流要点（来自 `kanban-cli-guide.md §9.4`）：
+
+- 产物**先**落到 live worktree；卡进入 `DONE` / `BLOCKED` 时 `WorktreeManager.detach()` 会把
+  `gitignored` 路径下的产出抢救到 `workspace/raw/<card-id>/artifacts-<ts>/`，并写一条
+  `worktree.artifacts_saved` 事件（含快照路径），`events`/Web UI 都能看到。
+- 默认每卡保留最近 **5 份快照、上限 500 MiB**；环境变量 `KANBAN_ARTIFACTS_MAX_BYTES` 可调。
+- 如果 worker 自报"已写文件"但卡完成后找不到，**第一站**永远是 `workspace/raw/<id>/artifacts-*/`。
+
+### C. 三个最常被问的问题（一行流）
+
+```bash
+# "这张卡现在做到哪了？"
+uv run kanban show <id> && uv run kanban events <id> --limit 20
+
+# "worker 改了哪些文件？"
+#   DOING：
+uv run kanban worktree diff <id>
+#   DONE/BLOCKED（找最新一份 artifact 快照并展开看）：
+SNAP=$(ls -dt workspace/raw/<id>/artifacts-*/ 2>/dev/null | head -1) && \
+  echo "$SNAP" && find "$SNAP" -maxdepth 3 -type f | head -50
+
+# "agent 的原始输出是什么？"
+uv run kanban traces <id> --latest
+uv run kanban traces <id> --role worker     # 只看 worker 角色的全部 transcript
+```
+
+### D. 盘点 / 脚本化（多卡批量查看）
+
+```bash
+# 当前所有活跃 worktree（隐含：哪些卡在 DOING）
+uv run kanban worktree list
+
+# 某卡最近一份 artifact 快照路径
+ls -dt workspace/raw/<id>/artifacts-*/ 2>/dev/null | head -1
+
+# JSON 输出（喂下游脚本 / 喂 LLM 总结）
+uv run kanban show   <id> --json
+uv run kanban events <id> --json --limit 100
+uv run kanban claims --json
+
+# 全板事件复盘（最近 N 条；不带 card_id 即全板）
+uv run kanban events --limit 200
+```
+
+> 注意：`kanban list` 目前**没有** `--json`；要程序化全板视图，遍历 `show --json` 或解析 `workspace/board/`
+> 下的 Markdown frontmatter。
+
+## 常见坑
+
+- **"empty board"**：通常是 `.kanban/` 不存在且当前目录没有 `workspace/board/`。先 `kanban init`。
+- **写命令报锁**：daemon 在跑。要么停 daemon (`daemon stop`)，要么真的应急再加 `--force`。
+- **状态卡死在 BLOCKED**：用 `kanban events <id>` 找到原因，修后 `kanban unblock` 或 `requeue`。
+- **多个卡片同主题**：考虑合并而非加 `--depends`；依赖只表达"必须先完成"，不表达"相关"。
+- **改了 acceptance 之后**：用 `kanban card acceptance edit`，不要手改 `workspace/board/` 里的
+  Markdown frontmatter（除非你确定 daemon 停了且板状态干净）。
+
+## 与本仓库其他约定的关系
+
+- **引用规范**：在向用户报告进度或写复盘时，遵循 `AGENTAO.md §Evidence Conventions`——每条事实
+  要带 `path:line` 或 `[tool: kanban events <id>]` 这类 marker；推断结论标 `(unverified)` /
+  `(inferred from X)`。
+- **分类标签**：复盘里给问题打 `[CRITICAL]` / `[WARNING]` / `[SUGGESTION]` / `[NITPICK]`。
+- **隐私**：板上的卡片内容默认按机密处理，不要把 `workspace/board/` 里的原文发到外部。
+
+## 最小骨架命令清单（贴心备忘）
+
+板与卡：
+
+```bash
+uv run kanban init                                  # 起板
+uv run kanban card add --title T --goal G \
+  --acceptance "..." [--depends ID] [--priority HIGH]
+uv run kanban list
+uv run kanban show <id>
+uv run kanban move <id> ready
+uv run kanban tick                                  # 单步推
+uv run kanban run                                   # 跑到 idle
+uv run kanban block   <id> "reason"                 # reason 是位置参数
+uv run kanban unblock <id> [--to ready]             # 默认回 inbox
+uv run kanban events  <id>
+uv run kanban doctor [--fix]
+```
+
+后台服务（**复合触发优先；详见「一键启停」**）：
+
+```bash
+# 用户说 "启动 kanban"      → daemon (mock) + Web UI（自动开浏览器）
+# 用户说 "启动 kanban 真跑" → daemon (--executor agentao) + Web UI
+# 用户说 "停止 kanban"      → 先停 Web UI，再停 daemon
+
+# 单独操作 Daemon
+uv run kanban daemon --detach                       # 启（mock）
+uv run kanban --executor agentao daemon --detach    # 启（真跑）
+uv run kanban daemon status                         # 看
+uv run kanban daemon logs -f                        # 跟踪
+uv run kanban daemon stop                           # 停
+
+# 单独操作 Web UI（详细启停见「Web UI · 启 / 停」一节）
+nohup uv run kanban web --host 127.0.0.1 --port 8000 \
+  > workspace/board/web.log 2>&1 & \
+  echo $! > workspace/board/.web.pid && \
+  for _ in $(seq 1 30); do curl -fsS http://127.0.0.1:8000/ >/dev/null 2>&1 && break; sleep 0.5; done && \
+  open http://127.0.0.1:8000/                       # 启 + 自动开浏览器
+kill "$(cat workspace/board/.web.pid)" && rm workspace/board/.web.pid   # 停
+```
+
+察看状态 / 产物：
+
+```bash
+# 状态
+uv run kanban show <id> [--json]                    # 单卡详情
+uv run kanban events <id> [--limit N] [--role R] [--json]
+uv run kanban claims [<id>] [--json]                # 谁在跑
+uv run kanban workers                               # 多 worker 模式
+
+# 产物
+uv run kanban worktree list                         # DOING 时的活跃 worktree
+uv run kanban worktree diff <id>                    # DOING 时 worker 的改动
+ls -dt workspace/raw/<id>/artifacts-*/ | head -1    # DONE/BLOCKED 后的快照
+uv run kanban traces <id> --latest [--role R]       # agent 原始 transcript
+```

--- a/examples/skills/kanban-tasks/playbooks/break-down-requirements.md
+++ b/examples/skills/kanban-tasks/playbooks/break-down-requirements.md
@@ -1,0 +1,111 @@
+# 把需求拆成原子卡 · Survey → Classify → Prescribe → Verify
+
+> 本 playbook 是 SKILL.md Step 1 的展开，对应 `AGENTAO.md` 的 Code Review 思路（Survey → Classify → Prescribe → Verify）。
+
+## 工作面规则
+
+**动 CLI 之前**，先在对话中给用户一张表，等用户确认/调整再落卡。**不要**没确认就一口气 `card add` 5 张：
+
+| # | title | goal | priority | depends_on | acceptance(关键 1-3 条) |
+|---|---|---|---|---|---|
+
+≥3 张时直接套 `playbooks/cards.template.yaml` 模板，让用户在 YAML 里直接改，最后一条命令落卡：
+
+```bash
+uv run python $SKILL_DIR/scripts/kanban_cards_from_yaml.py cards.yaml
+```
+
+## 拆卡四原则
+
+### 1. 原子性
+
+一张卡 = 一个**可独立完成**、**可独立验证**的产出。
+
+| ❌ 不是卡 | ✅ 是卡 |
+|---|---|
+| "重构 X 模块" | "把 X.foo 拆成两个纯函数并迁移调用点" |
+| "改善 ingest 性能" | "给 ingest.read_batch 加 LRU cache，benchmark 提升 ≥30%" |
+| "整理文档" | "把 README §快速开始 拆出独立 docs/quickstart.md，并更新交叉引用" |
+
+启发式：如果你写不出至少 1 条**人/CI 能直接判定**的 acceptance，这张卡还不够原子。
+
+### 2. 依赖显式化
+
+只有**真依赖**（B 必须等 A 的产出落地）才用 `--depends`。同主题不等于依赖。
+
+- ✅ "B 用到了 A 新增的接口" → `B --depends A`
+- ✅ "重构必须等迁移脚本跑完" → `重构 --depends 迁移`
+- ❌ "都属于 ingest 主题" → 不写 depends；如果用户想看在一起，靠 priority 或 board view 而不是依赖
+- ❌ "顺序无所谓但希望先做 A" → 用 priority 表达
+
+依赖图越稀疏，并发度越高。**默认无依赖**，只在必须等时加。
+
+### 3. acceptance 是验收凭据
+
+每张卡至少 **1 条** `acceptance`，写成可被人/CI 直接判定通过/失败的语句：
+
+| ❌ 弱 acceptance | ✅ 强 acceptance |
+|---|---|
+| "代码质量提升" | "`uv run ruff check kanban/ingest.py` 0 错" |
+| "有测试覆盖" | "`uv run pytest tests/ingest -k reader` 至少 8 个 case 全绿" |
+| "文档更新" | "`docs/ingest.md` 存在且包含 §API、§错误码 两章" |
+| "性能更好" | "`benchmarks/ingest_bench.py` p50 < 50ms（基线 80ms）" |
+
+worker / verifier 真跑时会按 acceptance 自检；写得越具体，自动判定越靠谱。
+
+### 4. 优先级保守用
+
+- **MEDIUM**（默认）— 绝大多数卡。
+- **HIGH** — 这周必须出，或挡了下游卡。
+- **CRITICAL** — 阻断其它卡 / 线上故障类。**别滥用**，否则信号失效。
+- **LOW** — 想做但不急；通常该考虑直接砍掉。
+
+## Survey → Classify → Prescribe → Verify 套路
+
+走需求 → 卡片的四步：
+
+### Survey（看清需求边界）
+
+- 用户真正想要的产出是什么？拿在手里是个 PR、一份文档、一段数据，还是一个长期 dashboard？
+- 已有什么？哪些子目标已经在仓库里完成了？（先 `grep` / 看 `git log`，避免重复造轮子。）
+- 边界在哪？哪些**不在**这次范围内（写下来，免得被卷进卡里）。
+
+### Classify（分类拆解）
+
+把需求拆成离散类别。常见分类：
+
+| 类别 | 典型标题 |
+|---|---|
+| **代码改动** | "把 X 拆成 Y/Z" / "给 W 加 cache" |
+| **测试** | "给 X 写表格驱动单测" / "加端到端冒烟测试" |
+| **文档** | "把 §快速开始 拆到 docs/quickstart.md" |
+| **数据 / 一次性脚本** | "跑 schema 迁移脚本并落地结果到 workspace/data/" |
+| **复盘 / 报告** | "整理本次迭代的复盘到 workspace/reports/" |
+
+每类至少 1 张卡，避免一张卡跨类别（"改代码 + 写测试 + 改文档"是 3 张）。
+
+### Prescribe（开方）
+
+为每张卡写：
+
+- **title**：动词开头，≤60 字；目标对象具体到文件/模块。
+- **goal**：1-2 句，**为什么**做这件事 + 完成后能解锁什么。
+- **acceptance**：1-3 条，强 acceptance（见原则 3）。
+- **context**：把人/agent 看这张卡时**必须读**的文件/行号一并附上（`--kind required`）。可选参考用 `--kind optional`。
+- **depends**：仅真依赖。
+
+### Verify（落卡前自检）
+
+- [ ] 每张卡能不能拎出来单独做？
+- [ ] acceptance 是不是 CI/人能机械判定？
+- [ ] 依赖图有没有环（CLI 会拒，但你也别浪费时间）？
+- [ ] 是否有"重写整个模块"这种伪卡？拆细。
+- [ ] 要不要给某些卡加 `context_refs` 让 worker 不用满仓库找？
+
+## 反模式
+
+- **"重构 X"** 单卡：永远拆细，不然 verifier 没有抓手。
+- **`CRITICAL` 满天飞**：信号被稀释，真有线上故障时反而看不到。
+- **`--depends` 把同主题串起来**：让并发度归零；该用 priority 或同 sprint 标签（外部追踪）。
+- **acceptance 只有"完成"**：等于没写。
+- **没确认就批量落卡**：不可逆（要么挨个 `block` + 删除 frontmatter，要么 `--force` 修板）。先表格 → 用户点头 → 再 `card add`。

--- a/examples/skills/kanban-tasks/playbooks/cards.template.yaml
+++ b/examples/skills/kanban-tasks/playbooks/cards.template.yaml
@@ -1,0 +1,35 @@
+# Batch card creation template for `scripts/kanban_cards_from_yaml.py`.
+# Top-level can be a list directly, or `cards: [...]`.
+#
+# Per-card fields:
+#   title       (required)  one-line summary
+#   goal        (required)  what success looks like
+#   priority                LOW | MEDIUM | HIGH | CRITICAL  (default MEDIUM)
+#   name                    optional alias; later cards can `depends: [<name>]`
+#   depends                 list of names (resolved above) or full card UUIDs
+#   acceptance              list of strings, each a CI/human-checkable criterion
+#   context                 list of refs, either "path:lines" strings or
+#                           {path: "...", kind: required|optional, note: "..."}
+
+cards:
+  - name: split-ingest
+    title: 把 ingest.py 拆成 reader/parser 两个纯函数
+    goal:  降低 ingest.py 圈复杂度并允许独立单测
+    priority: MEDIUM
+    acceptance:
+      - "uv run pytest tests/ingest 全绿"
+      - "ingest.py 中无对全局状态的读写"
+    context:
+      - path: kanban/ingest.py:1-200
+        kind: required
+        note: 主体函数与现有调用点
+      - "tests/ingest/test_reader.py:1-40"
+
+  - name: write-tests
+    title: 给 reader 写表格驱动单测
+    goal:  覆盖 reader 的边界 case，保证后续重构有兜底
+    priority: MEDIUM
+    depends: [split-ingest]
+    acceptance:
+      - "tests/ingest/test_reader.py 至少 8 个 case"
+      - "uv run pytest tests/ingest -k reader 通过"

--- a/examples/skills/kanban-tasks/references/advanced.md
+++ b/examples/skills/kanban-tasks/references/advanced.md
@@ -1,0 +1,89 @@
+# 进阶用法
+
+## Multi-backend 执行器（profile 路由）
+
+`--executor multi-backend` 把卡按 `agent_profiles.yaml` 路由到不同 backend。
+
+- 配置文件：`<cwd>/.kanban/agent_profiles.yaml`，缺省回退 `docs/agent_profiles.sample.yaml`。
+- Backend：`subagent`（agentao 角色子 agent）/ `acp`（Anthropic Claude Pro 协议）。
+- `RouterPolicy`：可让 `kanban-router` agent 从角色的候选 profile 中挑一个。**永远不会**覆盖卡片 pin（`card.agent_profile`）或 planner 推荐；任何失败（disabled / 缺 spec / parse error / timeout）都降级到角色默认。
+
+```bash
+uv run kanban --executor multi-backend run
+uv run kanban profiles                                  # 看当前 profile 配置
+KANBAN_ROUTER=off uv run kanban --executor multi-backend run    # 关 router
+```
+
+每角色单独开关 router 见 config 顶层的 `router:` 段。
+
+## 并发（v0.1.2）
+
+```bash
+# 一个 scheduler 持锁分发，多个 worker 不持锁只执行
+uv run kanban daemon --detach --role scheduler --max-claims 4
+uv run kanban daemon --detach --role worker --worker-id w1
+uv run kanban daemon --detach --role worker --worker-id w2
+
+uv run kanban claims              # 当前 claim
+uv run kanban workers             # 在线 worker
+uv run kanban recover             # 清孤儿 claim、stale 状态等
+```
+
+默认 `--role all`（scheduler + worker 同进程，单卡串行）。**只有需要"多卡并行"或"真跑+其它人手动 tick"时才拆**。
+
+`legacy-serial` 是 v0.1.2 之前的串行 tick 路径，仅作回退使用。
+
+## Worktree
+
+- 默认 `--worktree auto`：板在 git 仓库内时启用，外面禁用并打印一行 stderr 警告。
+- 强制：`--worktree`（要求板在仓库内，否则退出）/ `--no-worktree`（关闭隔离）。
+- 分支命名：`kanban/<card-id>`。
+- live 路径：`workspace/worktrees/<card-id>/`。
+- 卡 detach 时（DONE / BLOCKED）：`WorktreeManager.detach()` 把 gitignored 路径产物抢救到 `workspace/raw/<card-id>/artifacts-<ts>/`，写 `worktree.artifacts_saved` 事件，再 `git worktree remove`。
+
+artifact 抢救参数：
+
+| 项 | 默认 | 调整 |
+|---|---|---|
+| 每卡保留份数 | 5 | 代码常量 |
+| 总大小上限 | 500 MiB | `KANBAN_ARTIFACTS_MAX_BYTES`（字节） |
+| denylist | `node_modules/` `__pycache__/` `.venv/` `dist/` `target/` | 代码常量 |
+
+per-file 累加：到上限后剩余文件**跳过**，已复制保留——不会让你的 `.zip` 半截损坏。
+
+## 环境变量速查
+
+| 变量 | 作用 |
+|---|---|
+| `KANBAN_ARTIFACTS_MAX_BYTES` | worktree detach 时 artifact 总大小上限（字节，默认 500 MiB） |
+| `KANBAN_ROUTER` | `off` 关掉 multi-backend 的 RouterPolicy |
+| `BOARD` | 脚本里覆盖 board 路径（默认 `workspace/board`） |
+| `PORT` | 脚本里覆盖 web 端口（默认 8000） |
+| `EDITOR` | `card edit` / `card acceptance edit` 用的编辑器 |
+
+## Mock 执行器细节
+
+`MockAgentaoExecutor` 是确定性状态机：每卡 `INBOX → READY → DOING → REVIEW → DONE`，不调任何 LLM。
+
+适用：
+
+- CI（不消耗配额）。
+- 教学 / 演示。
+- 给新接入的 store / executor 做基线测试。
+
+不适用：要真改文件、真跑 review / verify 的场景——用 `--executor agentao` 或 `multi-backend`。
+
+## 真跑（`--executor agentao`）
+
+四角色 sub-agent：`planner` / `worker` / `reviewer` / `verifier`，定义在 `.agentao/agents/kanban-<role>.md`。每次 `run()` 各角色一个 `agentao.Agentao` 实例，解析尾部 ```json 围栏（`{ok, summary, output[, acceptance_criteria][, blocked_reason]}`）。任何异常 → 卡进 `BLOCKED`。
+
+每条事件携带 `prompt_version` / `duration_ms` / 完整 raw 响应，便于审计。
+
+## MCP
+
+```bash
+uv run kanban mcp install                  # 把 kanban-mcp 注册到已知客户端
+uv run kanban mcp --help                   # 列子命令
+```
+
+MCP server 暴露看板的工具集供其它 LLM 客户端使用；通常给 Claude Desktop / Cursor 用，不在本 skill 主流程里。

--- a/examples/skills/kanban-tasks/references/cli-cheatsheet.md
+++ b/examples/skills/kanban-tasks/references/cli-cheatsheet.md
@@ -1,0 +1,135 @@
+# Kanban CLI 速查
+
+> 全部命令以 `uv run kanban …` 开头。`<id>` 接受全 UUID 或前缀（CLI 自动唯一匹配）。
+> `--board` 仅在不在板根目录或子目录时才需要；正常情况下**不要带**。
+
+## 板与生命周期
+
+```bash
+uv run kanban init                      # 在当前目录建 .kanban/ + workspace/board/
+uv run kanban init --demo               # 同上 + 4 张示例卡
+uv run kanban demo                      # 把示例卡推到 DONE（演示）
+uv run kanban doctor [--fix]            # 板 + 环境体检；--fix 清 stale lock 等
+```
+
+## card add / edit / context / acceptance
+
+```bash
+# 创建（--acceptance / --depends 可重复）
+uv run kanban card add \
+  --title "标题" --goal "目标" \
+  [--priority LOW|MEDIUM|HIGH|CRITICAL] \
+  [--acceptance "..." --acceptance "..."] \
+  [--depends <card_id> --depends <card_id>]
+
+# 编辑（开 $EDITOR 改 Markdown frontmatter）
+uv run kanban card edit <id>
+
+# context（--path 是命名参数，注意；--kind 默认 required）
+uv run kanban card context add  <id> --path path/to/ref.py:42-88 \
+    [--kind required|optional] [--note "..."]
+uv run kanban card context list <id>
+uv run kanban card context rm   <id> --path path/to/ref.py:42-88
+
+# acceptance（rm 用 1-based 索引）
+uv run kanban card acceptance add   <id> --item "uv run pytest tests/foo 全绿"
+uv run kanban card acceptance edit  <id>
+uv run kanban card acceptance list  <id>
+uv run kanban card acceptance rm    <id> 2
+uv run kanban card acceptance clear <id>
+```
+
+## 状态流转
+
+```bash
+uv run kanban list                       # 全板按状态分组（**没有 --json**）
+uv run kanban show <id> [--json]         # 单卡详情
+uv run kanban move <id> ready|doing|review|done|inbox
+
+# 状态名大小写都接受（CLI 标准化为大写）
+
+uv run kanban block   <id> "原因"        # reason 是位置参数，不是 --reason
+uv run kanban unblock <id> [--to ready]  # 默认回 inbox
+uv run kanban requeue <id> [--to ready] [--note "失败现场已修"]
+```
+
+## 推动执行
+
+```bash
+uv run kanban tick                       # 单步
+uv run kanban run                        # 跑到 idle（全 DONE 或全 BLOCKED）
+
+# 指定执行器（放在子命令前）：
+uv run kanban --executor mock          run    # 默认；离线安全
+uv run kanban --executor agentao       run    # 真调四角色 sub-agent
+uv run kanban --executor multi-backend run    # 走 agent_profiles.yaml
+```
+
+## 复盘 / 看产物（首选 result）
+
+```bash
+uv run kanban result <id> [--json]       # ★ 状态/summary/分支/artifacts/transcripts 一次给齐
+uv run kanban events  <id> [--limit N] [--role planner|worker|reviewer|verifier] [--json]
+uv run kanban events  --limit 200        # 全板事件流
+uv run kanban traces  <id> --latest [--role R]   # agent 原始 transcript
+uv run kanban claims  [<id>] [--json]    # 当前活跃 claim（v0.1.2 并发）
+uv run kanban workers                    # 多 worker 模式下的在线 worker
+```
+
+> `kanban traces` **必须**带 `<card_id>`（位置参数）；要全板复盘遍历各卡或读 `<board>/traces/`。
+
+## Worktree
+
+```bash
+uv run kanban worktree list              # DOING 时活跃的 worktree
+uv run kanban worktree diff <id>         # DOING 时 worker 的改动
+uv run kanban worktree prune             # 清理过期分支
+
+# DONE/BLOCKED 后产物在 workspace/raw/<id>/artifacts-<ts>/，由 result 直接给路径
+```
+
+## Daemon
+
+```bash
+uv run kanban daemon                      # 前台跑（Ctrl-C 优雅停）
+uv run kanban daemon --detach             # 后台 fork
+uv run kanban daemon --once               # 单 tick 即退
+uv run kanban daemon status               # running / stale / stopped
+uv run kanban daemon logs -f              # tail <board>/daemon.log
+uv run kanban daemon stop                 # SIGTERM 给 .daemon.lock 中的 pid
+```
+
+多 worker / 高级用法见 `references/advanced.md`。日常用 `scripts/kanban-up.sh`。
+
+## Web UI
+
+```bash
+uv run kanban web --host 127.0.0.1 --port 8000        # 只读
+uv run kanban web --host 127.0.0.1 --port 8000 --enable-writes        # 允许浏览器建卡
+uv run kanban web --host 0.0.0.0 --port 8000 --enable-writes --allow-remote-writes
+```
+
+`kanban web` 没有 `--detach`；后台化由 `scripts/kanban-up.sh` 处理。
+
+## MCP
+
+```bash
+uv run kanban mcp install                 # 把 kanban-mcp 注册到 MCP 客户端
+uv run kanban mcp --help                  # 列子命令
+```
+
+## 全局选项
+
+```bash
+--board DIR                  # 指定板目录（一般不需要）
+--executor mock|agentao|multi-backend
+--worktree | --no-worktree   # 默认 auto：在 git 仓库内启用，外面禁用
+--force                      # 绕过 daemon 锁；仅应急
+```
+
+## 已知小坑（细节见 troubleshooting.md）
+
+- `kanban list` **没有** `--json`；要程序化全板视图，遍历 `show --json` 或读 `<board>/cards/*.md` 的 TOML frontmatter。
+- `block` 的 `reason` 是位置参数；`unblock` / `requeue` 的 `--to` 默认 `inbox`。
+- `card context add` 的 `--path` 是命名参数（不是位置参数）。
+- 执行器在 daemon 启动时定型，要切换必须 stop → start。

--- a/examples/skills/kanban-tasks/references/inspect.md
+++ b/examples/skills/kanban-tasks/references/inspect.md
@@ -1,0 +1,77 @@
+# 看状态 / 看产物
+
+把"卡现在什么状态"和"卡到底产出了什么"分开看。两类问题对应不同入口。
+
+## 90% 场景：一条命令搞定
+
+```bash
+uv run kanban result <id>                # 状态 / summary / 分支 / artifacts 路径 / transcripts 路径
+uv run kanban result <id> --json         # 喂下游脚本
+```
+
+`kanban result` 是产物侧的**唯一推荐入口**。下面的细分入口是放大镜，按需用。
+
+## A. 状态视图
+
+| 想看什么 | 命令 | 备注 |
+|---|---|---|
+| 全板按状态分组 | `uv run kanban list` | 没有 `--json`；要程序化遍历 `show --json` |
+| 单卡详情（goal / priority / depends / context_refs / acceptance / status） | `uv run kanban show <id> [--json]` | 喂下游用 `--json` |
+| 结构化事件流（状态迁移、claim、artifact 快照） | `uv run kanban events <id>` | `--role …` / `--limit N` / `--json` |
+| 全板事件 | `uv run kanban events --limit 200` | 不带 `<id>` |
+| 当前活跃 claim | `uv run kanban claims [<id>] [--json]` | v0.1.2 并发 |
+| 在线 worker | `uv run kanban workers` | 多 worker 模式 |
+| acceptance / context 是否齐全 | `uv run kanban card acceptance list <id>` / `card context list <id>` | — |
+
+最常用三连：
+
+```bash
+uv run kanban show   <id>                 # 这张卡是什么、配置齐了吗
+uv run kanban events <id> --limit 20      # 最近发生了什么
+uv run kanban claims <id>                 # 现在谁在跑（如有）
+```
+
+## B. 产物视图（"这张卡到底产出了什么"）
+
+产物分布在 4 个位置，但**不要手动找**——`kanban result` 会按卡当前状态给出对应路径：
+
+| 卡的状态 | 产物在哪 | 直接看 |
+|---|---|---|
+| **DOING**（worktree 在线） | `workspace/worktrees/<card-id>/`（分支 `kanban/<card-id>`） | `uv run kanban worktree diff <id>` |
+| **DONE / BLOCKED**（worktree 已 detach） | `workspace/raw/<card-id>/artifacts-<ts>/` | `kanban result <id>` 给最新一份 |
+| 任意状态：agent 原始响应 | `<board>/traces/...` | `uv run kanban traces <id> --latest` |
+| 任意状态：结构化事件 | `<board>/events.log` | `uv run kanban events <id>` |
+
+机制要点：
+
+- 产物**先**落到 live worktree。
+- 卡进入 DONE / BLOCKED 时 `WorktreeManager.detach()` 把 gitignored 路径下的产出抢救到 `workspace/raw/<card-id>/artifacts-<ts>/`，并写一条 `worktree.artifacts_saved` 事件（含快照路径）；events / Web UI 都能看到。
+- 默认每卡保留**最近 5 份快照、上限 500 MiB**；超过的文件按顺序跳过、已复制的保留。
+- 调上限：`KANBAN_ARTIFACTS_MAX_BYTES`（环境变量；字节数）。
+- denylist：`node_modules/` / `__pycache__/` / `.venv/` / `dist/` / `target/` 不计入。
+
+## C. 三个最常被问的问题（一行流）
+
+```bash
+# "这张卡现在做到哪了？"
+uv run kanban show <id> && uv run kanban events <id> --limit 20
+
+# "这张卡产出了什么？"
+uv run kanban result <id>
+
+# "agent 原文是什么？"
+uv run kanban traces <id> --latest [--role worker|planner|reviewer|verifier]
+```
+
+## D. 多卡批量盘点
+
+```bash
+uv run kanban worktree list                       # 当前活跃 worktree（隐含：哪些卡在 DOING）
+uv run kanban events --limit 200                  # 全板最近事件
+uv run kanban claims --json                       # 喂下游
+
+# 程序化全板视图（弥补 list 没有 --json）
+for id in $(ls workspace/board/cards/*.md | xargs -n1 basename | sed 's/\.md$//'); do
+  uv run kanban show "$id" --json
+done | jq -s '.'
+```

--- a/examples/skills/kanban-tasks/references/services.md
+++ b/examples/skills/kanban-tasks/references/services.md
@@ -1,0 +1,83 @@
+# 后台服务详解（daemon + Web UI）
+
+两个常驻进程，**职责互不重叠**：
+
+| 服务 | 进程职责 | 是否写板 | 默认端口 |
+|---|---|---|---|
+| `kanban daemon` | 调度 + 执行卡片，按 `.daemon.lock` 串行写板 | 是 | — |
+| `kanban web` | 读板渲染浏览器看板（轮询） | 否（除非 `--enable-writes`） | 8000 |
+
+约定：
+
+- daemon 自管 `<board>/.daemon.lock` 和 `<board>/daemon.log`。
+- web 没有 `--detach`，由 `scripts/kanban-up.sh` 用 `nohup` 后台化，PID 落在 `<board>/.web.pid`，日志落在 `<board>/web.log`。
+- 默认 board 路径 `workspace/board/`。如果用户在别处 `init`，要么 `cd` 到 `.kanban/` 所在目录，要么在脚本里 `BOARD=<path>` 覆盖。
+
+## 日常用脚本（推荐）
+
+```bash
+$SKILL_DIR/scripts/kanban-up.sh         # daemon (mock) + Web UI + 自动开浏览器
+$SKILL_DIR/scripts/kanban-up-real.sh    # daemon (--executor agentao) + Web UI
+$SKILL_DIR/scripts/kanban-down.sh       # 先停 web 再停 daemon
+$SKILL_DIR/scripts/kanban-status.sh     # 一屏看 board/daemon/web/cards
+```
+
+环境变量覆盖：`BOARD=path/to/board PORT=8765 bash $SKILL_DIR/scripts/kanban-up.sh`。
+
+## 真跑（`--executor agentao`）前置检查
+
+1. 用户**已明确**要真跑（不要从"启动 kanban"擅自升级）。
+2. 板里有 `READY` / `INBOX` 卡，且 acceptance / context 写齐。
+3. 知晓真跑会消耗 LLM 配额、会真改 worktree 内文件。
+4. 执行器**在 daemon 启动时定型**——切换必须 `kanban-down.sh` → `kanban-up-real.sh`。
+
+## Web UI 写入模式
+
+默认只读。仅在用户明确"用浏览器建卡"时再开 `--enable-writes`，并且：
+
+- **绑 loopback**：只在本机可访问。直接 `--enable-writes` 即可。
+- **绑非 loopback / 暴露到网络**：还要加 `--allow-remote-writes`，且**必须**和用户单独确认——这是把板的写入面暴露出去，不要随手开。
+
+```bash
+# 仅本机用浏览器建卡
+nohup uv run kanban web --host 127.0.0.1 --port 8000 --enable-writes \
+  > workspace/board/web.log 2>&1 &
+echo $! > workspace/board/.web.pid
+```
+
+## 多 worker（v0.1.2 并发）
+
+一个 scheduler + 多个 worker，scheduler 持锁分发，worker 不持锁只执行：
+
+```bash
+uv run kanban daemon --detach --role scheduler --max-claims 4
+uv run kanban daemon --detach --role worker --worker-id w1
+uv run kanban daemon --detach --role worker --worker-id w2
+
+uv run kanban claims          # 看活跃 claim
+uv run kanban workers         # 看在线 worker
+uv run kanban recover         # 一次性 runtime 恢复（清残留 claim 等）
+```
+
+默认 `--role all`（scheduler + worker 同进程），日常足够。
+
+## Multi-backend 执行器（profile 路由）
+
+`--executor multi-backend` 走 `<cwd>/.kanban/agent_profiles.yaml`（fallback 到 `docs/agent_profiles.sample.yaml`）。每张卡按 profile + backend（`subagent` / `acp`）执行。`RouterPolicy` 可让 `kanban-router` agent 从角色候选中选 profile；router 不会覆盖卡片 pin / planner 推荐，任何失败都会降级到角色默认。
+
+```bash
+uv run kanban --executor multi-backend run
+KANBAN_ROUTER=off uv run kanban --executor multi-backend run    # 关 router
+uv run kanban profiles                       # 看当前 profile 配置
+```
+
+## 端口与日志
+
+| 文件 | 内容 |
+|---|---|
+| `<board>/daemon.log` | daemon 全部 stdout/stderr |
+| `<board>/web.log` | web UI 全部 stdout/stderr |
+| `<board>/.daemon.lock` | TOML（pid / started_at），daemon 写 |
+| `<board>/.web.pid` | nohup 后台化的 web pid，由脚本写 |
+
+> 端口被占用：`lsof -nP -iTCP:8000 -sTCP:LISTEN`。换端口：`PORT=8765 bash $SKILL_DIR/scripts/kanban-up.sh`。

--- a/examples/skills/kanban-tasks/references/troubleshooting.md
+++ b/examples/skills/kanban-tasks/references/troubleshooting.md
@@ -1,0 +1,117 @@
+# 常见坑
+
+## 板 / 锁
+
+**"empty board" / 找不到卡** — 通常是 `.kanban/` 不存在且当前目录没有 `workspace/board/`：
+
+```bash
+ls -d .kanban workspace/board 2>&1 || true
+uv run kanban init        # 没板就 init
+```
+
+**写命令报锁** — daemon 在跑。要么 `kanban daemon stop`，要么真的应急再加 `--force`：
+
+```bash
+uv run kanban daemon status
+uv run kanban daemon stop                          # 优雅
+uv run kanban --force move <id> ready              # 应急；不推荐常态用
+```
+
+**stale lock**（daemon 已死但 `.daemon.lock` 残留）：
+
+```bash
+uv run kanban doctor --fix
+```
+
+**状态卡死在 BLOCKED**：
+
+```bash
+uv run kanban events <id> --limit 50               # 找原因
+uv run kanban requeue <id> --to ready --note "失败现场已修"
+# 或
+uv run kanban unblock <id> [--to ready]            # 默认回 inbox
+```
+
+## 后台服务
+
+**端口被占用**：
+
+```bash
+lsof -nP -iTCP:8000 -sTCP:LISTEN
+PORT=8765 bash $SKILL_DIR/scripts/kanban-up.sh     # 换端口
+```
+
+**`web` 起来但浏览器空白**：通常是探活早于路由就绪。先看启动日志：
+
+```bash
+tail -f workspace/board/web.log
+```
+
+如果脚本里探活超时（`seq 1 60` = ~30s）仍空白，把循环加大或先确认端口没被防火墙拦。
+
+**`.web.pid` 指向已死进程**：`kanban-status.sh` 会自动清理；手动也行：
+
+```bash
+rm -f workspace/board/.web.pid
+```
+
+**daemon 写不动板**：
+
+```bash
+uv run kanban daemon status            # running / stale / stopped
+uv run kanban doctor --fix             # 清 stale lock
+# 仅本地误锁应急：uv run kanban --force ...
+```
+
+**同时跑 daemon + web** 完全 OK：两者职责不冲突，web 默认只读。
+
+**执行器切换不生效**：执行器在 daemon **启动时定型**。从 mock 切到真跑：
+
+```bash
+bash $SKILL_DIR/scripts/kanban-down.sh
+bash $SKILL_DIR/scripts/kanban-up-real.sh
+```
+
+## 卡片配置
+
+**改 acceptance / context** — 用 CLI，不要手改 `workspace/board/cards/*.md` 的 frontmatter（除非确认 daemon 停了且板状态干净）：
+
+```bash
+uv run kanban card acceptance edit <id>            # 开 $EDITOR
+uv run kanban card context add  <id> --path ref:1-50
+```
+
+**多卡同主题但不真依赖** — 不要乱加 `--depends`，依赖只表达"必须先完成"。同主题考虑合并卡或并列建。
+
+**位置参数 vs 命名参数**（最容易踩）：
+
+| 命令 | 类型 |
+|---|---|
+| `kanban block <id> "reason"` | reason 是**位置** |
+| `kanban unblock <id> [--to ready]` | `--to` 是**命名**，默认 inbox |
+| `kanban requeue <id> [--to ready] [--note "..."]` | 都是**命名** |
+| `kanban traces <id> --latest` | `<id>` **必填**位置 |
+| `kanban card context add <id> --path X --kind Y` | `--path` 是**命名**，不是位置 |
+
+## 产物找不到
+
+**worker 自报"已写文件"但 DONE 后找不到** — **第一站永远是 `workspace/raw/<id>/artifacts-*/`**，但更直接：
+
+```bash
+uv run kanban result <id>     # 自动指向最新 artifact 快照路径
+```
+
+**artifact 被截断 / 部分缺失** — 是触发了 500 MiB 上限或单卡 5 份保留：
+
+```bash
+KANBAN_ARTIFACTS_MAX_BYTES=$((2 * 1024 * 1024 * 1024))    # 加到 2 GiB
+# 写入 .envrc / shell rc 让它对未来执行生效；正在跑的 daemon 不会重读
+```
+
+denylist (`node_modules/` / `__pycache__/` / `.venv/` / `dist/` / `target/`) 内文件**不计入**，也**不会**复制到快照。
+
+## CLI 输出不符合预期
+
+**`kanban list` 没 `--json`** — 已知设计，要程序化全板视图遍历 `show --json` 或解析 `workspace/board/cards/*.md`。
+
+**`kanban traces` 提示要 `<card_id>`** — 是位置参数；没有"列全部 trace"的子命令，要全板复盘看 `<board>/traces/`。

--- a/examples/skills/kanban-tasks/scripts/kanban-down.sh
+++ b/examples/skills/kanban-tasks/scripts/kanban-down.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Stop Web UI then daemon (idempotent). Web first so it doesn't poll a
+# detached board.
+# Env: BOARD (default workspace/board).
+set -euo pipefail
+
+BOARD="${BOARD:-workspace/board}"
+PID_FILE="$BOARD/.web.pid"
+
+# 1) Web UI
+if [ -f "$PID_FILE" ]; then
+  PID=$(cat "$PID_FILE")
+  if kill -0 "$PID" 2>/dev/null; then
+    kill "$PID" 2>/dev/null || true
+    for _ in $(seq 1 10); do kill -0 "$PID" 2>/dev/null || break; sleep 0.2; done
+    if kill -0 "$PID" 2>/dev/null; then
+      kill -9 "$PID" 2>/dev/null || true
+      echo "web: force-killed (pid $PID)"
+    else
+      echo "web: stopped (pid $PID)"
+    fi
+  else
+    echo "web: pidfile present but process gone"
+  fi
+  rm -f "$PID_FILE"
+else
+  echo "web: not running"
+fi
+
+# 2) Daemon
+if uv run kanban daemon status 2>&1 | grep -E '^status:[[:space:]]+running' >/dev/null; then
+  uv run kanban daemon stop && echo "daemon: stop signal sent"
+else
+  echo "daemon: not running"
+fi

--- a/examples/skills/kanban-tasks/scripts/kanban-status.sh
+++ b/examples/skills/kanban-tasks/scripts/kanban-status.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Combined snapshot: board / daemon / web UI / cards.
+# Env: BOARD (default workspace/board).
+set -uo pipefail
+
+BOARD="${BOARD:-workspace/board}"
+
+echo "== board =="
+if [ -d "$BOARD" ]; then
+  echo "  path: $BOARD"
+else
+  echo "  not initialized — run 'uv run kanban init'"
+  exit 1
+fi
+
+echo
+echo "== daemon =="
+uv run kanban daemon status 2>&1 | sed 's/^/  /'
+
+echo
+echo "== web =="
+PID_FILE="$BOARD/.web.pid"
+if [ -f "$PID_FILE" ] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+  echo "  running pid=$(cat "$PID_FILE") log=$BOARD/web.log"
+else
+  echo "  not running"
+  [ -f "$PID_FILE" ] && rm -f "$PID_FILE"
+fi
+
+echo
+echo "== cards (head) =="
+uv run kanban list 2>&1 | sed 's/^/  /' | head -40

--- a/examples/skills/kanban-tasks/scripts/kanban-up-real.sh
+++ b/examples/skills/kanban-tasks/scripts/kanban-up-real.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Start kanban daemon with --executor agentao (REAL sub-agents) + Web UI.
+# Caller MUST already have explicit user confirmation. Refuses to attach to
+# an already-running daemon since the executor is fixed at daemon start.
+# Env: BOARD (default workspace/board), PORT (default 8000).
+set -euo pipefail
+
+BOARD="${BOARD:-workspace/board}"
+PORT="${PORT:-8000}"
+URL="http://127.0.0.1:${PORT}/"
+
+if [ ! -d "$BOARD" ]; then
+  echo "error: $BOARD not found. Run 'uv run kanban init' first." >&2
+  exit 1
+fi
+
+if uv run kanban daemon status 2>&1 | grep -E '^status:[[:space:]]+running' >/dev/null; then
+  echo "error: daemon already running. Stop it first ('kanban-down.sh') — executor is fixed at start." >&2
+  exit 2
+fi
+
+uv run kanban --executor agentao daemon --detach
+echo "daemon: started (--executor agentao)"
+
+PID_FILE="$BOARD/.web.pid"
+if [ -f "$PID_FILE" ] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+  echo "web: already running (pid $(cat "$PID_FILE"))"
+else
+  [ -f "$PID_FILE" ] && rm -f "$PID_FILE"
+  nohup uv run kanban web --host 127.0.0.1 --port "$PORT" \
+    > "$BOARD/web.log" 2>&1 &
+  echo $! > "$PID_FILE"
+  echo "web: starting (pid $(cat "$PID_FILE"))"
+fi
+
+for _ in $(seq 1 60); do
+  curl -fsS "$URL" >/dev/null 2>&1 && break
+  sleep 0.5
+done
+
+if curl -fsS "$URL" >/dev/null 2>&1; then
+  if   command -v open     >/dev/null 2>&1; then open     "$URL"
+  elif command -v xdg-open >/dev/null 2>&1; then xdg-open "$URL"
+  elif command -v wslview  >/dev/null 2>&1; then wslview  "$URL"
+  else echo "open URL manually: $URL"
+  fi
+  echo "web: ready at $URL"
+else
+  echo "web: not responding after 30s — tail $BOARD/web.log" >&2
+  exit 1
+fi
+
+uv run kanban daemon status

--- a/examples/skills/kanban-tasks/scripts/kanban-up.sh
+++ b/examples/skills/kanban-tasks/scripts/kanban-up.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Start kanban daemon (mock executor) + Web UI, open browser. Idempotent.
+# Run from the kanban project root (the directory containing .kanban/).
+# Env: BOARD (default workspace/board), PORT (default 8000).
+set -euo pipefail
+
+BOARD="${BOARD:-workspace/board}"
+PORT="${PORT:-8000}"
+URL="http://127.0.0.1:${PORT}/"
+
+if [ ! -d "$BOARD" ]; then
+  echo "error: $BOARD not found. Run 'uv run kanban init' first (or set BOARD=…)." >&2
+  exit 1
+fi
+
+# 1) Daemon — kanban itself manages the lock; just check status first.
+if uv run kanban daemon status 2>&1 | grep -E '^status:[[:space:]]+running' >/dev/null; then
+  echo "daemon: already running"
+else
+  uv run kanban daemon --detach
+  echo "daemon: started (mock executor)"
+fi
+
+# 2) Web UI — manual PID file management (kanban web has no --detach).
+PID_FILE="$BOARD/.web.pid"
+if [ -f "$PID_FILE" ] && kill -0 "$(cat "$PID_FILE")" 2>/dev/null; then
+  echo "web: already running (pid $(cat "$PID_FILE"))"
+else
+  [ -f "$PID_FILE" ] && rm -f "$PID_FILE"
+  nohup uv run kanban web --host 127.0.0.1 --port "$PORT" \
+    > "$BOARD/web.log" 2>&1 &
+  echo $! > "$PID_FILE"
+  echo "web: starting (pid $(cat "$PID_FILE"))"
+fi
+
+# 3) Probe and open browser.
+for _ in $(seq 1 60); do
+  curl -fsS "$URL" >/dev/null 2>&1 && break
+  sleep 0.5
+done
+
+if curl -fsS "$URL" >/dev/null 2>&1; then
+  if   command -v open     >/dev/null 2>&1; then open     "$URL"
+  elif command -v xdg-open >/dev/null 2>&1; then xdg-open "$URL"
+  elif command -v wslview  >/dev/null 2>&1; then wslview  "$URL"
+  else echo "open URL manually: $URL"
+  fi
+  echo "web: ready at $URL"
+else
+  echo "web: not responding after 30s — tail $BOARD/web.log" >&2
+  exit 1
+fi
+
+uv run kanban daemon status

--- a/examples/skills/kanban-tasks/scripts/kanban_cards_from_yaml.py
+++ b/examples/skills/kanban-tasks/scripts/kanban_cards_from_yaml.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Batch-create kanban cards from a YAML spec.
+
+Usage:
+    uv run python scripts/kanban_cards_from_yaml.py path/to/cards.yaml
+
+Schema (see playbooks/cards.template.yaml). Each card may carry a `name:`
+alias so later cards can reference it in `depends:` instead of guessing UUIDs.
+
+Calls `uv run kanban card add` per card (sequentially, since the board has
+a single writer); after add, runs `card context add` for any context refs.
+"""
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+try:
+    import yaml
+except ImportError:
+    sys.stderr.write("error: PyYAML not installed. Run: uv add pyyaml\n")
+    sys.exit(2)
+
+
+CARD_ID_RE = re.compile(r"Created card ([0-9a-f-]+)")
+
+
+def run(cmd: list[str]) -> str:
+    proc = subprocess.run(cmd, capture_output=True, text=True)
+    if proc.returncode != 0:
+        sys.stderr.write(f"  cmd failed: {' '.join(cmd)}\n  stderr: {proc.stderr}\n")
+        raise SystemExit(proc.returncode)
+    return proc.stdout
+
+
+def card_add(card: dict) -> str:
+    cmd = ["uv", "run", "kanban", "card", "add",
+           "--title", str(card["title"]),
+           "--goal",  str(card["goal"])]
+    if (p := card.get("priority")):
+        cmd += ["--priority", p.upper()]
+    for a in card.get("acceptance") or []:
+        cmd += ["--acceptance", str(a)]
+    for d in card.get("depends") or []:
+        cmd += ["--depends", str(d)]
+    out = run(cmd)
+    if (m := CARD_ID_RE.search(out)):
+        return m.group(1)
+    raise SystemExit(f"could not parse card id from output:\n{out}")
+
+
+def add_context(card_id: str, refs: list) -> None:
+    for ref in refs or []:
+        if isinstance(ref, str):
+            ref = {"path": ref}
+        cmd = ["uv", "run", "kanban", "card", "context", "add", card_id,
+               "--path", str(ref["path"])]
+        if (k := ref.get("kind")):
+            cmd += ["--kind", k]
+        if (n := ref.get("note")):
+            cmd += ["--note", n]
+        run(cmd)
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        sys.stderr.write(__doc__ or "")
+        return 1
+
+    spec = yaml.safe_load(Path(sys.argv[1]).read_text())
+    cards = spec.get("cards") if isinstance(spec, dict) else spec
+    if not isinstance(cards, list):
+        sys.stderr.write("error: top-level must be a list or {cards: [...]}\n")
+        return 1
+
+    name_to_id: dict[str, str] = {}
+    for card in cards:
+        if "depends" in card:
+            card["depends"] = [name_to_id.get(d, d) for d in (card["depends"] or [])]
+        cid = card_add(card)
+        if (n := card.get("name")):
+            name_to_id[n] = cid
+        add_context(cid, card.get("context") or [])
+        print(f"  {cid}  {card['title']}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/test_per_session_cwd.py
+++ b/tests/test_per_session_cwd.py
@@ -1,9 +1,16 @@
 """Tests for per-session working directory isolation (Issue 05).
 
+Since 0.3.0 ``working_directory`` is a required keyword argument: omitting
+it raises ``TypeError`` at construction (no ``Path.cwd()`` lazy fallback).
+The CLI-style auto-detection lives in
+``agentao.embedding.build_from_environment``, not in the constructor.
+
 Covers:
 
-- ``Agentao.working_directory`` property: ``None`` → lazy ``Path.cwd()``;
-  set → frozen resolved ``Path``
+- ``Agentao()`` without ``working_directory=`` raises ``TypeError``;
+  when passed, the value is frozen as a resolved absolute ``Path``
+- The ``_resolve_path`` helper: absolute pass-through, tilde expansion,
+  relative-against-wd, and relative-without-wd (returns the path unchanged)
 - Memory manager bound to session cwd (so two sessions don't share a
   SQLite database)
 - ``_load_project_instructions`` reads AGENTAO.md from session cwd
@@ -16,8 +23,7 @@ Covers:
   tool's session cwd
 - ACP ``session/new`` factory wires ``working_directory=cwd`` through to
   the constructed runtime
-- Default Agentao (no ``working_directory``) still reflects process cwd
-  (CLI compatibility)
+- ``agentao.log`` lands in the session cwd, not the process cwd
 """
 
 from __future__ import annotations


### PR DESCRIPTION
Two doc-only commits that were sitting unpushed on local `main`:

- **`docs(skills): add kanban-tasks to examples/skills gallery`** — new `examples/skills/kanban-tasks/` skill (SKILL.md, playbooks, references, scripts) for driving an `agentao-kanban` board; linked from `examples/skills/README.{md,zh.md}`.
- **`docs(tests): refresh test_per_session_cwd module docstring for 0.3.0`** — docstring-only update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)