### PR TITLE
docs: document the /compact manual-compaction command

### DIFF
--- a/developer-guide/en/cli/7-context-status.md
+++ b/developer-guide/en/cli/7-context-status.md
@@ -74,6 +74,33 @@ The summary lives both in the live message history (so the next turn sees it) an
 
 The "circuit breaker" is a safety: if compaction itself fails (LLM timeout, parse error) more than `CIRCUIT_BREAKER_LIMIT` times in a row, auto-compaction disables for the rest of the session — better to refuse a turn than spiral.
 
+## `/compact` — compact on demand
+
+`/compact` runs the *same* full-compaction path as the auto-compactor, but right now instead of waiting for the usage bar to climb.
+
+```text
+> /compact
+Compacted history: 54 → 19 messages, ~47,231 → ~12,880 tokens (6.4% of window).
+```
+
+What happens:
+
+- Calls `context_manager.compress_messages(..., is_auto=False)` — summarize an older block into a `[Conversation Summary]`, keep recent messages + the in-progress tool loop, re-inject recently-read files.
+- Fires the same `CONTEXT_COMPRESSED` and session-summary observability events as auto-compaction, and dispatches matching `PreCompact` plugin hooks (with `trigger="manual"`), so replay and hooks see manual `/compact` the same way they see the threshold-driven path.
+- Refreshes the context-usage % shown in the prompt.
+
+When to use it:
+
+- **Before a big task** — you know history is bloated and you'd rather pay the summarization cost now than have it land mid-turn.
+- **Right after `/sessions` resume** — squash a long restored history before the first new turn.
+- **Bills creeping up** — `/context` shows 50%+ but you're not near the auto-compaction trigger yet.
+
+Edge cases:
+
+- Fewer than 5 messages → `Not enough conversation history to compact yet.` (nothing to summarize).
+- If compaction can't make progress — circuit breaker open, no safe split point, or the summarization LLM call failed — you get `Compaction made no change …` and history is left untouched (check `agentao.log`).
+- Same lossiness as auto-compaction: anything not in the summary or in re-injected files is gone from the agent's perspective.
+
 ## `/status` quick-reference (full content in chapter 1)
 
 ```text
@@ -127,5 +154,5 @@ The context manager is `agent.context_manager`. Embedding hosts can read `cm.get
 :::
 
 ::: tip Authoritative help
