### PR TITLE
feat(hooks): decision-capable PreToolUse hooks

### DIFF
--- a/agentao/plugins/hooks/_dispatcher.py
+++ b/agentao/plugins/hooks/_dispatcher.py
@@ -25,6 +25,7 @@ from ..models import (
     CLAUDE_FLAT_EVENTS,
     HookAttachmentRecord,
     ParsedHookRule,
+    PreToolUseHookResult,
     StopHookResult,
     UserPromptSubmitResult,
 )
@@ -72,7 +73,43 @@ class PluginHookDispatcher:
         payload: dict[str, Any],
         rules: list[ParsedHookRule],
     ) -> list[HookAttachmentRecord]:
+        """Side-effect-only PreToolUse dispatch — returns attachments only.
+
+        .. deprecated::
+           Production code uses :meth:`dispatch_pre_tool_use_decision`,
+           which also parses the ``permissionDecision`` control surface.
+           This wrapper is kept for the lifecycle-dispatch tests.
+        """
         return self._dispatch_lifecycle("PreToolUse", payload, rules)
+
+    def dispatch_pre_tool_use_decision(
+        self,
+        *,
+        payload: dict[str, Any],
+        rules: list[ParsedHookRule],
+    ) -> PreToolUseHookResult:
+        """Run matching PreToolUse hooks; aggregate a permission decision.
+
+        Unlike :meth:`dispatch_pre_tool_use` (side-effect only, returns
+        attachments), this parses each hook's stdout for the Claude
+        Code-compatible ``hookSpecificOutput.permissionDecision`` shape
+        (``allow`` / ``deny`` / ``ask``) and merges the verdicts: the
+        first ``deny`` wins; otherwise the first ``ask`` wins; ``allow``
+        is a no-op. Stops forking subprocesses once a ``deny`` is seen.
+        Exit-code-2 "block" is intentionally NOT honored here — only the
+        JSON shape — matching the documented MVP scope. ``additionalContext``
+        is parsed and recorded on the result but not injected.
+        """
+        result = PreToolUseHookResult()
+        matched = self.select_matching_rules("PreToolUse", payload, rules)
+        result.matched_rule_count = len(matched)
+        for rule in matched:
+            if rule.hook_type != "command":
+                continue
+            self._run_pre_tool_use_command(rule, payload, result)
+            if result.decision == "deny":
+                break
+        return result
 
     def dispatch_post_tool_use(
         self,
@@ -202,18 +239,22 @@ class PluginHookDispatcher:
 
         return True
 
-    def _run_lifecycle_command(
-        self, rule: ParsedHookRule, payload: dict[str, Any]
-    ) -> HookAttachmentRecord | None:
-        """Execute a single lifecycle command hook.  Returns attachment or None."""
-        if not rule.command:
-            return None
+    def _run_subprocess(
+        self, rule: ParsedHookRule, payload: dict[str, Any],
+    ) -> tuple[subprocess.CompletedProcess[str] | None, bool]:
+        """Run ``rule.command`` with the JSON payload on stdin.
 
-        payload_json = json.dumps(payload)
+        Returns ``(proc, timed_out)``: ``proc`` is the completed process,
+        or ``None`` when the command timed out (``timed_out=True``), or
+        when it is empty / failed to start (``timed_out=False``). A
+        warning is logged on timeout and spawn failure.
+        """
+        if not rule.command:
+            return None, False
         try:
             proc = subprocess.run(
                 rule.command,
-                input=payload_json,
+                input=json.dumps(payload),
                 capture_output=True,
                 text=True,
                 timeout=rule.timeout,
@@ -221,15 +262,32 @@ class PluginHookDispatcher:
                 cwd=str(self._cwd),
             )
         except subprocess.TimeoutExpired:
-            logger.warning("Lifecycle hook timed out: %s (%s)", rule.event, rule.command)
-            return _make_attachment(
-                "hook_success",
-                {"warning": f"Hook timed out after {rule.timeout}s"},
-                hook_name=rule.command,
-                hook_event=rule.event,
+            logger.warning(
+                "%s hook timed out after %ds: %s", rule.event, rule.timeout, rule.command,
             )
+            return None, True
         except OSError as exc:
-            logger.warning("Lifecycle hook failed: %s (%s)", rule.command, exc)
+            logger.warning("%s hook failed to run: %s (%s)", rule.event, rule.command, exc)
+            return None, False
+        return proc, False
+
+    @staticmethod
+    def _timeout_attachment(rule: ParsedHookRule) -> HookAttachmentRecord:
+        return _make_attachment(
+            "hook_success",
+            {"warning": f"Hook timed out after {rule.timeout}s"},
+            hook_name=rule.command,
+            hook_event=rule.event,
+        )
+
+    def _run_lifecycle_command(
+        self, rule: ParsedHookRule, payload: dict[str, Any]
+    ) -> HookAttachmentRecord | None:
+        """Execute a single lifecycle command hook.  Returns attachment or None."""
+        proc, timed_out = self._run_subprocess(rule, payload)
+        if timed_out:
+            return self._timeout_attachment(rule)
+        if proc is None:
             return None
 
         if proc.returncode != 0:
@@ -244,6 +302,79 @@ class PluginHookDispatcher:
             hook_name=rule.command,
             hook_event=rule.event,
         )
+
+    # ------------------------------------------------------------------
+    # PreToolUse decision parsing (Phase 6, decision-capable)
+    # ------------------------------------------------------------------
+
+    def _run_pre_tool_use_command(
+        self,
+        rule: ParsedHookRule,
+        payload: dict[str, Any],
+        result: PreToolUseHookResult,
+    ) -> None:
+        """Run one PreToolUse command hook and fold its verdict into ``result``."""
+        proc, _timed_out = self._run_subprocess(rule, payload)
+        if proc is None:  # empty / timed out / failed to start — warning already logged
+            return
+
+        if proc.returncode != 0:
+            # MVP scope: exit-code-2 "block" is not honored — surface a
+            # warning like other lifecycle hooks. Any JSON on stdout is
+            # still parsed below.
+            logger.warning(
+                "PreToolUse hook exited %d: %s (stderr: %s)",
+                proc.returncode, rule.command, (proc.stderr or "")[:200],
+            )
+
+        stdout = (proc.stdout or "").strip()
+        if not stdout:
+            return
+
+        try:
+            data = json.loads(stdout)
+        except json.JSONDecodeError:
+            result.additional_contexts.append(stdout)
+            return
+        if not isinstance(data, dict):
+            result.additional_contexts.append(str(data))
+            return
+
+        decision: str | None = None
+        reason: str | None = None
+        hook_specific = data.get("hookSpecificOutput")
+        if isinstance(hook_specific, dict):
+            raw_decision = hook_specific.get("permissionDecision")
+            if isinstance(raw_decision, str) and raw_decision in ("allow", "deny", "ask"):
+                decision = raw_decision
+            for key in ("permissionDecisionReason", "reason"):
+                rv = hook_specific.get(key)
+                if isinstance(rv, str):
+                    reason = rv
+                    break
+            self._harvest_additional_context(hook_specific.get("additionalContext"), result)
+
+        # Tolerate top-level ``reason`` / ``additionalContext`` for hook
+        # scripts that don't nest under ``hookSpecificOutput``.
+        if reason is None and isinstance(data.get("reason"), str):
+            reason = data["reason"]
+        self._harvest_additional_context(data.get("additionalContext"), result)
+
+        # ``deny`` always wins (and the caller stops forking further hooks);
+        # ``ask`` only takes hold if nothing stronger has been seen.
+        if decision == "deny":
+            result.decision = "deny"
+            result.reason = reason
+        elif decision == "ask" and result.decision is None:
+            result.decision = "ask"
+            result.reason = reason
+
+    @staticmethod
+    def _harvest_additional_context(ctx: Any, result: PreToolUseHookResult) -> None:
+        if isinstance(ctx, str):
+            result.additional_contexts.append(ctx)
+        elif isinstance(ctx, list):
+            result.additional_contexts.extend(str(c) for c in ctx)
 
     # ------------------------------------------------------------------
     # UserPromptSubmit dispatch (Phase 5)
@@ -285,33 +416,11 @@ class PluginHookDispatcher:
         payload: dict[str, Any],
         result: UserPromptSubmitResult,
     ) -> None:
-        if not rule.command:
+        proc, timed_out = self._run_subprocess(rule, payload)
+        if timed_out:
+            result.messages.append(self._timeout_attachment(rule))
             return
-
-        payload_json = json.dumps(payload)
-        try:
-            proc = subprocess.run(
-                rule.command,
-                input=payload_json,
-                capture_output=True,
-                text=True,
-                timeout=rule.timeout,
-                shell=True,
-                cwd=str(self._cwd),
-            )
-        except subprocess.TimeoutExpired:
-            logger.warning("Hook command timed out after %ds: %s", rule.timeout, rule.command)
-            result.messages.append(
-                _make_attachment(
-                    "hook_success",
-                    {"warning": f"Hook timed out after {rule.timeout}s"},
-                    hook_name=rule.command,
-                    hook_event=rule.event,
-                )
-            )
-            return
-        except OSError as exc:
-            logger.warning("Hook command failed to run: %s (%s)", rule.command, exc)
+        if proc is None:
             return
 
         if proc.returncode != 0 and not proc.stdout.strip():
@@ -439,35 +548,11 @@ class PluginHookDispatcher:
         benign warning, which would silently drop the most common Claude
         Stop control signal.
         """
-        if not rule.command:
+        proc, timed_out = self._run_subprocess(rule, payload)
+        if timed_out:
+            result.messages.append(self._timeout_attachment(rule))
             return
-
-        payload_json = json.dumps(payload)
-        try:
-            proc = subprocess.run(
-                rule.command,
-                input=payload_json,
-                capture_output=True,
-                text=True,
-                timeout=rule.timeout,
-                shell=True,
-                cwd=str(self._cwd),
-            )
-        except subprocess.TimeoutExpired:
-            logger.warning(
-                "Stop hook timed out after %ds: %s", rule.timeout, rule.command,
-            )
-            result.messages.append(
-                _make_attachment(
-                    "hook_success",
-                    {"warning": f"Hook timed out after {rule.timeout}s"},
-                    hook_name=rule.command,
-                    hook_event="Stop",
-                )
-            )
-            return
-        except OSError as exc:
-            logger.warning("Stop hook failed to run: %s (%s)", rule.command, exc)
+        if proc is None:
             return
 
         # Exit code 2 is checked BEFORE the JSON parser so ``continue:

--- a/agentao/plugins/models.py
+++ b/agentao/plugins/models.py
@@ -299,6 +299,30 @@ class UserPromptSubmitResult:
 
 
 @dataclass
+class PreToolUseHookResult:
+    """Aggregated decision from all PreToolUse hooks for one tool call.
+
+    ``decision`` is the merged Claude Code-compatible
+    ``hookSpecificOutput.permissionDecision`` — ``"deny"`` / ``"ask"`` /
+    ``None`` (continue). Merge rule: the first ``deny`` wins; otherwise
+    the first ``ask`` wins; ``"allow"`` from a hook is a no-op and is
+    never recorded here. ``reason`` is the human-readable reason that
+    accompanied the winning decision, if any. ``additional_contexts`` is
+    parsed and recorded but intentionally NOT injected into the model or
+    tool execution path in this minimal version. ``matched_rule_count``
+    is the selection count and gates ``PLUGIN_HOOK_FIRED`` emission.
+
+    Exit-code-2 "block" is intentionally not honored — only the JSON
+    shape — matching the documented MVP scope.
+    """
+
+    decision: Literal["deny", "ask"] | None = None
+    reason: str | None = None
+    additional_contexts: list[str] = field(default_factory=list)
+    matched_rule_count: int = 0
+
+
+@dataclass
 class StopHookResult:
     """Aggregated result of all hooks for a single Stop event.
 

--- a/agentao/runtime/tool_executor.py
+++ b/agentao/runtime/tool_executor.py
@@ -32,7 +32,7 @@ from ..sandbox import SandboxMisconfiguredError, SandboxPolicy
 from ..tools.base import AsyncToolBase
 from ..transport import AgentEvent, EventType
 from . import identity as _identity
