### PR TITLE
feat(cli): add /compact command for manual history compaction

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -183,6 +183,8 @@ User commands (start with `/`):
 - `/skills` - List available/active skills
 - `/memory` - Show saved memories
 - `/mcp` - List MCP servers and tools
+- `/context` - Show context-window token usage; `/context limit <n>` overrides max tokens
+- `/compact` - Manually run full history compaction (`compress_messages(is_auto=False)`); handler in `cli/commands/compact.py`
 - `/help` - Show help
 
 Session state `allow_all_tools` persists across tool confirmations within one session.

--- a/agentao/cli/_utils.py
+++ b/agentao/cli/_utils.py
@@ -36,7 +36,7 @@ _SLASH_COMMANDS = [
     '/crystallize feedback', '/crystallize refine', '/crystallize revise',
     '/crystallize status', '/crystallize suggest',
     '/plan', '/plan clear', '/plan history', '/plan implement', '/plan show',
-    '/context', '/context limit', '/exit', '/help',
+    '/compact', '/context', '/context limit', '/exit', '/help',
     '/mcp', '/mcp add', '/mcp list', '/mcp remove',
     '/markdown',
     '/memory', '/memory clear', '/memory delete', '/memory list',

--- a/agentao/cli/commands/__init__.py
+++ b/agentao/cli/commands/__init__.py
@@ -8,6 +8,7 @@ compat facade — the import sites at the call layer stay unchanged.
 
 from __future__ import annotations
 
+from .compact import handle_compact_command
 from .context import handle_context_command
 from .mcp import handle_mcp_command
 from .permission import handle_permission_command, handle_sandbox_command
@@ -21,6 +22,7 @@ from .sessions import handle_sessions_command, resume_session
 from .tools_intro import handle_tools_command
 
 __all__ = [
+    "handle_compact_command",
     "handle_context_command",
     "handle_mcp_command",
     "handle_model_command",

--- a/agentao/cli/commands/compact.py
+++ b/agentao/cli/commands/compact.py
@@ -1,0 +1,143 @@
+"""``/compact`` — manually trigger full conversation-history compaction.
+
+Mirrors the threshold-driven path in
+``runtime/chat_loop/_compaction.py::_maybe_full_compress`` but runs on
+demand: it calls ``ContextManager.compress_messages(..., is_auto=False)``,
+swaps in the summarized history, fires the same ``CONTEXT_COMPRESSED`` /
+session-summary observability events, and refreshes the cached context
+percentage shown in the prompt.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import TYPE_CHECKING
+
+from .._globals import console
+
+if TYPE_CHECKING:
+    from ..app import AgentaoCLI
+
+# Below this many messages there is nothing worth summarizing — matches the
+# guard inside ``ContextManager.compress_messages``.
+_MIN_MESSAGES_TO_COMPACT = 5
+
+
+def _produced_fresh_compaction(before: list, after: list) -> bool:
+    """True if ``compress_messages`` actually built a new compact block.
+
+    A successful compaction returns ``[boundary_marker, summary, …]`` — a
+    brand-new first message. Every failure path (circuit breaker open, no
+    safe split, summarization error) instead returns the original list or
+    a microcompacted copy that leaves the first message untouched. Probing
+    for *any* ``[Conversation Summary]`` would misfire when an older summary
+    from a previous compaction is still in history, so key off the freshly
+    prepended ``[Compact Boundary]`` marker instead.
+    """
+    if not after or after[0] is (before[0] if before else None):
+        return False
+    head = after[0].get("content")
+    return isinstance(head, str) and head.startswith("[Compact Boundary")
+
+
+def _dispatch_pre_compact(agent) -> None:
+    """Best-effort ``PreCompact`` plugin-hook dispatch (side-effect only).
+
+    Mirrors ``ChatLoopRunner._dispatch_pre_compact`` — dispatch matching
+    rules *and* emit the ``PLUGIN_HOOK_FIRED`` replay event so manual
+    ``/compact`` runs keep the same observability contract as the
+    threshold-driven path.
+    """
+    rules = getattr(agent, "_plugin_hook_rules", None)
+    if not rules:
+        return
+    try:
+        from ...plugins.hooks import ClaudeHookPayloadAdapter, PluginHookDispatcher
+        from ...transport import AgentEvent, EventType
+
+        cwd = agent.working_directory
+        payload = ClaudeHookPayloadAdapter().build_pre_compact(
+            session_id=agent._session_id,
+            cwd=cwd,
+            compaction_type="full",
+            reason="manual_cli",
+            permission_mode=agent.active_permissions().mode,
+        )
+        dispatcher = PluginHookDispatcher(cwd=cwd)
+        matched = dispatcher.select_matching_rules("PreCompact", payload, rules)
+        if not matched:
+            return
+        dispatcher.dispatch_pre_compact(payload=payload, rules=matched)
+        agent.transport.emit(AgentEvent(EventType.PLUGIN_HOOK_FIRED, {
+            "hook_name": "PreCompact",
+            "outcome": "allow",
+            "compaction_type": "full",
+            "trigger": "manual",
+            "matched_rule_count": len(matched),
+        }))
+    except Exception:
+        pass
+
+
+def handle_compact_command(cli: AgentaoCLI, args: str) -> None:
+    """Handle ``/compact`` — summarize old history into a compact block."""
+    agent = cli.agent
+    cm = agent.context_manager
+    messages = agent.messages
+
+    if len(messages) < _MIN_MESSAGES_TO_COMPACT:
+        console.print(
+            "\n[info]Not enough conversation history to compact yet.[/info]\n"
+        )
+        return
+
+    _dispatch_pre_compact(agent)
+
+    pre_msgs = len(messages)
+    system_prompt = agent._build_system_prompt()
+    pre_tokens = cm.estimate_tokens(
+        [{"role": "system", "content": system_prompt}] + messages
+    )
+
+    t0 = time.monotonic()
+    compacted = cm.compress_messages(messages, is_auto=False)
+
+    if not _produced_fresh_compaction(messages, compacted):
+        console.print(
+            "\n[warning]Compaction made no change — nothing to summarize "
+            "(or summarization failed; see agentao.log).[/warning]\n"
+        )
+        return
+
+    agent.messages = compacted
+    cm._last_api_prompt_tokens = None  # stale after compression
+    system_prompt = agent._build_system_prompt()
+    post_msgs = len(agent.messages)
+    post_tokens = cm.estimate_tokens(
+        [{"role": "system", "content": system_prompt}] + agent.messages
+    )
+
+    agent._emit_context_compressed(
+        compression_type="full",
+        reason="manual_cli",
+        pre_msgs=pre_msgs,
+        post_msgs=post_msgs,
+        pre_tokens=pre_tokens,
+        post_tokens=post_tokens,
+        duration_ms=round((time.monotonic() - t0) * 1000),
+    )
+    # ``_last_session_summary_id`` is created lazily on the first chat turn
+    # (runtime/turn.py); a manual /compact may run before that — e.g. right
+    # after /sessions resume — so fall back to None.
+    agent._last_session_summary_id = agent._emit_session_summary_if_new(
+        getattr(agent, "_last_session_summary_id", None),
+    )
+
+    pct = cm.get_usage_stats(agent.messages).get("usage_percent", 0.0)
+    cli._cached_ctx_pct = pct
+
+    console.print(
+        f"\n[success]Compacted history: {pre_msgs} → {post_msgs} messages, "
+        f"~{pre_tokens:,} → ~{post_tokens:,} tokens "
+        f"({pct:.1f}% of window).[/success]\n"
+    )

--- a/agentao/cli/help_text.py
+++ b/agentao/cli/help_text.py
@@ -65,6 +65,7 @@ All commands start with `/`:
   - `/memory review [approve|reject <id>]` - Review crystallized memory candidates
 - `/context` - Show context window token usage and limit
   - `/context limit <n>` - Set max context tokens (default: 200,000)
+- `/compact` - Summarize older history now into a compact block (manual compaction)
 - `/plugins` - List loaded plugins with diagnostics
 - `/permission` - Show active permission rules
 - `/mcp [subcommand]` - Manage MCP servers

--- a/agentao/cli/input_loop.py
+++ b/agentao/cli/input_loop.py
@@ -148,7 +148,7 @@ def run_loop(cli: "AgentaoCLI") -> None:
         handle_todos_command, handle_plan_command, handle_provider_command,
         handle_model_command, handle_temperature_command, handle_context_command,
         handle_mcp_command, handle_permission_command, handle_sessions_command,
-        handle_tools_command, handle_sandbox_command,
+        handle_tools_command, handle_sandbox_command, handle_compact_command,
     )
     from .replay_commands import handle_replay_command
     from .commands_ext import (
@@ -292,6 +292,10 @@ def run_loop(cli: "AgentaoCLI") -> None:
 
                 elif command == "context":
                     handle_context_command(cli, args)
+                    continue
+
+                elif command == "compact":
+                    handle_compact_command(cli, args)
                     continue
 
                 elif command == "mcp":

--- a/tests/test_compact_command.py
+++ b/tests/test_compact_command.py
@@ -1,0 +1,83 @@
+"""Tests for the manual /compact slash command."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from agentao.cli.commands import handle_compact_command
+
+
+def _cli_with_messages(messages: list[dict], compacted: list[dict] | None = None):
+    cm = Mock()
+    cm.CIRCUIT_BREAKER_LIMIT = 3
+    cm.estimate_tokens.side_effect = [1000, 250]
+    cm.compress_messages.return_value = compacted if compacted is not None else messages
+    cm.get_usage_stats.return_value = {
+        "usage_percent": 12.5,
+        "circuit_breaker_failures": 0,
+    }
+    agent = SimpleNamespace(
+        messages=messages,
+        context_manager=cm,
+        _plugin_hook_rules=[],
+        _last_session_summary_id=None,
+        _build_system_prompt=Mock(return_value="system"),
+        _emit_context_compressed=Mock(),
+        _emit_session_summary_if_new=Mock(return_value="summary-id"),
+    )
+    cli = SimpleNamespace(agent=agent, _cached_ctx_pct=0.0)
+    return cli, agent, cm
+
+
+def test_compact_command_updates_history_and_emits_event():
+    messages = [{"role": "user", "content": f"m{i}"} for i in range(10)]
+    compacted = [
+        {"role": "system", "content": "[Compact Boundary | auto=False]"},
+        {"role": "system", "content": "[Conversation Summary]\nsummary"},
+        {"role": "user", "content": "recent"},
+    ]
+    cli, agent, cm = _cli_with_messages(messages, compacted)
+
+    handle_compact_command(cli, "")
+
+    assert agent.messages == compacted
+    cm.compress_messages.assert_called_once_with(messages, is_auto=False)
+    agent._emit_context_compressed.assert_called_once()
+    kwargs = agent._emit_context_compressed.call_args.kwargs
+    assert kwargs["compression_type"] == "full"
+    assert kwargs["reason"] == "manual_cli"
+    assert kwargs["pre_msgs"] == 10
+    assert kwargs["post_msgs"] == 3
+    assert cli._cached_ctx_pct == 12.5
+
+
+def test_compact_command_no_change_keeps_history():
+    messages = [{"role": "user", "content": f"m{i}"} for i in range(10)]
+    cli, agent, cm = _cli_with_messages(messages)  # compress_messages returns same list
+
+    handle_compact_command(cli, "")
+
+    assert agent.messages == messages
+    agent._emit_context_compressed.assert_not_called()
+
+
+def test_compact_command_treats_summarization_failure_as_no_change():
+    # compress_messages can return a *new* list (microcompacted copy) without
+    # ever producing a [Conversation Summary] — that must not count as success.
+    messages = [{"role": "user", "content": f"m{i}"} for i in range(10)]
+    failed = [dict(m) for m in messages]
+    cli, agent, cm = _cli_with_messages(messages, failed)
+
+    handle_compact_command(cli, "")
+
+    assert agent.messages == messages
+    agent._emit_context_compressed.assert_not_called()
+
+
+def test_compact_command_skips_short_history():
+    messages = [{"role": "user", "content": "short"} for _ in range(4)]
+    cli, agent, cm = _cli_with_messages(messages)
+
+    handle_compact_command(cli, "")
+
+    cm.compress_messages.assert_not_called()
+    agent._emit_context_compressed.assert_not_called()


### PR DESCRIPTION
## Summary

Adds a `/compact` CLI command that runs full conversation-history compaction on demand, mirroring the threshold-driven path in `runtime/chat_loop/_compaction.py`:

- Dispatches the `PreCompact` plugin hook and emits the matching `PLUGIN_HOOK_FIRED` replay event (`trigger="manual"`), keeping the same observability contract as automatic compaction.
- Calls `ContextManager.compress_messages(is_auto=False)`, swaps in the summarized history, and emits `CONTEXT_COMPRESSED` + session-summary events.
- Success detection keys off the freshly prepended `[Compact Boundary]` marker, so a no-op (circuit breaker open / no safe split / summarization failure) reports "no change" rather than misfiring when a stale `[Conversation Summary]` from a prior compaction is still in history.
- Reads `_last_session_summary_id` via `getattr` so `/compact` works before the first chat turn (e.g. right after `/sessions resume`).
- Wired into `input_loop` dispatch, slash-command completion (`_utils.py`), and help text; documented in `CLAUDE.md`.

## Test plan

- `uv run python -m pytest tests/test_compact_command.py` — 4 passed (covers history swap + event emission, no-op keeps history, summarization-failure treated as no-op, short-history skip).
- Broader CLI/command suite: 359 passed, no regressions.
- Reviewed via `/codex:review` across iterations — no remaining actionable findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)