-Command syntax: `/help`. `/context` body: [`agentao/cli/commands.py:handle_context_command`](https://github.com/jin-bo/agentao/blob/main/agentao/cli/commands.py). Compaction logic: [`agentao/context_manager.py`](https://github.com/jin-bo/agentao/blob/main/agentao/context_manager.py).
+Command syntax: `/help`. `/context` body: [`agentao/cli/commands/context.py`](https://github.com/jin-bo/agentao/blob/main/agentao/cli/commands/context.py). `/compact` body: [`agentao/cli/commands/compact.py`](https://github.com/jin-bo/agentao/blob/main/agentao/cli/commands/compact.py). Compaction logic: [`agentao/context_manager.py`](https://github.com/jin-bo/agentao/blob/main/agentao/context_manager.py).
 :::

--- a/developer-guide/en/cli/index.md
+++ b/developer-guide/en/cli/index.md
@@ -24,7 +24,7 @@ You drop into a chat REPL. Type a normal sentence to talk to the agent. Type `/`
 - [**4. Plan Mode**](./4-plan-mode) — `/plan` workflow · read-only "think first, then commit" loop
 - [**5. Skills & Crystallize**](./5-skills-crystallize) — `/skills`, `/crystallize` · activate skills and distill new ones from a session
 - [**6. Memory**](./6-memory) — `/memory` · what gets remembered, where it lives, how to inspect and clear it
-- [**7. Context & Status**](./7-context-status) — `/context`, `/status` · token budget, compaction, session size
+- [**7. Context & Status**](./7-context-status) — `/context`, `/compact`, `/status` · token budget, compaction, session size
 - [**8. MCP / ACP / Plugins**](./8-mcp-acp-plugins) — `/mcp`, `/acp`, `/plugins` · attach external tool servers
 - [**9. Replay & Output**](./9-replay-output) — `/replay`, `/copy`, `/markdown` · record sessions, copy answers, render control
 - [**10. Configuration Reference**](./10-config-reference) — every config file the CLI reads, with paths and precedence

--- a/developer-guide/zh/cli/7-context-status.md
+++ b/developer-guide/zh/cli/7-context-status.md
@@ -74,6 +74,33 @@ Context limit set to 500,000 tokens
 
 "熔断器"是兜底：如果压缩本身失败（LLM 超时、解析错）连续超过 `CIRCUIT_BREAKER_LIMIT` 次，本会话剩余时间自动压缩关闭 — 拒绝一轮总比螺旋崩溃好。
 
+## `/compact` — 手动立即压缩
+
+`/compact` 走的是和自动压缩**完全一样**的全量压缩路径，只是现在就执行，不等用量条爬上去。
+
+```text
+> /compact
+Compacted history: 54 → 19 messages, ~47,231 → ~12,880 tokens (6.4% of window).
+```
+
+发生了什么：
+
+- 调用 `context_manager.compress_messages(..., is_auto=False)` — 把较老的一块消息摘要成 `[Conversation Summary]`，保留最近的消息 + 正在进行的工具循环，重新挂回最近读过的文件。
+- 触发和自动压缩相同的 `CONTEXT_COMPRESSED`、session-summary 可观测事件，并派发匹配的 `PreCompact` 插件 hook（`trigger="manual"`）—— 所以 replay 和 hook 看到手动 `/compact` 和看到阈值触发的路径是一样的。
+- 刷新 prompt 里显示的上下文用量百分比。
+
+什么时候用：
+
+- **开一个大任务之前** —— 你知道历史已经臃肿，与其让压缩在某一轮中间发生，不如现在就付掉摘要成本。
+- **`/sessions` 恢复之后** —— 在第一轮新对话前先把恢复出来的长历史压一下。
+- **账单在涨** —— `/context` 显示 50%+ 但还没到自动压缩的触发点。
+
+边界情况：
+
+- 少于 5 条消息 → `Not enough conversation history to compact yet.`（没什么可摘要的）。
+- 压缩推进不了 —— 熔断器开着、找不到安全的切分点、或摘要 LLM 调用失败 —— 会得到 `Compaction made no change …`，历史原样不动（看 `agentao.log`）。
+- 和自动压缩一样有损：不在摘要里、也不在重新挂回的文件里的东西，从 agent 视角看就没了。
+
 ## `/status` 速查（完整在第 1 章）
 
 ```text
@@ -127,5 +154,5 @@ Context manager 是 `agent.context_manager`。嵌入式宿主可以读 `cm.get_u
 :::
 
 ::: tip 真相源头
-命令语法：`/help`。`/context` 实现：[`agentao/cli/commands.py:handle_context_command`](https://github.com/jin-bo/agentao/blob/main/agentao/cli/commands.py)。压缩逻辑：[`agentao/context_manager.py`](https://github.com/jin-bo/agentao/blob/main/agentao/context_manager.py)。
+命令语法：`/help`。`/context` 实现：[`agentao/cli/commands/context.py`](https://github.com/jin-bo/agentao/blob/main/agentao/cli/commands/context.py)。`/compact` 实现：[`agentao/cli/commands/compact.py`](https://github.com/jin-bo/agentao/blob/main/agentao/cli/commands/compact.py)。压缩逻辑：[`agentao/context_manager.py`](https://github.com/jin-bo/agentao/blob/main/agentao/context_manager.py)。
 :::

--- a/developer-guide/zh/cli/index.md
+++ b/developer-guide/zh/cli/index.md
@@ -24,7 +24,7 @@ uv run agentao
 - [**4. Plan 模式**](./4-plan-mode) — `/plan` 工作流 · 只读的"先想清楚再动手"循环
 - [**5. Skills 与 Crystallize**](./5-skills-crystallize) — `/skills` `/crystallize` · 激活技能 / 从会话中析出新技能
 - [**6. 记忆**](./6-memory) — `/memory` · 什么被记住、存在哪里、怎么查、怎么清
-- [**7. 上下文与状态**](./7-context-status) — `/context` `/status` · token 预算、压缩、会话规模
+- [**7. 上下文与状态**](./7-context-status) — `/context` `/compact` `/status` · token 预算、压缩、会话规模
 - [**8. MCP / ACP / 插件**](./8-mcp-acp-plugins) — `/mcp` `/acp` `/plugins` · 接入外部工具服务器
 - [**9. 回放与输出**](./9-replay-output) — `/replay` `/copy` `/markdown` · 录会话、复制答案、控制渲染
 - [**10. 配置文件参考**](./10-config-reference) — CLI 读取的所有配置文件、路径与优先级

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -83,6 +83,8 @@ All commands start with `/`:
   - `/model claude-sonnet-4-6` - Switch to Claude Sonnet
 - `/clear` - Clear conversation history
 - `/status` - Show conversation status (includes current model)
+- `/context` - Show context-window token usage (`/context limit <n>` to change it)
+- `/compact` - Summarize older history now into a compact block (manual compaction)
 - `/skills` - List available skills
 - `/memory` - Show saved memories
 - `/exit` or `/quit` - Exit the program


### PR DESCRIPTION
## Summary

`/compact` (added in #38) had no developer-guide coverage. This adds it.

- **`developer-guide/{en,zh}/cli/7-context-status.md`** — new `## /compact — compact on demand` section after the auto-compaction explanation: it runs the same full-compaction path as the auto-compactor on demand (`compress_messages(is_auto=False)`), fires the same `CONTEXT_COMPRESSED` / session-summary observability events and dispatches matching `PreCompact` hooks (with `trigger="manual"`), and refreshes the prompt's context-usage %. Covers when to use it (before a big task / after `/sessions` resume / bills creeping up) and the edge cases (<5 messages → "not enough history", no-progress → "made no change" with history untouched, same lossiness as auto-compaction). The "Authoritative help" footer now links `agentao/cli/commands/compact.py`.
- **`developer-guide/{en,zh}/cli/index.md`** — chapter-7 entry now lists `/compact`.
- **`docs/QUICKSTART.md`** — command list now includes `/compact` (and `/context`, which was also missing).

Docs only — no code changes. The in-app `/help` already listed `/compact` (`agentao/cli/help_text.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)