-from .tool_planning import ToolCallDecision, ToolCallPlan
+from .tool_planning import ToolCallDecision, ToolCallPlan, is_pre_tool_hook_reason
 
 if TYPE_CHECKING:  # pragma: no cover - import-time only
     from ..host.projection import HostToolEmitter
@@ -196,29 +196,42 @@ class ToolExecutor:
         call_id = plan.tool_call_id
         t0 = time.monotonic()
 
+        # ``TOOL_START`` is emitted unconditionally — before the deny/cancel
+        # guards — so it always pairs with the ``TOOL_COMPLETE`` below for
+        # *every* call_id. ACP (``tool_call`` → ``tool_call_update``), replay
+        # (``TOOL_STARTED`` → ``TOOL_COMPLETED``), and the CLI run loop all
+        # rely on that pairing; a denied call still gets ``TOOL_START`` here
+        # and ``TOOL_COMPLETE`` with ``status="cancelled"`` just below. The
+        # *host* ``ToolLifecycleEvent(started)`` is the start signal that does
+        # NOT fire for denied calls — it's emitted only on the ALLOW path.
         self._transport.emit(AgentEvent(EventType.TOOL_START, {
             "tool": fn, "args": args, "call_id": call_id,
         }))
 
         if decision == ToolCallDecision.DENY:
             self._logger.info(f"Tool {fn} denied")
+            detail = plan.permission_detail
+            deny_reason = detail.reason if detail is not None else None
             if readonly_mode and not tool.is_read_only:
                 result_text = (
                     f"[Readonly mode] Tool '{fn}' is blocked — "
                     f"only read-only tools are permitted in readonly mode."
                 )
+                summary = "denied by permission engine"
+            elif is_pre_tool_hook_reason(deny_reason):
+                result_text = f"Tool execution blocked by a PreToolUse hook: '{fn}'."
+                summary = "denied by pre-tool-use hook"
             else:
                 result_text = (
                     f"Tool execution denied: '{fn}' is not permitted "
                     f"by the current permission rules."
                 )
-            self._emit_complete(fn, call_id, "cancelled", 0, "denied by permission engine")
-            self._emit_host_terminal_cancelled(
-                fn, call_id, summary="denied by permission engine",
-            )
+                summary = "denied by permission engine"
+            self._emit_complete(fn, call_id, "cancelled", 0, summary)
+            self._emit_host_terminal_cancelled(fn, call_id, summary=summary)
             return call_id, ToolExecutionResult(
                 fn_name=fn, result=result_text, status="cancelled",
-                duration_ms=0, error="denied by permission engine",
+                duration_ms=0, error=summary,
             )
 
         if decision == ToolCallDecision.CANCELLED:
@@ -269,10 +282,6 @@ class ToolExecutor:
                 fn_name=fn, result=result_text, status="cancelled",
                 duration_ms=duration_ms, error="cancelled by user",
             )
-
-        self._dispatch_pre_tool_hook(
-            fn, args, rules=hook_rules, cwd=hook_cwd, session_id=hook_session_id,
-        )
 
         # Inject macOS sandbox profile for run_shell_command when policy is
         # enabled. Private kwarg — never exposed to LLM or to plugin
@@ -569,28 +578,12 @@ class ToolExecutor:
 
     # ------------------------------------------------------------------
     # Plugin hook dispatch (each helper short-circuits on empty rules)
+    #
+    # PreToolUse is *not* dispatched here. It is decision-capable and
+    # runs in ``ToolRunner`` (Phase 1.5) before the PermissionDecisionEvent
+    # emit and before any tool ``started`` event, so a hook ``deny`` / ``ask``
+    # is reflected in the public event ordering without special-casing.
     # ------------------------------------------------------------------
