### PR TITLE
feat(telemetry): model latency / TTFT + turn-level tool count (P1)

### DIFF
--- a/agentao/replay/adapter.py
+++ b/agentao/replay/adapter.py
@@ -72,18 +72,22 @@ class ReplayAdapter:
         *,
         status: str = "ok",
         error: Optional[str] = None,
+        tool_count: Optional[int] = None,
     ) -> None:
         turn_id = self._turn_id
         if turn_id is None:
             return
+        payload: Dict[str, Any] = {
+            "final_text": final_text or "",
+            "status": status,
+            "error": error,
+        }
+        if tool_count is not None:
+            payload["tool_count"] = tool_count
         self._recorder.record(
             EventKind.TURN_COMPLETED,
             turn_id=turn_id,
-            payload={
-                "final_text": final_text or "",
-                "status": status,
-                "error": error,
-            },
+            payload=payload,
         )
         self._turn_id = None
 
@@ -192,10 +196,12 @@ class ReplayAdapter:
 
         if kind == EventType.TURN_END:
             try:
+                tc = data.get("tool_count")
                 self.end_turn(
                     str(data.get("final_text", "") or ""),
                     status=str(data.get("status", "ok") or "ok"),
                     error=data.get("error"),
+                    tool_count=tc if isinstance(tc, int) else None,
                 )
             except Exception:
                 pass

--- a/agentao/runtime/chat_loop/_runner.py
+++ b/agentao/runtime/chat_loop/_runner.py
@@ -295,6 +295,12 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
                     cancellation_token=token,
                 )
                 agent.messages.extend(tool_results)
+                # Turn-level telemetry: count tool calls the LLM made
+                # this iteration; run_turn reset this to 0 and TURN_END
+                # reports the total.
+                agent._turn_tool_count = (
+                    getattr(agent, "_turn_tool_count", 0) + len(clean_tool_calls)
+                )
                 if doom_triggered:
                     doom_content = (assistant_msg.get("content") or "").strip()
                     assistant_content_doom = (

--- a/agentao/runtime/llm_call.py
+++ b/agentao/runtime/llm_call.py
@@ -112,14 +112,31 @@ def run_llm_call(
         }))
 
     t0 = time.monotonic()
+    # Time-to-first-token: monotonic stamp of the first streamed text
+    # chunk reaching ``on_text_chunk``. Stays ``None`` for calls that
+    # produce only tool_calls (no text deltas) or that fail before any
+    # delta. ``model_latency_ms`` on LLM_CALL_COMPLETED is the same
+    # value as ``duration_ms`` — a stable, intent-named alias for host
+    # telemetry consumers.
+    first_token_at: Optional[float] = None
+
+    def _on_text_chunk(chunk: str) -> None:
+        nonlocal first_token_at
+        if first_token_at is None:
+            first_token_at = time.monotonic()
+        agent.transport.emit(AgentEvent(EventType.LLM_TEXT, {"chunk": chunk}))
+
+    def _first_token_ms() -> Optional[int]:
+        if first_token_at is None:
+            return None
+        return round((first_token_at - t0) * 1000)
+
     try:
         response = agent.llm.chat_stream(
             messages=messages,
             tools=tools,
             max_tokens=agent.llm.max_tokens,
-            on_text_chunk=lambda chunk: agent.transport.emit(
-                AgentEvent(EventType.LLM_TEXT, {"chunk": chunk})
-            ),
+            on_text_chunk=_on_text_chunk,
             cancellation_token=cancellation_token,
         )
     except Exception as exc:
@@ -129,10 +146,13 @@ def run_llm_call(
         # between regenerate-from-scratch and resume-style retry without
         # having to count emitted LLM_TEXT events themselves.
         streamed = bool(getattr(exc, "streamed", False))
+        elapsed_ms = round((time.monotonic() - t0) * 1000)
         agent.transport.emit(AgentEvent(EventType.LLM_CALL_COMPLETED, {
             "attempt": attempt,
             "status": "error",
-            "duration_ms": round((time.monotonic() - t0) * 1000),
+            "duration_ms": elapsed_ms,
+            "model_latency_ms": elapsed_ms,
+            "first_token_ms": _first_token_ms(),
             "error_class": type(exc).__name__,
             "error_message": str(exc)[:500],
             "streamed": streamed,
@@ -156,10 +176,13 @@ def run_llm_call(
     except Exception:
         pass
 
+    elapsed_ms = round((time.monotonic() - t0) * 1000)
     agent.transport.emit(AgentEvent(EventType.LLM_CALL_COMPLETED, {
         "attempt": attempt,
         "status": "ok",
-        "duration_ms": round((time.monotonic() - t0) * 1000),
+        "duration_ms": elapsed_ms,
+        "model_latency_ms": elapsed_ms,
+        "first_token_ms": _first_token_ms(),
         "error_class": None,
         "error_message": None,
         "finish_reason": finish_reason,

--- a/agentao/runtime/turn.py
+++ b/agentao/runtime/turn.py
@@ -73,6 +73,11 @@ def run_turn(
     # instead of replaying the entire accumulated conversation every turn.
     agent._llm_call_seq = 0
     agent._llm_call_last_msg_count = 1 + len(agent.messages)
+    # Turn-level tool-call counter. The chat loop bumps this by the
+    # number of tool calls in each LLM response; TURN_END reports the
+    # total so host telemetry can size a turn without replaying every
+    # TOOL_START. Reset per turn (and read defensively in the finally).
+    agent._turn_tool_count = 0
     # Snapshot the latest session-summary id so the inner loop can
     # fire SESSION_SUMMARY_WRITTEN each time compress_messages writes
     # a new one. Held on the instance so compression paths inside the
@@ -117,6 +122,7 @@ def run_turn(
                 "final_text": final_text,
                 "status": status,
                 "error": error_detail,
+                "tool_count": getattr(agent, "_turn_tool_count", 0),
             }))
         except Exception:
             pass

--- a/developer-guide/en/part-4/2-agent-events.md
+++ b/developer-guide/en/part-4/2-agent-events.md
@@ -74,8 +74,8 @@ Distinct from `TURN_START` (which fires per LLM iteration). `TURN_BEGIN` carries
 | Field | Description |
 |-------|-------------|
 | Trigger | Once at the end of each user-driven turn, after the final assistant reply (or on error / cancellation) |
-| `data` | `{"final_text": "...", "status": "ok"\|"error"\|"cancelled", "error": None}` |
-| Typical use | Close the turn frame; flush per-turn metrics |
+| `data` | `{"final_text": "...", "status": "ok"\|"error"\|"cancelled", "error": None, "tool_count": 3}` |
+| Typical use | Close the turn frame; flush per-turn metrics — `tool_count` is the number of tool calls the LLM made across all iterations of the turn, so a host can size a turn without replaying every `TOOL_START` |
 
 Replay recorders pair this with `TURN_BEGIN` to delimit a turn. Drives the runtime → replay handoff that used to be a direct call into the replay adapter.
 
@@ -182,8 +182,8 @@ For normal UI spinners, prefer `TOOL_COMPLETE`. Use `TOOL_RESULT` for replay, au
 | Field | Description |
 |-------|-------------|
 | Trigger | Around each provider call |
-| `data` | Provider-call metadata before the call; usage / finish metadata after the call |
-| Typical use | Metrics, cost tracking, debugging model behavior |
+| `data` | Provider-call metadata before the call; usage / finish metadata after the call. `LLM_CALL_COMPLETED` carries `duration_ms`, `model_latency_ms` (a stable intent-named alias of `duration_ms`), `first_token_ms` (time-to-first-token in ms, or `null` when the call streamed no text — e.g. a tool-only response or a failure before the first delta), `prompt_tokens`, `completion_tokens`, `finish_reason`, plus `status` / `error_class` / `error_message` / `streamed` on the error path |
+| Typical use | Metrics, cost tracking, debugging model behavior — `first_token_ms` vs `model_latency_ms` separates queueing/TTFT from total generation time |
 
 ### `LLM_CALL_DELTA`
 

--- a/developer-guide/zh/part-4/2-agent-events.md
+++ b/developer-guide/zh/part-4/2-agent-events.md
@@ -74,8 +74,8 @@ TURN_END   -> (turn 结束；携带最终 assistant 文本 + status/error)
 | 字段 | 说明 |
 |------|------|
 | 触发时机 | 每个用户驱动 turn 结束时**一次**，在最终 assistant 回复之后（或出错 / 被取消时） |
-| `data` | `{"final_text": "...", "status": "ok"\|"error"\|"cancelled", "error": None}` |
-| 典型用法 | 关闭 turn 帧；刷出 per-turn 指标 |
+| `data` | `{"final_text": "...", "status": "ok"\|"error"\|"cancelled", "error": None, "tool_count": 3}` |
+| 典型用法 | 关闭 turn 帧；刷出 per-turn 指标 —— `tool_count` 是这个 turn 内所有迭代里 LLM 发起的工具调用总数，宿主无需重放每个 `TOOL_START` 就能掂量这一 turn 的规模 |
 
 Replay 录制器靠它和 `TURN_BEGIN` 配对来界定一个 turn。它替代了运行时直接调用 replay adapter 的旧路径。
 
@@ -182,8 +182,8 @@ if event.type == EventType.TOOL_COMPLETE:
 | 字段 | 说明 |
 |------|------|
 | 触发时机 | 每次 provider 调用前后 |
-| `data` | 调用前元数据；调用后的 usage / finish 元数据 |
-| 典型用法 | 指标、成本统计、调试模型行为 |
+| `data` | 调用前元数据；调用后的 usage / finish 元数据。`LLM_CALL_COMPLETED` 携带 `duration_ms`、`model_latency_ms`（`duration_ms` 的稳定别名，命名更贴合意图）、`first_token_ms`（首 token 时延，毫秒；当本次调用没有流式文本——例如纯工具调用响应、或首个 delta 之前就失败——为 `null`）、`prompt_tokens`、`completion_tokens`、`finish_reason`，错误路径上还有 `status` / `error_class` / `error_message` / `streamed` |
+| 典型用法 | 指标、成本统计、调试模型行为 —— `first_token_ms` 与 `model_latency_ms` 把排队/TTFT 与总生成时间区分开 |
 
 ### `LLM_CALL_DELTA`
 

--- a/docs/design/codex-reverse-review.md
+++ b/docs/design/codex-reverse-review.md
@@ -222,6 +222,37 @@ Add only the small set needed to debug host integrations:
 covered. Do not introduce a large SQLite telemetry subsystem unless Agentao's
 deployment model changes.
 
+### Status — implemented 2026-05-12
+
+Landed (all as optional fields on existing transport/replay event payloads —
+no new event types, no public host-schema bump):
+
+- `runtime/llm_call.py`: `LLM_CALL_COMPLETED` now carries `model_latency_ms`
+  (a stable, intent-named alias of the existing `duration_ms`) and
+  `first_token_ms` (TTFT — monotonic stamp of the first streamed text chunk
+  reaching `on_text_chunk`, minus call start; `None` for tool-only responses
+  or failures before the first delta). Both the ok and error emit paths
+  include them. The streaming callback was promoted from a lambda to a named
+  closure so it can record the first-chunk timestamp.
+- `runtime/turn.py` + `runtime/chat_loop/_runner.py`: a per-turn
+  `agent._turn_tool_count` is reset in `run_turn`, bumped by
+  `len(clean_tool_calls)` after each tool batch in the chat loop, and reported
+  on `TURN_END` as `tool_count`. `replay/adapter.py` mirrors it onto the
+  `TURN_COMPLETED` replay record (`end_turn(..., tool_count=...)`).
+- Compaction duration was *already* covered: `CONTEXT_COMPRESSED` has carried
+  `duration_ms` (populated by every microcompaction / full-compaction call
+  site) and the replay adapter already records it — no change needed.
+- Tests: `tests/test_telemetry_increment.py` (TTFT/latency on the ok, error,
+  and tool-only paths; `tool_count` on `TURN_END` and the replay mirror).
+- Docs: `developer-guide/{en,zh}/part-4/2-agent-events.md` updated for the new
+  `LLM_CALL_COMPLETED` and `TURN_END` fields.
+
+Deliberately *not* done: `model_latency_ms` is not re-exposed on the public
+`agentao.host` Pydantic models — the host contract does not currently project
+LLM-call events at all, and adding that surface is a larger decision than this
+increment. Hosts that want latency today subscribe to the transport
+`LLM_CALL_COMPLETED` event (same as cost/usage tracking already does).
+
 ## P2: Permission Abstraction and Redaction
 
 Read denial is worth modeling in the permission abstraction, but OS-level

--- a/tests/test_telemetry_increment.py
+++ b/tests/test_telemetry_increment.py
@@ -1,0 +1,154 @@
+"""P1 telemetry increment: LLM latency / TTFT + turn-level tool count.
+
+Pins three small additions to the existing observability event set:
+
+  - ``LLM_CALL_COMPLETED`` carries ``model_latency_ms`` (alias of
+    ``duration_ms``) and ``first_token_ms`` (TTFT, or ``None`` when the
+    call produced no streamed text).
+  - ``TURN_END`` carries ``tool_count`` for the turn.
+  - The replay adapter mirrors ``tool_count`` onto ``TURN_COMPLETED``.
+
+No new event types, no public host-schema change — just extra optional
+fields on payloads host/replay consumers already drain.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from agentao.runtime.llm_call import run_llm_call
+from agentao.runtime.turn import run_turn
+from agentao.transport import EventType
+from agentao.transport.events import AgentEvent
+
+
+class _CaptureTransport:
+    def __init__(self) -> None:
+        self.events: list[AgentEvent] = []
+
+    def emit(self, event: AgentEvent) -> None:
+        self.events.append(event)
+
+
+def _completed(transport: _CaptureTransport) -> dict:
+    for ev in transport.events:
+        if ev.type == EventType.LLM_CALL_COMPLETED:
+            return ev.data
+    raise AssertionError("no LLM_CALL_COMPLETED event emitted")
+
+
+def _make_llm(chunks: list[str], *, finish: str = "stop"):
+    """A stand-in ``agent.llm`` whose ``chat_stream`` streams ``chunks``."""
+
+    def chat_stream(*, messages, tools, max_tokens, on_text_chunk, cancellation_token):
+        for c in chunks:
+            on_text_chunk(c)
+        choice = SimpleNamespace(finish_reason=finish)
+        usage = SimpleNamespace(prompt_tokens=11, completion_tokens=7)
+        return SimpleNamespace(choices=[choice], usage=usage)
+
+    return SimpleNamespace(
+        model="test-model", temperature=0.0, max_tokens=256, chat_stream=chat_stream
+    )
+
+
+def _make_agent(llm) -> SimpleNamespace:
+    return SimpleNamespace(transport=_CaptureTransport(), llm=llm, replay_manager=None)
+
+
+def test_llm_call_completed_has_latency_and_ttft_on_streamed_text():
+    agent = _make_agent(_make_llm(["Hel", "lo", " world"]))
+    run_llm_call(agent, messages=[{"role": "user", "content": "hi"}], tools=[])
+
+    data = _completed(agent.transport)
+    assert data["status"] == "ok"
+    assert isinstance(data["model_latency_ms"], int)
+    assert data["model_latency_ms"] == data["duration_ms"]
+    assert isinstance(data["first_token_ms"], int)
+    assert data["first_token_ms"] >= 0
+    assert data["first_token_ms"] <= data["model_latency_ms"]
+
+
+def test_llm_call_completed_ttft_none_when_no_text_streamed():
+    agent = _make_agent(_make_llm([]))  # tool-only style response: no deltas
+    run_llm_call(agent, messages=[{"role": "user", "content": "hi"}], tools=[])
+
+    data = _completed(agent.transport)
+    assert data["first_token_ms"] is None
+    assert isinstance(data["model_latency_ms"], int)
+
+
+def test_llm_call_completed_error_path_still_reports_latency():
+    def chat_stream(*, messages, tools, max_tokens, on_text_chunk, cancellation_token):
+        on_text_chunk("partial ")
+        exc = RuntimeError("boom")
+        exc.streamed = True
+        raise exc
+
+    llm = SimpleNamespace(
+        model="test-model", temperature=0.0, max_tokens=256, chat_stream=chat_stream
+    )
+    agent = _make_agent(llm)
+    with pytest.raises(RuntimeError):
+        run_llm_call(agent, messages=[{"role": "user", "content": "hi"}], tools=[])
+
+    data = _completed(agent.transport)
+    assert data["status"] == "error"
+    assert isinstance(data["model_latency_ms"], int)
+    assert data["model_latency_ms"] == data["duration_ms"]
+    assert isinstance(data["first_token_ms"], int)  # one chunk reached on_text_chunk
+
+
+def test_turn_end_carries_tool_count():
+    transport = _CaptureTransport()
+
+    def _chat_inner(user_message, max_iterations, token):
+        # Simulate the chat loop bumping the per-turn counter.
+        agent._turn_tool_count += 2
+        agent._turn_tool_count += 1
+        return "done"
+
+    agent = SimpleNamespace(
+        transport=transport,
+        memory_manager=None,
+        messages=[],
+        _chat_inner=_chat_inner,
+    )
+    run_turn(agent, "hello")
+
+    end = next(e for e in transport.events if e.type == EventType.TURN_END)
+    assert end.data["tool_count"] == 3
+    assert end.data["status"] == "ok"
+
+
+def test_turn_end_tool_count_zero_when_no_tools():
+    transport = _CaptureTransport()
+    agent = SimpleNamespace(
+        transport=transport,
+        memory_manager=None,
+        messages=[],
+        _chat_inner=lambda *a, **k: "no tools here",
+    )
+    run_turn(agent, "hello")
+
+    end = next(e for e in transport.events if e.type == EventType.TURN_END)
+    assert end.data["tool_count"] == 0
+
+
+def test_replay_adapter_mirrors_tool_count_on_turn_completed(tmp_path):
+    from agentao.replay import ReplayAdapter, ReplayReader, ReplayRecorder
+    from agentao.transport import NullTransport
+
+    rec = ReplayRecorder.create("sess", tmp_path)
+    adapter = ReplayAdapter(NullTransport(), rec)
+    adapter.emit(AgentEvent(EventType.TURN_BEGIN, {"user_message": "hi"}))
+    adapter.emit(AgentEvent(EventType.TURN_END, {
+        "final_text": "bye", "status": "ok", "error": None, "tool_count": 4,
+    }))
+    rec.close()
+
+    events = ReplayReader(rec.path).events()
+    completed = [e for e in events if e["kind"] == "turn_completed"]
+    assert completed and completed[-1]["payload"].get("tool_count") == 4


### PR DESCRIPTION
Implements **P1** from `docs/design/codex-reverse-review.md` — the minimal telemetry increment for debugging host integrations. All additions are optional fields on event payloads host/replay consumers already drain: **no new event types, no public `agentao.host` schema bump.**

## What changed

- **`LLM_CALL_COMPLETED`** now carries:
  - `model_latency_ms` — a stable, intent-named alias of the existing `duration_ms`.
  - `first_token_ms` — time-to-first-token (monotonic stamp of the first streamed text chunk reaching `on_text_chunk`, minus call start). `null` for tool-only responses or failures before the first delta.
  - Both the ok and error emit paths include them; the streaming callback is promoted from a lambda to a named closure so it can record the first-chunk timestamp.
- **`TURN_END`** now carries `tool_count` — a per-turn `agent._turn_tool_count` reset in `run_turn`, bumped by `len(clean_tool_calls)` after each tool batch in the chat loop, and mirrored onto the `TURN_COMPLETED` replay record via `end_turn(..., tool_count=...)`.
- **Compaction duration** was already covered (`CONTEXT_COMPRESSED.duration_ms`, populated by every micro/full-compaction call site and recorded by the replay adapter) — no change needed.

## Not done on purpose

`model_latency_ms` is **not** re-exposed on the public `agentao.host` Pydantic models — the host contract doesn't currently project LLM-call events at all, and adding that surface is a larger decision than this increment. Hosts that want latency today subscribe to the transport `LLM_CALL_COMPLETED` event (same as cost/usage tracking already does).

## Tests / docs

- `tests/test_telemetry_increment.py` — TTFT/latency on ok/error/tool-only paths; `tool_count` on `TURN_END` + the replay mirror. Full suite: 2601 passed, 2 skipped.
- `developer-guide/{en,zh}/part-4/2-agent-events.md` updated for the new `LLM_CALL_COMPLETED` / `TURN_END` fields; `docs/design/codex-reverse-review.md` gets a "Status — implemented 2026-05-12" section under P1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)