### PR TITLE
fix(chat-loop): guard against empty final assistant content in history

### DIFF
--- a/agentao/runtime/chat_loop/_runner.py
+++ b/agentao/runtime/chat_loop/_runner.py
@@ -411,8 +411,24 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
                 ] + agent.messages
             else:
                 agent.llm.logger.info(f"Reached final response in iteration {iteration}")
-                assistant_content = assistant_message.content or ""
                 reasoning_content = getattr(assistant_message, "reasoning_content", None)
+                assistant_content = assistant_message.content or ""
+                if not assistant_content.strip():
+                    # Some models (byte-level reasoning backends — Kimi,
+                    # GLM, Qwen-via-Ollama) end a turn with empty/whitespace
+                    # content and no tool calls. Persisting "" leaves a
+                    # contentless assistant message that strict API proxies
+                    # reject on the next turn. Substitute a neutral marker.
+                    assistant_content = (
+                        "[No text response]"
+                        if reasoning_content
+                        else "[No response]"
+                    )
+                    agent.llm.logger.warning(
+                        "Empty final assistant content in iteration %d; "
+                        "substituted placeholder to keep history valid",
+                        iteration,
+                    )
                 final_msg: Dict[str, Any] = {"role": "assistant", "content": assistant_content}
                 _attach_reasoning(final_msg, reasoning_content)
                 if sanitize_assistant_message(final_msg):

--- a/tests/test_empty_final_response.py
+++ b/tests/test_empty_final_response.py
@@ -1,0 +1,81 @@
+"""An empty/whitespace-only final assistant turn must not enter history verbatim.
+
+Byte-level reasoning backends (Kimi, GLM, Qwen-via-Ollama) occasionally end a
+turn with no text and no tool calls. Persisting ``{"role": "assistant",
+"content": ""}`` leaves a contentless message that strict API proxies reject on
+the next turn. The chat loop substitutes a neutral placeholder instead.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from agentao import Agentao
+
+
+def _fake_response(content, *, reasoning=None):
+    message = SimpleNamespace(content=content, tool_calls=None, reasoning_content=reasoning)
+    choice = SimpleNamespace(message=message, finish_reason="stop")
+    return SimpleNamespace(choices=[choice], usage=None, model="test-model")
+
+
+def _make_agent() -> Agentao:
+    return Agentao(
+        api_key="test-key",
+        base_url="https://example.test/v1",
+        model="test-model",
+        working_directory=Path.cwd(),
+    )
+
+
+def _assert_no_contentless_assistant_message(agent: Agentao) -> None:
+    assistant_msgs = [m for m in agent.messages if m.get("role") == "assistant"]
+    assert assistant_msgs, "expected an assistant message in history"
+    for m in assistant_msgs:
+        assert (m.get("content") or "").strip(), "contentless assistant message leaked into history"
+
+
+def test_empty_final_content_substituted_with_placeholder():
+    agent = _make_agent()
+    agent._llm_call = lambda messages, tools, token: _fake_response("   \n  ")
+
+    response = agent.chat("hi")
+
+    assert response == "[No response]"
+    _assert_no_contentless_assistant_message(agent)
+
+
+def test_none_final_content_treated_as_empty():
+    agent = _make_agent()
+    agent._llm_call = lambda messages, tools, token: _fake_response(None)
+
+    response = agent.chat("hi")
+
+    assert response == "[No response]"
+    _assert_no_contentless_assistant_message(agent)
+
+
+def test_empty_final_content_with_reasoning_gets_distinct_marker():
+    agent = _make_agent()
+    agent._llm_call = lambda messages, tools, token: _fake_response("", reasoning="thought hard")
+
+    response = agent.chat("hi")
+
+    assert response == "[No text response]"
+    _assert_no_contentless_assistant_message(agent)
+
+
+def test_nonempty_final_content_passes_through():
+    agent = _make_agent()
+    agent._llm_call = lambda messages, tools, token: _fake_response("the answer is 42")
+
+    response = agent.chat("hi")
+
+    assert response == "the answer is 42"
+
+
+if __name__ == "__main__":
+    test_empty_final_content_substituted_with_placeholder()
+    test_none_final_content_treated_as_empty()
+    test_empty_final_content_with_reasoning_gets_distinct_marker()
+    test_nonempty_final_content_passes_through()
+    print("ok")


### PR DESCRIPTION
## Problem

Byte-level reasoning backends (Kimi, GLM, Qwen-via-Ollama) occasionally end a turn with empty/whitespace `content` and **no** tool calls. In the final-response branch of the chat loop we persisted `{"role": "assistant", "content": ""}` verbatim — a contentless assistant message that strict API proxies reject on the next turn.

## Fix

In `ChatLoopRunner`'s final-response branch, when the assistant content is empty/whitespace-only, substitute a neutral placeholder and log a warning:
- `[No text response]` when `reasoning_content` was present (model put everything in reasoning)
- `[No response]` otherwise

Tool-call turns (where empty `content` is legitimate) and the max-iter / doom-loop branches (which already have their own fallback text) are untouched.

## Tests

`tests/test_empty_final_response.py` — patches `agent._llm_call` to return empty / `None` / whitespace / reasoning-only / normal content and asserts the placeholder substitution and that no contentless assistant message leaks into history. 4 passed; related suites (chat/loop/turn/hooks_stop/telemetry/replay) still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)