-
-    def _dispatch_pre_tool_hook(
-        self,
-        tool_name: str,
-        tool_args: Dict[str, Any],
-        *,
-        rules: Optional[list],
-        cwd: Optional[Path],
-        session_id: Optional[str],
-    ) -> None:
-        if not rules:
-            return
-        try:
-            from ..plugins.hooks import PluginHookDispatcher
-            payload = self._hook_adapter.build_pre_tool_use(
-                tool_name=tool_name, tool_input=tool_args, session_id=session_id,
-            )
-            dispatcher = PluginHookDispatcher(cwd=cwd)
-            dispatcher.dispatch_pre_tool_use(payload=payload, rules=rules)
-        except Exception as exc:
-            self._logger.warning("PreToolUse hook dispatch error: %s", exc)
 
     def _dispatch_post_tool_hook(
         self,

--- a/agentao/runtime/tool_planning.py
+++ b/agentao/runtime/tool_planning.py
@@ -33,6 +33,12 @@ DOOM_LOOP_THRESHOLD = 3
 # garbage JSON for the same tool would loop forever.
 PARSE_FAILURE_THRESHOLD = 3
 
+# ``PermissionDecisionDetail.reason`` prefix stamped on decisions that
+# originate from a PreToolUse plugin hook (vs the permission engine).
+# ``ToolExecutor`` checks for it to tailor the model-facing deny message.
+# The full reason is either exactly this string or ``"<prefix>: <hook reason>"``.
+PRE_TOOL_HOOK_REASON = "pre-tool-hook"
+
 
 def _synth(
     decision: PermissionDecision,
@@ -41,6 +47,18 @@ def _synth(
     """Synthesize a public-event detail for paths with no matched rule."""
     return PermissionDecisionDetail(
         decision, matched_rule=None, reason=reason,
+    )
+
+
+def pre_tool_hook_reason(hook_reason: str | None) -> str:
+    """Build the ``PermissionDecisionDetail.reason`` for a hook decision."""
+    return f"{PRE_TOOL_HOOK_REASON}: {hook_reason}" if hook_reason else PRE_TOOL_HOOK_REASON
+
+
+def is_pre_tool_hook_reason(reason: str | None) -> bool:
+    """True if ``reason`` was produced by :func:`pre_tool_hook_reason`."""
+    return reason == PRE_TOOL_HOOK_REASON or (
+        reason is not None and reason.startswith(PRE_TOOL_HOOK_REASON + ": ")
     )
 
 

--- a/agentao/runtime/tool_runner.py
+++ b/agentao/runtime/tool_runner.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING, Tuple
 
-from ..permissions import PermissionEngine
+from ..permissions import PermissionDecision, PermissionEngine
 from ..sandbox import SandboxPolicy
 from ..tools import ToolRegistry
 from ..transport import AgentEvent, EventType
@@ -13,7 +13,9 @@ from .tool_executor import ToolExecutor
 from .tool_planning import (
     ToolCallDecision,
     ToolCallPlanner,
+    _synth,
     make_tool_result_message,
+    pre_tool_hook_reason,
 )
 from .tool_result_formatter import ToolResultFormatter
 
@@ -185,6 +187,17 @@ class ToolRunner:
         if not _plans:
             return False, result_messages
 
+        # --- Phase 1.5: PreToolUse hook policy (decision-capable) ---
+        # A PreToolUse hook may deny a tool call outright or downgrade it
+        # to "ask" (which then flows through the same Phase 2 confirmation
+        # path). This runs *before* the PermissionDecisionEvent emit and
+        # *before* any tool starts, so a hook-derived decision lands in the
+        # public event ordering (decision precedes started) without
+        # special-casing. A hook ``allow`` is a no-op — it never downgrades
+        # an engine deny/ask or a tool's own requires_confirmation ask.
+        if self._plugin_hook_rules:
+            self._apply_pre_tool_use_hooks(_plans)
+
         # PermissionDecisionEvent must precede the tool's started event
         # for the same tool_call_id; firing here, before Phase 2 / 3,
         # honours that. Skip the per-plan loop entirely when no host is
@@ -230,6 +243,80 @@ class ToolRunner:
         # --- Phase 4: Result formatting (delegated to ToolResultFormatter) ---
         result_messages.extend(self._formatter.format_batch(_plans, _exec_results))
         return False, result_messages
+
+    # ------------------------------------------------------------------
+    # PreToolUse hook policy (Phase 1.5)
+    # ------------------------------------------------------------------
+
+    def _apply_pre_tool_use_hooks(self, plans) -> None:
+        """Let PreToolUse hooks deny / downgrade-to-ask each planned call.
+
+        Mutates ``plan.decision`` / ``plan.permission_detail`` in place so
+        the downstream PermissionDecisionEvent and Phase 2 confirmation see
+        the post-hook state. Hook-derived decisions are attributed via the
+        existing ``reason`` field (prefixed ``pre-tool-hook``); no new
+        public field is introduced. Dispatch errors are swallowed with a
+        warning — a broken hook must not wedge tool execution.
+        """
+        pre_rules = [
+            r for r in self._plugin_hook_rules
+            if r.event == "PreToolUse" and r.is_supported
+        ]
+        if not pre_rules:
+            return
+
+        from ..plugins.hooks import ClaudeHookPayloadAdapter, PluginHookDispatcher
+
+        adapter = ClaudeHookPayloadAdapter()
+        dispatcher = PluginHookDispatcher(cwd=self._working_directory)
+        for plan in plans:
+            # An already-DENY plan can't be made "more denied"; skip the fork.
+            if plan.decision not in (ToolCallDecision.ALLOW, ToolCallDecision.ASK):
+                continue
+            payload = adapter.build_pre_tool_use(
+                tool_name=plan.function_name,
+                tool_input=plan.function_args,
+                session_id=self._session_id,
+            )
+            try:
+                hook_result = dispatcher.dispatch_pre_tool_use_decision(
+                    payload=payload, rules=pre_rules,
+                )
+            except Exception as exc:  # pragma: no cover - defensive
+                self._logger.warning("PreToolUse hook dispatch error: %s", exc)
+                continue
+            if hook_result.matched_rule_count == 0:
+                continue
+
+            # Replay parity with the other hook sites.
+            try:
+                self._transport.emit(AgentEvent(EventType.PLUGIN_HOOK_FIRED, {
+                    "hook_name": "PreToolUse",
+                    "tool": plan.function_name,
+                    "outcome": hook_result.decision or "allow",
+                    "matched_rule_count": hook_result.matched_rule_count,
+                    "added_context_count": len(hook_result.additional_contexts),
+                }))
+            except Exception:
+                pass
+
+            if hook_result.additional_contexts:
+                # MVP: recorded, not injected into the model or tool path.
+                self._logger.info(
+                    "PreToolUse hook returned additionalContext for '%s' "
+                    "(not injected): %d block(s)",
+                    plan.function_name, len(hook_result.additional_contexts),
+                )
+
+            reason = pre_tool_hook_reason(hook_result.reason)
+            if hook_result.decision == "deny":
+                plan.decision = ToolCallDecision.DENY
+                plan.permission_detail = _synth(PermissionDecision.DENY, reason)
+            elif hook_result.decision == "ask" and plan.decision == ToolCallDecision.ALLOW:
+                plan.decision = ToolCallDecision.ASK
+                plan.permission_detail = _synth(PermissionDecision.ASK, reason)
+            # ``allow`` / no decision → no-op (must not downgrade an existing
+            # engine deny/ask or a tool's own requires_confirmation ask).
 
     # ------------------------------------------------------------------
     # Public-event helpers

--- a/docs/design/codex-reverse-review.md
+++ b/docs/design/codex-reverse-review.md
@@ -1,0 +1,264 @@
+# Codex Reverse Review for Agentao
+
+Date: 2026-05-12
+
+This note records the reverse review of the latest Codex changes against
+Agentao's current architecture. The goal is to identify what Agentao actually
+needs, not to mirror Codex's product shape.
+
+## Summary
+
+Codex's recent architecture work is mostly driven by Codex-specific scale:
+app-server, remote environments, multiple workspaces, Windows enterprise
+sandboxing, and a broader extension surface. Agentao should not copy that
+weight by default.
+
+For Agentao, the immediate gaps are narrower:
+
+1. Make `PreToolUse` hooks minimally decision-capable instead of
+   fire-and-forget.
+2. Add a small host-facing telemetry increment for model latency, first token
+   latency, and turn-level aggregates.
+
+The host contract is already mostly done and should not be treated as a fresh
+P0 project.
+
+## Current State Check
+
+### Host Contract
+
+Status: mostly complete.
+
+Evidence:
+
+- `agentao/host/models.py` defines the public lifecycle models:
+  `ToolLifecycleEvent`, `SubagentLifecycleEvent`, and
+  `PermissionDecisionEvent`.
+- `turn_id` and `tool_call_id` are already present on the public event surface.
+- `docs/schema/host.events.v1.json` and `docs/schema/host.acp.v1.json` are
+  checked-in schema snapshots.
+- Host schema tests already assert snapshot compatibility.
+
+Remaining work is small: keep public API signature tests and schema snapshots
+tight. This is maintenance, not a P0 architecture gap.
+
+### PreToolUse Hooks
+
+Status: real gap — **resolved 2026-05-12** (see "Status — implemented" under
+P0 below). The description below is the pre-fix state, kept for context.
+
+`agentao/runtime/tool_executor.py::_dispatch_pre_tool_hook()` discards the
+dispatcher's return value. `PluginHookDispatcher.dispatch_pre_tool_use(...)`
+runs the matching hooks and returns a list of attachment records, but the
+executor drops it and the dispatcher never parses any control fields out of
+hook stdout for `PreToolUse` (only the `Stop` path parses
+`decision` / `hookSpecificOutput`; `PreToolUse` goes through
+`_dispatch_lifecycle` → `_run_lifecycle_command`, which only wraps stdout in an
+attachment). So `PreToolUse` is observational only:
+
+- hook output cannot deny a tool call;
+- hook output cannot ask for confirmation;
+- hook-provided context is not injected into the execution path;
+- host/replay consumers do not see a permission decision caused by the hook.
+
+This is the primary P0. Note the change spans two layers: the dispatcher must
+learn to parse `permissionDecision` out of `PreToolUse` hook stdout, and the
+executor must consume the parsed decision.
+
+There is also an event-ordering constraint. `_dispatch_pre_tool_hook()` is
+called at `tool_executor.py:273` — *after* the permission/cancel guards and
+*after* `host_tool_emitter.started()` has already fired (line 251). The
+existing ordering contract (code comment at `tool_executor.py:244-247`)
+requires `PermissionDecisionEvent` to precede `ToolLifecycleEvent(started)` for
+the same `tool_call_id`. Making the hook decision-capable therefore requires
+moving the hook dispatch *before* the `started` emission, and emitting a
+`cancelled` terminal event for any tool that already emitted `started` and is
+then denied by a hook.
+
+### Telemetry
+
+Status: partially present.
+
+Existing pieces:
+
+- `agentao/runtime/llm_call.py` emits `LLM_CALL_STARTED` and
+  `LLM_CALL_COMPLETED`.
+- LLM call completion already includes `duration_ms`.
+- Tool lifecycle events carry timestamps, so tool duration can be derived.
+- Context compaction paths already emit duration in transport/replay events.
+
+Missing pieces:
+
+- host-facing `model_latency_ms` — this is a forward/rename of the existing
+  `duration_ms` already on `LLM_CALL_COMPLETED`, not a new measurement;
+- `first_token_ms` / TTFT — feasible today because `llm_call.py` is streaming
+  (`chat_stream` + `LLM_CALL_DELTA`); TTFT = timestamp of the first
+  `LLM_CALL_DELTA` minus call start. The data already flows through transport;
+  only aggregation is missing. No LLM-client change required;
+- turn-level tool count;
+- stable public/replay placement for context compaction duration.
+
+This is useful and low-cost, but it is P1 rather than P0.
+
+## P0: Minimal Decision-Capable PreToolUse
+
+`PreToolUse` should use the Claude Code-compatible
+`hookSpecificOutput.permissionDecision` shape. Do not reuse the Stop/PreCompact
+`decision: "block"` or `preventContinuation` semantics. Those mean "prevent
+Stop and continue the agent loop", which is different from rejecting a tool
+call.
+
+Keep the first implementation deliberately small. The goal is to close the
+current fire-and-forget hole, not to introduce a new hook policy subsystem.
+
+Supported output shape:
+
+```json
+{
+  "hookSpecificOutput": {
+    "permissionDecision": "allow",
+    "reason": "optional human-readable reason",
+    "additionalContext": "optional structured context"
+  }
+}
+```
+
+Recognized `permissionDecision` values:
+
+- `allow`
+- `deny`
+- `ask`
+
+MVP behavior:
+
+- `deny` cancels the current tool call.
+- `ask` must reuse the existing confirmation path through the transport
+  permission prompt. Do not introduce a separate interaction channel.
+- `deny` and `ask` must produce a `PermissionDecisionEvent`.
+- Replay must record the decision with enough metadata to explain why the tool
+  was blocked or prompted.
+- Do not add a new public `source` field just for this. Use existing
+  `reason`/`matched_rule` fields to mark hook-derived decisions, for example
+  `pre-tool-hook`. (Replay/projection consumers must tolerate the new origin
+  string without a schema bump — it is just another value in an existing
+  string field.)
+- `allow` is a no-op in the MVP. It must not downgrade an existing
+  `deny`/`ask` from the permission engine.
+- If multiple hooks return decisions, keep merge behavior simple:
+  first `deny` wins; otherwise first `ask` wins; otherwise continue.
+- `additionalContext` should be parsed and recorded as hook output, but should
+  not be injected into the model or tool execution path in the MVP. Today's
+  `PreToolUse` attachments are only returned by the dispatcher and discarded by
+  the executor; they are not wired into the UserPromptSubmit
+  `_attachment_to_message` prompt-injection path.
+
+Precedence (must be stated, not left implicit):
+
+- A hook `deny`/`ask` *overrides* an `allow` from the permission engine
+  (allowlist auto-allow or a prior user "allow"). Otherwise P0 has no effect.
+- A hook `allow` never overrides an engine `deny`/`ask` (already stated above).
+- A hook `ask` is implemented by setting the plan decision to `ASK`, so it
+  reuses the *same* Phase 2 confirmation path as any other prompt — and is
+  therefore subject to the `allow_all_tools` / full-access session state like
+  any other prompt. Letting a hook `ask` bypass that toggle would need a new
+  flag on `Transport.confirm_tool`, which is out of scope for the MVP; revisit
+  if a host needs it.
+
+Event ordering (part of P0 scope, see "Current State Check"):
+
+- Move the hook dispatch to before the `host_tool_emitter.started()` emission
+  so a hook-derived `PermissionDecisionEvent` precedes `ToolLifecycleEvent(started)`.
+- If a tool has already emitted `started` and is then denied/asked-and-cancelled
+  by a hook, emit a `cancelled` terminal event for it.
+
+Out of scope for P0:
+
+- public host schema changes;
+- context injection into the model prompt;
+- exit-code-based deny for `PreToolUse` (Claude Code honors exit code 2 =
+  block, stderr → model); MVP supports only the JSON `permissionDecision`
+  shape — see Non-Goals;
+- `updatedInput`
+- arbitrary argument rewriting
+- complex multi-hook policy merging
+- new extension APIs
+
+### Status — implemented 2026-05-12
+
+Landed:
+
+- `PluginHookDispatcher.dispatch_pre_tool_use_decision()` parses the
+  `hookSpecificOutput.permissionDecision` shape (`allow` / `deny` / `ask`),
+  merges verdicts (first `deny` wins, then first `ask`), stops forking on the
+  first `deny`, and records `additionalContext` on a new
+  `PreToolUseHookResult` without injecting it. Exit-code-2 "block" is not
+  honored. The old side-effect-only `dispatch_pre_tool_use()` is left intact
+  for callers that just want attachments.
+- The fire-and-forget `_dispatch_pre_tool_hook()` in
+  `runtime/tool_executor.py` is removed; PreToolUse now runs in
+  `ToolRunner._apply_pre_tool_use_hooks()` as Phase 1.5 — before the
+  `PermissionDecisionEvent` emit and before any tool `started` event, so the
+  ordering contract holds without an after-the-fact `cancelled`.
+- A hook `deny` flips the plan to `DENY`; a hook `ask` flips an `ALLOW` plan to
+  `ASK` (flows through Phase 2 confirmation); `allow`/no-decision is a no-op.
+  Hook-derived decisions carry `reason = "pre-tool-hook[: <hook reason>]"` and
+  `matched_rule = None`; no new public field. A `PLUGIN_HOOK_FIRED` replay
+  event with `hook_name: "PreToolUse"` is emitted for parity with the other
+  hook sites.
+- Tests: `tests/test_hooks_pre_tool_use_decision.py` (dispatcher parsing/merge
+  + runner Phase 1.5 wiring, including the deny/ask/allow precedence and the
+  no-rules fast path).
+
+## P1: Minimal Telemetry Increment
+
+Add only the small set needed to debug host integrations:
+
+- `model_latency_ms`
+- `first_token_ms`
+- turn-level `tool_count`
+- stable compaction duration field for public/replay consumers
+
+`trace_id`, `turn_id`, and `tool_call_id` are already present or conceptually
+covered. Do not introduce a large SQLite telemetry subsystem unless Agentao's
+deployment model changes.
+
+## P2: Permission Abstraction and Redaction
+
+Read denial is worth modeling in the permission abstraction, but OS-level
+Windows deny-read parity is not a current priority. Agentao's current sandbox
+focus remains local-first and macOS-first.
+
+P2 work:
+
+- add first-class read-deny concepts to the permission model;
+- verify ACP/remote output redaction boundaries;
+- keep OS-specific enforcement separate from the public permission contract.
+
+## Explicit Non-Goals
+
+Do not prioritize these based on Codex alone:
+
+- a large unified extension API;
+- moving guardian/review out of core;
+- multi-environment `apply_patch` selection;
+- OS-level Windows deny-read implementation;
+- exit-code-based deny for `PreToolUse` hooks in the MVP (JSON
+  `permissionDecision` only; exit-code-2 parity can come later);
+- TUI restructuring just because Codex split its TUI modules.
+
+These may become useful later, but current Agentao needs do not justify the
+complexity.
+
+## Final Priority
+
+P0: make `PreToolUse` minimally decision-capable and auditable: support
+hook-driven `deny` and `ask`, record the source through existing event fields,
+fix the hook-dispatch ordering so the decision event precedes `started`, and
+avoid schema or context-injection changes.
+
+P1: add the minimal telemetry fields for model latency, TTFT, compaction
+duration, and turn tool count.
+
+P2: model read-deny and verify ACP/remote redaction.
+
+Everything else should be deferred until Agentao has a concrete product need.

--- a/tests/test_hooks_pre_tool_use_decision.py
+++ b/tests/test_hooks_pre_tool_use_decision.py
@@ -1,0 +1,257 @@
+"""Decision-capable PreToolUse hooks.
+
+Covers the dispatcher's ``dispatch_pre_tool_use_decision`` parsing/merge
+logic and the ``ToolRunner`` Phase 1.5 wiring: a PreToolUse hook may
+``deny`` a tool call outright or downgrade an ``allow`` to ``ask`` (which
+then flows through the existing confirmation path). A hook ``allow`` is a
+no-op. Hook-derived decisions are attributed via the ``reason`` field
+(prefixed ``pre-tool-hook``) and must produce a ``PermissionDecisionEvent``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from types import SimpleNamespace
+from typing import Any, Dict, List
+
+from agentao.host.models import PermissionDecisionEvent, ToolLifecycleEvent
+from agentao.host.projection import HostPermissionEmitter, HostToolEmitter
+from agentao.permissions import PermissionEngine
+from agentao.plugins.hooks import ClaudeHookPayloadAdapter, PluginHookDispatcher
+from agentao.plugins.models import ParsedHookRule
+from agentao.runtime.tool_planning import ToolCallDecision
+from agentao.runtime.tool_runner import ToolRunner
+from agentao.tools import Tool, ToolRegistry
+
+
+# ---------------------------------------------------------------------------
+# Dispatcher-level: parsing + merge
+# ---------------------------------------------------------------------------
+
+
+def _rule(command: str) -> ParsedHookRule:
+    return ParsedHookRule(
+        event="PreToolUse", hook_type="command", command=command, plugin_name="t",
+    )
+
+
+def _echo_json(obj) -> str:
+    # ``shell=True`` — single-quote the JSON so braces/quotes survive.
+    return "echo '" + json.dumps(obj) + "'"
+
+
+def test_dispatch_decision_deny(tmp_path):
+    rule = _rule(_echo_json({
+        "hookSpecificOutput": {"permissionDecision": "deny", "reason": "nope"}
+    }))
+    payload = ClaudeHookPayloadAdapter().build_pre_tool_use(tool_name="run_shell_command")
+    res = PluginHookDispatcher(cwd=tmp_path).dispatch_pre_tool_use_decision(
+        payload=payload, rules=[rule],
+    )
+    assert res.decision == "deny"
+    assert res.reason == "nope"
+    assert res.matched_rule_count == 1
+
+
+def test_dispatch_decision_ask(tmp_path):
+    rule = _rule(_echo_json({"hookSpecificOutput": {"permissionDecision": "ask"}}))
+    payload = ClaudeHookPayloadAdapter().build_pre_tool_use(tool_name="read_file")
+    res = PluginHookDispatcher(cwd=tmp_path).dispatch_pre_tool_use_decision(
+        payload=payload, rules=[rule],
+    )
+    assert res.decision == "ask"
+
+
+def test_dispatch_decision_allow_is_none(tmp_path):
+    rule = _rule(_echo_json({"hookSpecificOutput": {"permissionDecision": "allow"}}))
+    payload = ClaudeHookPayloadAdapter().build_pre_tool_use(tool_name="read_file")
+    res = PluginHookDispatcher(cwd=tmp_path).dispatch_pre_tool_use_decision(
+        payload=payload, rules=[rule],
+    )
+    assert res.decision is None
+
+
+def test_dispatch_decision_deny_wins_over_ask(tmp_path):
+    ask_rule = _rule(_echo_json({"hookSpecificOutput": {"permissionDecision": "ask"}}))
+    deny_rule = _rule(_echo_json({"hookSpecificOutput": {"permissionDecision": "deny"}}))
+    payload = ClaudeHookPayloadAdapter().build_pre_tool_use(tool_name="x")
+    res = PluginHookDispatcher(cwd=tmp_path).dispatch_pre_tool_use_decision(
+        payload=payload, rules=[ask_rule, deny_rule],
+    )
+    assert res.decision == "deny"
+
+
+def test_dispatch_decision_non_json_recorded_not_decided(tmp_path):
+    rule = _rule("echo just-some-text")
+    payload = ClaudeHookPayloadAdapter().build_pre_tool_use(tool_name="x")
+    res = PluginHookDispatcher(cwd=tmp_path).dispatch_pre_tool_use_decision(
+        payload=payload, rules=[rule],
+    )
+    assert res.decision is None
+    assert res.additional_contexts == ["just-some-text"]
+
+
+def test_dispatch_decision_no_matching_rules(tmp_path):
+    rule = ParsedHookRule(
+        event="PreToolUse", hook_type="command", command=_echo_json({}),
+        matcher={"toolName": "Bash"}, plugin_name="t",
+    )
+    payload = ClaudeHookPayloadAdapter().build_pre_tool_use(tool_name="read_file")  # → Read
+    res = PluginHookDispatcher(cwd=tmp_path).dispatch_pre_tool_use_decision(
+        payload=payload, rules=[rule],
+    )
+    assert res.matched_rule_count == 0
+    assert res.decision is None
+
+
+# ---------------------------------------------------------------------------
+# ToolRunner Phase 1.5 wiring
+# ---------------------------------------------------------------------------
+
+
+class _FakeStream:
+    def __init__(self) -> None:
+        self.events: List = []
+
+    def publish(self, event):
+        self.events.append(event)
+
+
+class _ConfirmingTransport:
+    def __init__(self, confirm: bool = True) -> None:
+        self._confirm = confirm
+        self.emitted = []
+
+    def emit(self, event):
+        self.emitted.append(event)
+
+    def confirm_tool(self, *_a, **_kw):
+        return self._confirm
+
+    def ask_user(self, _q):
+        return ""
+
+    def on_max_iterations(self, _c, _m):
+        return {"action": "stop"}
+
+
+class _ReadTool(Tool):
+    def __init__(self) -> None:
+        super().__init__()
+        self.executed = False
+
+    @property
+    def name(self) -> str: return "read_thing"
+    @property
+    def description(self) -> str: return "read"
+    @property
+    def parameters(self) -> Dict[str, Any]: return {"type": "object"}
+    @property
+    def is_read_only(self) -> bool: return True
+    def execute(self, **kwargs) -> str:
+        self.executed = True
+        return "ok"
+
+
+def _build_runner(tmp_path, *, hook_command: str | None, confirm: bool = True):
+    stream = _FakeStream()
+    registry = ToolRegistry()
+    tool = _ReadTool()
+    registry.register(tool)
+    engine = PermissionEngine(project_root=tmp_path)
+    perm_emitter = HostPermissionEmitter(
+        stream,
+        session_id_provider=lambda: "s-1",
+        turn_id_provider=lambda: "t-1",
+        active_permissions_provider=lambda: engine.active_permissions(),
+    )
+    tool_emitter = HostToolEmitter(
+        stream, session_id_provider=lambda: "s-1", turn_id_provider=lambda: "t-1",
+    )
+    transport = _ConfirmingTransport(confirm=confirm)
+    runner = ToolRunner(
+        tools=registry,
+        permission_engine=engine,
+        transport=transport,
+        logger=logging.getLogger("test.pre_tool_decision"),
+        host_tool_emitter=tool_emitter,
+        host_permission_emitter=perm_emitter,
+    )
+    if hook_command is not None:
+        runner._plugin_hook_rules = [_rule(hook_command)]
+        runner._working_directory = tmp_path
+        runner._session_id = "s-1"
+    return runner, stream, transport, tool
+
+
+def _tool_call(name: str = "read_thing", *, call_id: str = "tc-1"):
+    return SimpleNamespace(id=call_id, function=SimpleNamespace(name=name, arguments="{}"))
+
+
+def test_runner_hook_deny_blocks_execution(tmp_path):
+    runner, stream, _, tool = _build_runner(
+        tmp_path,
+        hook_command=_echo_json({
+            "hookSpecificOutput": {"permissionDecision": "deny", "reason": "blocked by policy"}
+        }),
+    )
+    doom, messages = runner.execute([_tool_call()])
+    assert doom is False
+    assert tool.executed is False
+    assert "pretooluse hook" in messages[0]["content"].lower()
+
+    perm_events = [e for e in stream.events if isinstance(e, PermissionDecisionEvent)]
+    assert len(perm_events) == 1
+    assert perm_events[0].outcome == "deny"
+    assert perm_events[0].reason == "pre-tool-hook: blocked by policy"
+    # No tool ever started.
+    started = [
+        e for e in stream.events
+        if isinstance(e, ToolLifecycleEvent) and e.phase == "started"
+    ]
+    assert started == []
+
+
+def test_runner_hook_ask_then_user_declines(tmp_path):
+    runner, stream, _, tool = _build_runner(
+        tmp_path,
+        hook_command=_echo_json({"hookSpecificOutput": {"permissionDecision": "ask"}}),
+        confirm=False,
+    )
+    doom, messages = runner.execute([_tool_call()])
+    assert tool.executed is False
+    assert "cancelled" in messages[0]["content"].lower()
+    perm_events = [e for e in stream.events if isinstance(e, PermissionDecisionEvent)]
+    # ASK projects to the "prompt" outcome on the public event.
+    assert perm_events[0].outcome == "prompt"
+    assert perm_events[0].reason == "pre-tool-hook"
+
+
+def test_runner_hook_ask_then_user_confirms_executes(tmp_path):
+    runner, stream, _, tool = _build_runner(
+        tmp_path,
+        hook_command=_echo_json({"hookSpecificOutput": {"permissionDecision": "ask"}}),
+        confirm=True,
+    )
+    runner.execute([_tool_call()])
+    assert tool.executed is True
+
+
+def test_runner_hook_allow_is_noop(tmp_path):
+    runner, stream, _, tool = _build_runner(
+        tmp_path,
+        hook_command=_echo_json({"hookSpecificOutput": {"permissionDecision": "allow"}}),
+    )
+    runner.execute([_tool_call()])
+    assert tool.executed is True
+    perm_events = [e for e in stream.events if isinstance(e, PermissionDecisionEvent)]
+    # Engine's own allow stands; not attributed to the hook.
+    assert perm_events[0].outcome == "allow"
+    assert perm_events[0].reason != "pre-tool-hook"
+
+
+def test_runner_no_hook_rules_skips_dispatch(tmp_path):
+    runner, stream, _, tool = _build_runner(tmp_path, hook_command=None)
+    runner.execute([_tool_call()])
+    assert tool.executed is True


### PR DESCRIPTION
## Summary

PreToolUse plugin hooks can now **deny** a tool call or **downgrade it to "ask"** via the Claude Code-compatible `hookSpecificOutput.permissionDecision` shape, instead of being fire-and-forget. Implements P0 of `docs/design/codex-reverse-review.md`.

## What changed

- **`PluginHookDispatcher.dispatch_pre_tool_use_decision()`** — parses each matching hook's stdout for `permissionDecision` (`allow`/`deny`/`ask`), merges verdicts (first `deny` wins, then first `ask`), stops forking subprocesses on the first `deny`, and records `additionalContext` on a new `PreToolUseHookResult` (recorded, **not** injected — MVP scope). Exit-code-2 "block" is intentionally not honored. The old side-effect-only `dispatch_pre_tool_use()` is kept (marked deprecated) for the lifecycle-dispatch tests.
- **Moved the dispatch out of the executor.** `runtime/tool_executor.py::_dispatch_pre_tool_hook()` (fire-and-forget, result discarded) is removed. PreToolUse now runs in `ToolRunner._apply_pre_tool_use_hooks()` as **Phase 1.5** — before the `PermissionDecisionEvent` emit and before any tool `started` event — so a hook-derived decision lands in the public event ordering without an after-the-fact `cancelled`.
- **Decision wiring.** Hook `deny` → plan `DENY`; hook `ask` on an `ALLOW` plan → `ASK` (flows through the existing Phase 2 confirmation path); `allow`/no-decision → no-op (never downgrades an engine deny/ask or a tool's own `requires_confirmation` ask). Hook-derived decisions carry `reason = pre_tool_hook_reason(...)` (prefix `pre-tool-hook`, a shared constant in `tool_planning.py`) and `matched_rule = None` — no new public field. A `PLUGIN_HOOK_FIRED` replay event with `hook_name: "PreToolUse"` is emitted for parity with the other hook sites. The executor's deny message distinguishes hook-denied calls via `is_pre_tool_hook_reason()`.
- **Cleanup.** The 4 hook-runner subprocess-spawn blocks (`_run_lifecycle_command`, `_run_command_hook`, `_run_stop_command_hook`, `_run_pre_tool_use_command`) now share `_run_subprocess()` / `_timeout_attachment()`. Added a comment on the always-emit-`TOOL_START`-before-deny pairing contract (ACP / replay / CLI loop rely on it).

## Notes / deliberate non-goals

- A hook `ask` reuses the Phase 2 confirmation path, so it respects `allow_all_tools` / full-access session state like any other prompt; a bypass flag on `Transport.confirm_tool` is deferred.
- No public host schema changes; `additionalContext` is parsed/recorded but not injected; no `updatedInput` / argument rewriting; no exit-code-based deny for PreToolUse.

## Testing

- New `tests/test_hooks_pre_tool_use_decision.py` (dispatcher parsing/merge + `ToolRunner` Phase 1.5 wiring: deny/ask/allow precedence, no-rules fast path, event ordering).
- Full suite: 2595 passed, 2 skipped.
- Codex review (4 rounds) + `/simplify` (3 rounds): no remaining comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)