### PR TITLE
feat(cli): agentao doctor + agentao config validate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,30 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **`agentao doctor` and `agentao config validate` — diagnostics CLI.** Two
+  new non-interactive subcommands that aggregate or validate the harness's
+  existing signals without instantiating an agent. `doctor` covers the `.env`
+  provider check (API-key *presence*, never the value), `settings.json`,
+  permissions, MCP, replay, ACP schema export, project + user memory stores,
+  plugin diagnostics, and optional-dep probes. `config validate` is the
+  narrower companion that only checks user-editable config (no plugin
+  section). Output contract is `{"ok": bool, "sections": {...}, "findings":
+  [...]}`; errors exit `1`, warnings keep exit `0`. `--json` is the contract
+  surface for CI/hosts, human-readable is the default. Both are **read-only**
+  (probing an absent `memory.db` reports `"absent"` instead of bootstrapping
+  it) and reject unknown flags with exit `2`. Implementation in
+  `agentao/cli/diagnostics_cli.py`; documented under
+  `developer-guide/{en,zh}/cli/12-non-interactive.md`; design rationale in
+  `docs/design/codex-reverse-review.md` (2026-05-17 follow-up).
+
+- **`collect_full_plugin_diagnostics()` helper** in
+  `agentao/embedding/plugins/diagnostics.py`. Shared by `agentao plugin list`
+  and `agentao doctor` so the two commands cannot drift on which plugins they
+  consider failed (it runs the post-load `resolve_plugin_entries` /
+  `resolve_plugin_agents` simulation in addition to `PluginManager.load_plugins`).
+
 ### Changed
 
 - **`web_fetch` no longer silently falls back to crawl4ai.** The previous

--- a/agentao/cli/__init__.py
+++ b/agentao/cli/__init__.py
@@ -35,6 +35,11 @@ if TYPE_CHECKING:
         handle_plugin_subcommand,
         handle_skill_subcommand,
     )
+    from .diagnostics_cli import (
+        handle_config_subcommand,
+        handle_config_validate_subcommand,
+        handle_doctor_subcommand,
+    )
 
 
 def _names(mod: str, *names: str) -> dict[str, tuple[str, str]]:
@@ -52,6 +57,11 @@ _LAZY_NAMES: dict[str, tuple[str, str]] = {
         "handle_skill_subcommand", "handle_plugin_subcommand",
         "_skill_list", "_skill_remove", "_skill_install", "_skill_update",
         "_plugin_list_cli", "_load_and_register_plugins", "_handle_plugins_interactive",
+    ),
+    **_names(".diagnostics_cli",
+        "handle_doctor_subcommand",
+        "handle_config_subcommand",
+        "handle_config_validate_subcommand",
     ),
 }
 

--- a/agentao/cli/diagnostics_cli.py
+++ b/agentao/cli/diagnostics_cli.py
@@ -1,0 +1,862 @@
+"""CLI subcommand handlers for ``agentao doctor`` and ``agentao config validate``.
+
+Both commands aggregate or validate signals Agentao already produces; they do
+not introduce a new diagnostics subsystem and they do not change runtime
+startup semantics. See ``docs/design/codex-reverse-review.md`` (2026-05-17
+follow-up) for the rationale.
+
+Redaction policy: neither command prints API keys, environment variable
+values, or other secrets. They report presence / parse-status / source paths.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sqlite3
+import sys
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Literal, Optional, Tuple
+
+from ._globals import console, _plugin_inline_dirs
+
+
+FindingLevel = Literal["info", "warning", "error"]
+FileStatus = Literal["absent", "ok", "unreadable", "malformed"]
+
+
+def _load_dotenv(wd: Path) -> None:
+    """Mirror ``build_from_environment``'s dotenv search order.
+
+    Without this, ``_collect_provider`` reads ``os.getenv`` against a process
+    env that has not seen the project's ``.env`` yet, and ``agentao doctor``
+    falsely warns that the API key is missing right after the user ran
+    ``agentao init`` (which writes the key to ``.env``).
+    """
+    from dotenv import load_dotenv as _ld
+
+    dotenv_path = wd / ".env"
+    if dotenv_path.is_file():
+        _ld(dotenv_path)
+    else:
+        _ld()
+
+
+# ---------------------------------------------------------------------------
+# Shared finding records
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class Finding:
+    """A single diagnostic finding.
+
+    ``source`` carries the file path or env-derived label when known so the
+    user can act on the finding without re-deriving where it came from.
+    """
+
+    level: FindingLevel
+    area: str
+    message: str
+    source: Optional[str] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {k: v for k, v in asdict(self).items() if v is not None}
+
+
+@dataclass
+class DiagnosticReport:
+    """Aggregated doctor / config-validate output."""
+
+    ok: bool = True
+    sections: Dict[str, Any] = field(default_factory=dict)
+    findings: List[Finding] = field(default_factory=list)
+
+    def add(self, finding: Finding) -> None:
+        self.findings.append(finding)
+        if finding.level == "error":
+            self.ok = False
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "ok": self.ok,
+            "sections": self.sections,
+            "findings": [f.to_dict() for f in self.findings],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Shared JSON-object loader
+# ---------------------------------------------------------------------------
+
+
+def _load_json_object(
+    path: Path,
+    *,
+    area: str,
+    label: Optional[str] = None,
+) -> Tuple[Optional[Dict[str, Any]], FileStatus, Optional[Finding]]:
+    """Read ``path`` as a JSON object with explicit absence/parse semantics.
+
+    Returns ``(data, status, finding)``:
+
+    - ``data`` is the parsed object, or ``None`` for any non-``"ok"`` status;
+    - ``status`` distinguishes ``"absent"`` (no file) from ``"unreadable"``
+      (filesystem error) and ``"malformed"`` (JSON or shape error);
+    - ``finding`` is ``None`` when status is ``"absent"`` or ``"ok"``;
+      otherwise it is an error-level Finding the caller can append.
+
+    ``label`` is used in user-facing messages so files that exist in multiple
+    scopes (``"user-scope mcp.json"``) read sensibly. Defaults to ``path.name``.
+    """
+    display = label or path.name
+    if not path.is_file():
+        return None, "absent", None
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        return None, "unreadable", Finding(
+            level="error",
+            area=area,
+            message=f"Cannot read {display}: {type(exc).__name__}: {exc}",
+            source=str(path),
+        )
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        return None, "malformed", Finding(
+            level="error",
+            area=area,
+            message=(
+                f"Invalid JSON in {display}: "
+                f"{exc.msg} (line {exc.lineno}, col {exc.colno})"
+            ),
+            source=str(path),
+        )
+    if not isinstance(data, dict):
+        return None, "malformed", Finding(
+            level="error",
+            area=area,
+            message=f"Top-level value in {display} is not an object",
+            source=str(path),
+        )
+    return data, "ok", None
+
+
+# ---------------------------------------------------------------------------
+# Per-section collectors
+# ---------------------------------------------------------------------------
+
+
+def _collect_settings(wd: Path, report: DiagnosticReport) -> Optional[Dict[str, Any]]:
+    """Load ``.agentao/settings.json`` and record parse findings.
+
+    Returns the parsed dict (``None`` on missing/malformed). The path is always
+    reported in the section so consumers can see where the loader looked.
+    """
+    path = wd / ".agentao" / "settings.json"
+    data, status, finding = _load_json_object(
+        path, area="settings", label="settings.json",
+    )
+    if finding is not None:
+        report.add(finding)
+
+    section: Dict[str, Any] = {
+        "path": str(path),
+        "exists": status != "absent",
+        "status": status,
+    }
+    if data is not None:
+        section["keys"] = sorted(data.keys())
+    report.sections["settings"] = section
+    return data
+
+
+def _collect_provider(report: DiagnosticReport) -> None:
+    """Report which LLM provider env vars are present (no secret values)."""
+    provider = os.getenv("LLM_PROVIDER", "OPENAI").strip().upper()
+    api_key = os.getenv(f"{provider}_API_KEY")
+    base_url = os.getenv(f"{provider}_BASE_URL")
+    model = os.getenv(f"{provider}_MODEL")
+
+    section: Dict[str, Any] = {
+        "provider": provider,
+        "api_key_present": bool(api_key),
+        "base_url": base_url,
+        "model": model,
+    }
+    temperature_raw = os.getenv("LLM_TEMPERATURE")
+    if temperature_raw is not None:
+        section["temperature_raw"] = temperature_raw
+        try:
+            float(temperature_raw)
+        except ValueError:
+            report.add(Finding(
+                level="error",
+                area="provider",
+                message=(
+                    f"LLM_TEMPERATURE='{temperature_raw}' is not a valid float."
+                ),
+                source="env:LLM_TEMPERATURE",
+            ))
+    max_tokens_raw = os.getenv("LLM_MAX_TOKENS")
+    if max_tokens_raw is not None:
+        section["max_tokens_raw"] = max_tokens_raw
+        try:
+            int(max_tokens_raw)
+        except ValueError:
+            report.add(Finding(
+                level="error",
+                area="provider",
+                message=(
+                    f"LLM_MAX_TOKENS='{max_tokens_raw}' is not a valid integer."
+                ),
+                source="env:LLM_MAX_TOKENS",
+            ))
+
+    report.sections["provider"] = section
+
+    if not api_key:
+        report.add(Finding(
+            level="warning",
+            area="provider",
+            message=(
+                f"{provider}_API_KEY is not set. LLM calls will fail until "
+                f"the key is configured (run `agentao init` or edit .env)."
+            ),
+            source=f"env:{provider}_API_KEY",
+        ))
+
+
+def _collect_permissions(wd: Path, report: DiagnosticReport) -> None:
+    """Load permission rules and capture parse-status findings.
+
+    Mirrors ``embedding.permission_loader.load_permission_rules`` but
+    distinguishes 'missing' from 'malformed' so the user knows when their file
+    is being silently ignored.
+    """
+    from ..paths import user_root
+
+    ur = user_root()
+    user_path = ur / "permissions.json"
+    project_path = wd / ".agentao" / "permissions.json"
+
+    section: Dict[str, Any] = {
+        "user_path": str(user_path),
+        "user_status": "absent",
+        "project_path": str(project_path),
+        "project_status": "absent",
+        "rule_count": 0,
+        "loaded_sources": [],
+    }
+
+    data, status, finding = _load_json_object(
+        user_path, area="permissions", label="user-scope permissions.json",
+    )
+    if finding is not None:
+        report.add(finding)
+    section["user_status"] = status
+    if status == "ok" and data is not None:
+        rules = data.get("rules", [])
+        if not isinstance(rules, list):
+            section["user_status"] = "malformed"
+            report.add(Finding(
+                level="error",
+                area="permissions",
+                message="'rules' in permissions.json must be a list",
+                source=str(user_path),
+            ))
+        else:
+            section["rule_count"] = len(rules)
+            section["loaded_sources"].append(f"user:{user_path}")
+
+    if project_path.exists():
+        section["project_status"] = "ignored"
+        report.add(Finding(
+            level="warning",
+            area="permissions",
+            message=(
+                "Project-scope permissions.json is no longer honored "
+                "(could grant capabilities the user never approved). "
+                "Move custom rules to the user-scope file."
+            ),
+            source=str(project_path),
+        ))
+
+    report.sections["permissions"] = section
+
+
+def _validate_mcp_server_fields(servers: Dict[str, Any]) -> List[str]:
+    """Return error messages for any server with non-string env/headers/args.
+
+    The MCP runtime loader walks these fields and assumes every value is a
+    string; non-string values raise ``TypeError`` from inside the env-var
+    expansion regex. Validate them so the failure surfaces here rather than
+    at agent startup.
+    """
+    messages: List[str] = []
+    for name, cfg in servers.items():
+        for field_name in ("env", "headers"):
+            value = cfg.get(field_name)
+            if value is None:
+                continue
+            if not isinstance(value, dict):
+                messages.append(
+                    f"server {name!r}: {field_name!r} must be an object"
+                )
+                continue
+            bad = [k for k, v in value.items() if not isinstance(v, str)]
+            if bad:
+                messages.append(
+                    f"server {name!r}: {field_name!r} values must be strings "
+                    f"(non-string keys: {', '.join(repr(k) for k in bad)})"
+                )
+        args = cfg.get("args")
+        if args is None:
+            continue
+        if not isinstance(args, list):
+            messages.append(f"server {name!r}: 'args' must be a list")
+            continue
+        if not all(isinstance(a, str) for a in args):
+            messages.append(f"server {name!r}: 'args' must contain only strings")
+    return messages
+
+
+def _collect_mcp(wd: Path, report: DiagnosticReport) -> None:
+    """Validate MCP config files and report server counts."""
+    from ..paths import user_root
+
+    ur = user_root()
+    user_path = ur / "mcp.json"
+    project_path = wd / ".agentao" / "mcp.json"
+
+    section: Dict[str, Any] = {
+        "user_path": str(user_path),
+        "user_status": "absent",
+        "user_server_count": 0,
+        "project_path": str(project_path),
+        "project_status": "absent",
+        "project_server_count": 0,
+    }
+    server_names: Dict[str, set] = {"user": set(), "project": set()}
+
+    def _check(label: str, path: Path) -> None:
+        data, status, finding = _load_json_object(
+            path, area="mcp", label=f"{label}-scope mcp.json",
+        )
+        if finding is not None:
+            report.add(finding)
+        section[f"{label}_status"] = status
+        if status != "ok" or data is None:
+            return
+        servers = data.get("mcpServers", {})
+        if not isinstance(servers, dict):
+            section[f"{label}_status"] = "malformed"
+            report.add(Finding(
+                level="error",
+                area="mcp",
+                message=f"'mcpServers' in {label}-scope mcp.json must be an object",
+                source=str(path),
+            ))
+            return
+        # Each entry value must also be a dict — the runtime loader's
+        # ``_expand_config_env`` calls ``dict(config)`` on it and will raise
+        # on a string/list/null, so validation should reject it up front.
+        bad_entries = [
+            name for name, cfg in servers.items() if not isinstance(cfg, dict)
+        ]
+        if bad_entries:
+            section[f"{label}_status"] = "malformed"
+            report.add(Finding(
+                level="error",
+                area="mcp",
+                message=(
+                    f"{label}-scope mcp.json has non-object server entries: "
+                    f"{', '.join(repr(n) for n in bad_entries)}"
+                ),
+                source=str(path),
+            ))
+            return
+        # The runtime loader's ``expand_env_vars`` walks ``env``, ``headers``,
+        # and ``args`` and assumes every value is a string. Non-string values
+        # would raise ``TypeError`` at startup. Validate them up front so the
+        # failure is visible from ``config validate`` instead of first run.
+        nested_errors = _validate_mcp_server_fields(servers)
+        if nested_errors:
+            section[f"{label}_status"] = "malformed"
+            for msg in nested_errors:
+                report.add(Finding(
+                    level="error",
+                    area="mcp",
+                    message=f"{label}-scope mcp.json: {msg}",
+                    source=str(path),
+                ))
+            return
+        section[f"{label}_server_count"] = len(servers)
+        server_names[label] = set(servers.keys())
+
+    _check("user", user_path)
+    _check("project", project_path)
+
+    # User scope wins on name collision; the runtime drops project-scope
+    # entries that share a name with a user entry and logs a warning. The
+    # validator must mirror that so the user notices the project entry will
+    # not take effect.
+    shadowed = server_names["user"] & server_names["project"]
+    if shadowed:
+        section["shadowed_project_servers"] = sorted(shadowed)
+        report.add(Finding(
+            level="warning",
+            area="mcp",
+            message=(
+                "Project-scope mcp.json entries are shadowed by user-scope "
+                "entries with the same name (project entries ignored at "
+                f"runtime): {', '.join(repr(n) for n in sorted(shadowed))}"
+            ),
+            source=str(project_path),
+        ))
+
+    report.sections["mcp"] = section
+
+
+def _collect_replay(
+    wd: Path,
+    report: DiagnosticReport,
+    settings_data: Optional[Dict[str, Any]],
+) -> None:
+    """Report effective replay configuration.
+
+    Takes the already-parsed ``settings.json`` dict so the doctor doesn't
+    open the same file twice. ``ReplayConfig.from_mapping`` is *deliberately*
+    lenient at runtime — it coerces malformed values to defaults so a broken
+    settings file never blocks startup. That leniency is the wrong default
+    for an explicit validation command, so we walk the raw block first and
+    surface findings for shapes that ``from_mapping`` would silently swallow.
+    """
+    from ..replay.config import CAPTURE_FLAG_DEFAULTS, ReplayConfig, settings_path
+
+    raw = settings_data.get("replay") if settings_data else None
+    source = str(settings_path(wd))
+
+    if raw is not None and not isinstance(raw, dict):
+        report.add(Finding(
+            level="error",
+            area="replay",
+            message=(
+                f"'replay' in settings.json must be an object, got "
+                f"{type(raw).__name__}"
+            ),
+            source=source,
+        ))
+    elif isinstance(raw, dict):
+        if "enabled" in raw and not isinstance(raw["enabled"], (bool, str)):
+            report.add(Finding(
+                level="error",
+                area="replay",
+                message=(
+                    f"replay.enabled must be a bool or bool-like string, "
+                    f"got {type(raw['enabled']).__name__}"
+                ),
+                source=source,
+            ))
+        if "max_instances" in raw:
+            try:
+                parsed = int(raw["max_instances"])
+            except (TypeError, ValueError):
+                report.add(Finding(
+                    level="error",
+                    area="replay",
+                    message=(
+                        f"replay.max_instances must be an integer, got "
+                        f"{raw['max_instances']!r}"
+                    ),
+                    source=source,
+                ))
+            else:
+                # ``from_mapping`` silently replaces any value < 1 with the
+                # default — that means ``max_instances: 0`` parses but is
+                # ignored at runtime. Surface it as a validation error so
+                # the user does not assume their (no-op) value applied.
+                if parsed < 1:
+                    report.add(Finding(
+                        level="error",
+                        area="replay",
+                        message=(
+                            f"replay.max_instances must be >= 1, got "
+                            f"{parsed} (ignored at runtime)"
+                        ),
+                        source=source,
+                    ))
+        raw_flags = raw.get("capture_flags")
+        if raw_flags is not None and not isinstance(raw_flags, dict):
+            report.add(Finding(
+                level="error",
+                area="replay",
+                message=(
+                    f"replay.capture_flags must be an object, got "
+                    f"{type(raw_flags).__name__}"
+                ),
+                source=source,
+            ))
+        elif isinstance(raw_flags, dict):
+            unknown = [k for k in raw_flags if k not in CAPTURE_FLAG_DEFAULTS]
+            if unknown:
+                report.add(Finding(
+                    level="warning",
+                    area="replay",
+                    message=(
+                        f"Unknown replay.capture_flags keys (ignored at "
+                        f"runtime): {', '.join(repr(k) for k in unknown)}"
+                    ),
+                    source=source,
+                ))
+            for key, value in raw_flags.items():
+                if key in CAPTURE_FLAG_DEFAULTS and not isinstance(value, (bool, str)):
+                    report.add(Finding(
+                        level="error",
+                        area="replay",
+                        message=(
+                            f"replay.capture_flags[{key!r}] must be a bool or "
+                            f"bool-like string, got {type(value).__name__}"
+                        ),
+                        source=source,
+                    ))
+
+    cfg = ReplayConfig.from_mapping(raw)
+    report.sections["replay"] = {
+        "source": source,
+        "status": "ok",
+        "enabled": cfg.enabled,
+        "max_instances": cfg.max_instances,
+        "capture_flags": dict(cfg.capture_flags),
+        "deep_capture_enabled": cfg.deep_capture_enabled(),
+    }
+
+
+def _collect_acp_schema(report: DiagnosticReport) -> None:
+    """Best-effort probe that the host/ACP schema exports still resolve."""
+    section: Dict[str, Any] = {}
+    try:
+        from ..host.schema import (
+            export_host_acp_json_schema,
+            export_host_event_json_schema,
+        )
+        events_schema = export_host_event_json_schema()
+        acp_schema = export_host_acp_json_schema()
+        section["status"] = "ok"
+        section["events_defs"] = len(events_schema.get("$defs", {}))
+        section["acp_defs"] = len(acp_schema.get("$defs", {}))
+    except Exception as exc:
+        section["status"] = "error"
+        section["error"] = f"{type(exc).__name__}: {exc}"
+        report.add(Finding(
+            level="error",
+            area="acp_schema",
+            message=f"Host/ACP schema export failed: {type(exc).__name__}: {exc}",
+        ))
+    report.sections["acp_schema"] = section
+
+
+def _collect_memory_stores(wd: Path, report: DiagnosticReport) -> None:
+    """Probe project + user SQLite memory stores without creating them.
+
+    ``sqlite3.connect`` on a non-existent path silently creates an empty file,
+    which would mean running ``agentao doctor`` bootstraps a memory DB in
+    directories the user never opted into. We pre-check existence and probe
+    read-only when the file is already there.
+    """
+    from ..paths import user_root
+
+    project_path = wd / ".agentao" / "memory.db"
+    ur = user_root()
+    user_path: Optional[Path] = (ur / "memory.db") if ur is not None else None
+
+    section: Dict[str, Any] = {
+        "project_path": str(project_path),
+        "project_status": "absent",
+        "user_path": str(user_path) if user_path else None,
+        "user_status": "absent" if user_path else "skipped",
+    }
+
+    def _probe(path: Path, label: str) -> None:
+        if not path.exists():
+            return
+        try:
+            conn = sqlite3.connect(f"file:{path}?mode=ro", uri=True)
+            conn.close()
+        except (OSError, sqlite3.Error) as exc:
+            section[f"{label}_status"] = "unavailable"
+            section[f"{label}_error"] = f"{type(exc).__name__}: {exc}"
+            report.add(Finding(
+                # Project-scope failure degrades to :memory: at runtime and
+                # user-scope failure disables the scope entirely; neither
+                # crashes the agent, so both are warnings, not errors.
+                level="warning",
+                area="memory",
+                message=(
+                    f"{label.capitalize()}-scope memory store unavailable: "
+                    f"{type(exc).__name__}: {exc}"
+                ),
+                source=str(path),
+            ))
+            return
+        section[f"{label}_status"] = "ok"
+
+    _probe(project_path, "project")
+    if user_path is not None:
+        _probe(user_path, "user")
+
+    report.sections["memory"] = section
+
+
+def _collect_plugins(report: DiagnosticReport) -> None:
+    """Reuse ``collect_full_plugin_diagnostics`` for the plugin section.
+
+    Shares the post-load registration simulation with ``agentao plugin list``
+    so the two commands cannot drift on which plugins they consider failed.
+    """
+    from ..embedding.plugins.diagnostics import collect_full_plugin_diagnostics
+
+    try:
+        loaded, failed_plugins, diag = collect_full_plugin_diagnostics(
+            inline_dirs=_plugin_inline_dirs or None,
+        )
+    except Exception as exc:
+        report.sections["plugins"] = {
+            "status": "error",
+            "error": f"{type(exc).__name__}: {exc}",
+        }
+        report.add(Finding(
+            level="error",
+            area="plugins",
+            message=f"Plugin discovery failed: {type(exc).__name__}: {exc}",
+        ))
+        return
+
+    plugins = [
+        {
+            "name": p.name,
+            "version": p.version,
+            "source": p.source,
+            "marketplace": p.marketplace,
+            "qualified_name": p.qualified_name,
+            "root_path": str(p.root_path),
+            "status": "failed" if p.name in failed_plugins else "ok",
+        }
+        for p in loaded
+    ]
+    report.sections["plugins"] = {
+        "status": "ok",
+        "count": diag.plugin_count,
+        "plugins": plugins,
+        "warnings": [str(w) for w in diag.warnings],
+        "errors": [str(e) for e in diag.errors],
+    }
+    for w in diag.warnings:
+        report.add(Finding(level="warning", area="plugins", message=str(w)))
+    for e in diag.errors:
+        report.add(Finding(level="error", area="plugins", message=str(e)))
+
+
+def _collect_optional_deps(report: DiagnosticReport) -> None:
+    """Probe optional dependencies relevant to common features."""
+    # Keep this list short — only deps the design doc explicitly allows
+    # ("only where the feature is configured or obviously requested").
+    probes = (
+        ("rich", "cli"),
+        ("prompt_toolkit", "cli"),
+        ("readchar", "cli"),
+        ("mcp", "mcp"),
+        ("openai", "llm"),
+        ("httpx", "web"),
+    )
+    deps: Dict[str, Dict[str, Any]] = {}
+    for name, feature in probes:
+        try:
+            present = importlib.util.find_spec(name) is not None
+        except (ImportError, ValueError):
+            present = False
+        deps[name] = {"feature": feature, "present": present}
+    report.sections["optional_deps"] = deps
+
+
+# ---------------------------------------------------------------------------
+# Rendering
+# ---------------------------------------------------------------------------
+
+
+_FINDING_TAG = {
+    "error": "[red]ERROR[/red]",
+    "warning": "[yellow]WARN[/yellow]",
+    "info": "[cyan]INFO[/cyan]",
+}
+
+
+def _render_human(report: DiagnosticReport, *, header: str) -> None:
+    """Print a human-readable summary to the rich console."""
+    sections = report.sections
+
+    console.print(f"[bold]{header}[/bold]")
+    console.print()
+
+    if "settings" in sections:
+        s = sections["settings"]
+        status = s.get("status", "absent")
+        console.print(f"[bold]settings.json[/bold]: {status}  [dim]{s['path']}[/dim]")
+
+    if "provider" in sections:
+        s = sections["provider"]
+        marker = "[green]yes[/green]" if s["api_key_present"] else "[red]no[/red]"
+        console.print(
+            f"[bold]LLM provider[/bold]: {s['provider']} "
+            f"(api_key={marker}, model={s.get('model') or '-'}, "
+            f"base_url={s.get('base_url') or '-'})"
+        )
+
+    if "permissions" in sections:
+        s = sections["permissions"]
+        console.print(
+            f"[bold]Permissions[/bold]: user={s['user_status']} "
+            f"(rules={s['rule_count']}), project={s['project_status']}"
+        )
+
+    if "mcp" in sections:
+        s = sections["mcp"]
+        console.print(
+            f"[bold]MCP[/bold]: user={s['user_status']} "
+            f"(servers={s['user_server_count']}), "
+            f"project={s['project_status']} (servers={s['project_server_count']})"
+        )
+
+    if "replay" in sections:
+        s = sections["replay"]
+        enabled = "on" if s["enabled"] else "off"
+        console.print(
+            f"[bold]Replay[/bold]: {enabled}  "
+            f"max_instances={s['max_instances']}, "
+            f"deep_capture={'yes' if s['deep_capture_enabled'] else 'no'}"
+        )
+
+    if "acp_schema" in sections:
+        s = sections["acp_schema"]
+        if s.get("status") == "ok":
+            console.print(
+                f"[bold]ACP schema[/bold]: ok  "
+                f"events_defs={s['events_defs']}, acp_defs={s['acp_defs']}"
+            )
+        else:
+            console.print(f"[bold]ACP schema[/bold]: [red]error[/red] — {s.get('error','')}")
+
+    if "memory" in sections:
+        s = sections["memory"]
+        console.print(
+            f"[bold]Memory stores[/bold]: project={s['project_status']}, "
+            f"user={s['user_status']}"
+        )
+
+    if "plugins" in sections:
+        s = sections["plugins"]
+        if s.get("status") == "ok":
+            console.print(
+                f"[bold]Plugins[/bold]: {s['count']} loaded, "
+                f"warnings={len(s.get('warnings', []))}, "
+                f"errors={len(s.get('errors', []))}"
+            )
+        else:
+            console.print(f"[bold]Plugins[/bold]: [red]error[/red] — {s.get('error','')}")
+
+    if "optional_deps" in sections:
+        deps = sections["optional_deps"]
+        missing = [name for name, info in deps.items() if not info["present"]]
+        if missing:
+            console.print(
+                f"[bold]Optional deps[/bold]: missing {', '.join(missing)} "
+                f"[dim](features may degrade)[/dim]"
+            )
+        else:
+            console.print("[bold]Optional deps[/bold]: all probed packages present")
+
+    if report.findings:
+        console.print()
+        console.print("[bold]Findings[/bold]:")
+        for f in report.findings:
+            tag = _FINDING_TAG.get(f.level, f.level.upper())
+            src = f" [dim]({f.source})[/dim]" if f.source else ""
+            console.print(f"  {tag} [{f.area}] {f.message}{src}")
+    else:
+        console.print()
+        console.print("[green]No findings.[/green]")
+
+
+# ---------------------------------------------------------------------------
+# Public entry points
+# ---------------------------------------------------------------------------
+
+
+def handle_doctor_subcommand(args) -> None:
+    """Run ``agentao doctor``: aggregate every health signal Agentao already owns."""
+    wd = Path.cwd().resolve()
+    _load_dotenv(wd)
+    report = DiagnosticReport()
+
+    settings_data = _collect_settings(wd, report)
+    _collect_provider(report)
+    _collect_permissions(wd, report)
+    _collect_mcp(wd, report)
+    _collect_replay(wd, report, settings_data)
+    _collect_acp_schema(report)
+    _collect_memory_stores(wd, report)
+    _collect_plugins(report)
+    _collect_optional_deps(report)
+
+    if getattr(args, "json_output", False):
+        print(json.dumps(report.to_dict(), indent=2))
+    else:
+        _render_human(report, header=f"agentao doctor — {wd}")
+
+    # Doctor never exits non-zero on warnings; only errors flip the gate.
+    if not report.ok:
+        sys.exit(1)
+
+
+def handle_config_validate_subcommand(args) -> None:
+    """Run ``agentao config validate``: report config errors without changing startup."""
+    wd = Path.cwd().resolve()
+    _load_dotenv(wd)
+    report = DiagnosticReport()
+
+    settings_data = _collect_settings(wd, report)
+    _collect_provider(report)
+    _collect_permissions(wd, report)
+    _collect_mcp(wd, report)
+    _collect_replay(wd, report, settings_data)
+    _collect_memory_stores(wd, report)
+
+    if getattr(args, "json_output", False):
+        print(json.dumps(report.to_dict(), indent=2))
+    else:
+        _render_human(report, header=f"agentao config validate — {wd}")
+
+    if not report.ok:
+        sys.exit(1)
+
+
+def handle_config_subcommand(args) -> None:
+    """Dispatch ``agentao config <action>`` subcommands."""
+    action = getattr(args, "config_action", None)
+    if action == "validate":
+        handle_config_validate_subcommand(args)
+    else:
+        sys.stderr.write("Usage: agentao config {validate}\n")
+        sys.exit(2)
+
+
+__all__ = [
+    "DiagnosticReport",
+    "Finding",
+    "handle_config_subcommand",
+    "handle_config_validate_subcommand",
+    "handle_doctor_subcommand",
+]

--- a/agentao/cli/entrypoints.py
+++ b/agentao/cli/entrypoints.py
@@ -316,6 +316,29 @@ def _build_parser():
         help="Scope to update (default: auto-detect)",
     )
 
+    doctor_parser = subparsers.add_parser(
+        "doctor",
+        help="Aggregate Agentao health signals (config, plugins, permissions, …).",
+    )
+    doctor_parser.add_argument(
+        "--json", dest="json_output", action="store_true",
+        help="Emit a single JSON document instead of a human-readable report.",
+    )
+
+    config_parser = subparsers.add_parser(
+        "config",
+        help="Inspect or validate Agentao configuration.",
+    )
+    config_sub = config_parser.add_subparsers(dest="config_action")
+    config_validate_p = config_sub.add_parser(
+        "validate",
+        help="Report config errors in settings, permissions, MCP, replay, memory.",
+    )
+    config_validate_p.add_argument(
+        "--json", dest="json_output", action="store_true",
+        help="Emit a single JSON document instead of a human-readable report.",
+    )
+
     return parser
 
 
@@ -370,6 +393,25 @@ def entrypoint():
         _cli.handle_plugin_subcommand(args)
     elif args.subcommand == "skill":
         _cli.handle_skill_subcommand(args)
+    elif args.subcommand == "doctor":
+        # Automation-oriented like ``run``: a typo (``--jsno`` instead of
+        # ``--json``) must fail loudly so CI surfaces the broken invocation
+        # instead of exit-0 success against the wrong flag.
+        if extras:
+            sys.stderr.write(
+                "agentao doctor: unrecognized arguments: "
+                + " ".join(extras) + "\n"
+            )
+            sys.exit(2)
+        _cli.handle_doctor_subcommand(args)
+    elif args.subcommand == "config":
+        if extras:
+            sys.stderr.write(
+                "agentao config: unrecognized arguments: "
+                + " ".join(extras) + "\n"
+            )
+            sys.exit(2)
+        _cli.handle_config_subcommand(args)
     elif args.prompt is not None:
         stdin_text = "" if sys.stdin.isatty() else sys.stdin.read()
         parts = [p for p in [args.prompt.strip(), stdin_text.strip()] if p]

--- a/agentao/cli/subcommands.py
+++ b/agentao/cli/subcommands.py
@@ -247,43 +247,14 @@ def handle_plugin_subcommand(args) -> None:
 
 def _plugin_list_cli(args) -> None:
     """``agentao plugin list`` — show loaded plugins with diagnostics."""
-    from ..embedding.plugins.diagnostics import build_diagnostics
-    from ..embedding.plugins.manager import PluginManager
+    from ..embedding.plugins.diagnostics import collect_full_plugin_diagnostics
 
     _top = getattr(args, "plugin_dirs", []) or []
     _sub = getattr(args, "sub_plugin_dirs", None) or []
     inline_dirs = [Path(d) for d in _top + _sub]
-    mgr = PluginManager(inline_dirs=inline_dirs)
-    loaded = mgr.load_plugins()
-
-    # Simulate registration checks so the listing reflects post-load
-    # failures (e.g. skill/agent name collisions) that would cause
-    # _load_and_register_plugins() to reject a plugin at runtime.
-    from ..embedding.plugins.resolvers.agents import resolve_plugin_agents
-    from ..embedding.plugins.resolvers.skills import resolve_plugin_entries
-
-    all_warnings = list(mgr.get_warnings())
-    all_errors = list(mgr.get_errors())
-    failed_plugins: set[str] = set()
-
-    for plugin in loaded:
-        entries, pw, pe = resolve_plugin_entries(plugin)
-        all_warnings.extend(pw)
-        all_errors.extend(pe)
-        if pe:
-            failed_plugins.add(plugin.name)
-
-    for plugin in loaded:
-        if plugin.name in failed_plugins:
-            continue
-        defs, aw, ae = resolve_plugin_agents(plugin)
-        all_warnings.extend(aw)
-        all_errors.extend(ae)
-        if ae:
-            failed_plugins.add(plugin.name)
-
-    healthy = [p for p in loaded if p.name not in failed_plugins]
-    diag = build_diagnostics(healthy, all_warnings, all_errors)
+    loaded, failed_plugins, diag = collect_full_plugin_diagnostics(
+        inline_dirs=inline_dirs,
+    )
 
     if getattr(args, "json_output", False):
         import json as _json

--- a/agentao/embedding/plugins/diagnostics.py
+++ b/agentao/embedding/plugins/diagnostics.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from pathlib import Path
+from typing import List, Optional, Tuple
 
 from agentao.plugins.models import LoadedPlugin, PluginLoadError, PluginWarning
 
@@ -72,3 +74,58 @@ def build_diagnostics(
         warnings=list(warnings),
         errors=list(errors),
     )
+
+
+def collect_full_plugin_diagnostics(
+    *,
+    inline_dirs: Optional[List[Path]] = None,
+) -> Tuple[List[LoadedPlugin], set[str], "PluginDiagnostics"]:
+    """Load plugins **and** simulate registration to surface post-load errors.
+
+    ``PluginManager.load_plugins`` alone misses the failures that only show up
+    once ``resolve_plugin_entries`` / ``resolve_plugin_agents`` run — for
+    example, skill or agent name collisions that would cause
+    ``_load_and_register_plugins`` to reject the plugin at runtime. Returning
+    just the manager's view would mean ``agentao doctor`` under-reports
+    compared to ``agentao plugin list``.
+
+    Returns ``(loaded, failed_names, diagnostics)``:
+
+    - ``loaded`` is the unfiltered list (callers that need per-plugin
+      ``"ok"`` / ``"failed"`` status pair it with ``failed_names``);
+    - ``failed_names`` is the set of plugin names that fell out during
+      registration simulation;
+    - ``diagnostics`` already has resolver warnings/errors folded in and its
+      ``loaded`` field contains only healthy plugins.
+    """
+    # Local imports keep the diagnostics module light on its own load path.
+    from .manager import PluginManager
+    from .resolvers.agents import resolve_plugin_agents
+    from .resolvers.skills import resolve_plugin_entries
+
+    mgr = PluginManager(inline_dirs=inline_dirs)
+    loaded = mgr.load_plugins()
+
+    all_warnings = list(mgr.get_warnings())
+    all_errors = list(mgr.get_errors())
+    failed_plugins: set[str] = set()
+
+    for plugin in loaded:
+        _entries, pw, pe = resolve_plugin_entries(plugin)
+        all_warnings.extend(pw)
+        all_errors.extend(pe)
+        if pe:
+            failed_plugins.add(plugin.name)
+
+    for plugin in loaded:
+        if plugin.name in failed_plugins:
+            continue
+        _defs, aw, ae = resolve_plugin_agents(plugin)
+        all_warnings.extend(aw)
+        all_errors.extend(ae)
+        if ae:
+            failed_plugins.add(plugin.name)
+
+    healthy = [p for p in loaded if p.name not in failed_plugins]
+    diag = build_diagnostics(healthy, all_warnings, all_errors)
+    return loaded, failed_plugins, diag

--- a/developer-guide/en/cli/10-config-reference.md
+++ b/developer-guide/en/cli/10-config-reference.md
@@ -95,11 +95,26 @@ Files that exist under `.agentao/` but you should **not** hand-edit:
 
 Editing them while the CLI is running can desync state. Stop the CLI first if you must.
 
+## Verify your config
+
+Two non-interactive commands inspect the files in the tables above without starting an agent:
+
+```bash
+agentao config validate      # config files only (.env, settings, permissions, mcp, replay, memory)
+agentao config validate --json
+
+agentao doctor               # adds plugin diagnostics, ACP schema, optional-dep probes
+agentao doctor --json
+```
+
+Use them in CI, in a `make check` target, or right after editing one of the files in the table above. Errors (malformed JSON, non-object MCP entries, unparseable `LLM_TEMPERATURE`, etc.) exit **1**; warnings (missing API key on a fresh clone, user/project MCP collisions) keep exit **0** so CI doesn't trip on benign states. Full surface is documented in [chapter 12](./12-non-interactive#agentao-doctor-health-snapshot).
+
 ## Where to go next
 
 | Want to… | Read |
 |----------|------|
 | Full schema reference for any of the files above | [`docs/CONFIGURATION.md`](https://github.com/jin-bo/agentao/blob/main/docs/CONFIGURATION.md) |
+| Validate your config files from CI | [12. Non-Interactive Entry Points → `agentao config validate`](./12-non-interactive#agentao-config-validate-explicit-config-check) |
 | Change default permission rules with intent | [Part 5.4 · Permissions](/en/part-5/4-permissions) |
 | Author an `AGENTAO.md` for your project | [Part 5.6 · System Prompt Customization](/en/part-5/6-system-prompt) |
 

--- a/developer-guide/en/cli/12-non-interactive.md
+++ b/developer-guide/en/cli/12-non-interactive.md
@@ -173,6 +173,44 @@ agentao plugin list --json
 
 This loads plugins and emits diagnostics, useful for CI or pre-release checks. REPL `/plugins` is the interactive version of the same surface.
 
+## `agentao doctor` — health snapshot
+
+```bash
+agentao doctor
+agentao doctor --json
+```
+
+Aggregates every health signal the harness already produces — `.env` provider check (API-key *presence*, never the value), `settings.json`, permissions, MCP, replay config, ACP schema export, project + user memory stores, plugin diagnostics, and optional-dep probes — into one report. `--json` is the contract surface for CI / hosts; the human-readable default is for terminal use.
+
+Output contract:
+
+- `{"ok": bool, "sections": {...}, "findings": [...]}`
+- `ok` is `false` iff at least one finding has `"level": "error"`; in that case the command exits **1**. Warnings (e.g. "API key not set" on a fresh clone) keep `ok=true` and exit **0** so they don't trip CI.
+- Findings carry `level` (`info` / `warning` / `error`), `area` (the section the issue belongs to), a human message, and `source` (path or env-var label).
+- Doctor is **read-only**: it never creates a memory DB or mutates files. Probing an absent `memory.db` reports `"absent"` without bootstrapping the file.
+- Unknown flags fail with exit **2** (like `agentao run`), so a CI typo (`--jsno`) surfaces instead of exiting 0 against the wrong invocation.
+
+## `agentao config validate` — explicit config check
+
+```bash
+agentao config validate
+agentao config validate --json
+```
+
+A narrower companion to `doctor` that *only* validates user-editable config — `settings.json`, `.env` provider variables, `permissions.json`, `mcp.json`, the `replay` block in `settings.json`, and the memory-store probe. Plugin discovery is intentionally excluded (use `doctor` or `plugin list`).
+
+Validation surfaces problems the runtime would otherwise swallow silently:
+
+- malformed JSON or non-object shapes in any of the above files;
+- `LLM_TEMPERATURE` / `LLM_MAX_TOKENS` that fail to parse;
+- per-server MCP entries that aren't objects, with non-string `env` / `headers` / `args` values that would crash `expand_env_vars` at runtime;
+- user/project `mcp.json` name collisions (project entries are dropped at runtime — validate warns so you notice);
+- replay block values that `ReplayConfig.from_mapping` silently coerces away (`max_instances: 0`, non-bool capture flags, unknown flag keys, …).
+
+Runtime behavior is **unchanged** — `agentao config validate` is the explicit surface. The factory stays best-effort so an embedded host with a bad optional config isn't blocked from running.
+
+Both commands honor `--plugin-dir DIR` (doctor uses it for plugin discovery) and require the `[cli]` extra to be installed; without it the standard missing-dep guard prints an install hint.
+
 ---
 
 ::: tip Authoritative reference

--- a/developer-guide/en/cli/index.md
+++ b/developer-guide/en/cli/index.md
@@ -29,7 +29,7 @@ You drop into a chat REPL. Type a normal sentence to talk to the agent. Type `/`
 - [**9. Replay & Output**](./9-replay-output) — `/replay`, `/copy`, `/markdown` · record sessions, copy answers, render control
 - [**10. Configuration Reference**](./10-config-reference) — every config file the CLI reads, with paths and precedence
 - [**11. Sessions, Agents & Tasks**](./11-sessions-agents) — `/sessions`, `/agent`, `/agents`, `/todos`, `/tools` · restore and parallel workbench
-- [**12. Non-Interactive Entry Points**](./12-non-interactive) — `agentao init`, `-p`, `--resume`, `--acp` · scripts and host integration
+- [**12. Non-Interactive Entry Points**](./12-non-interactive) — `agentao init`, `-p`, `--resume`, `--acp`, `agentao doctor`, `agentao config validate` · scripts, CI checks, and host integration
 
 ## How to read
 

--- a/developer-guide/zh/cli/10-config-reference.md
+++ b/developer-guide/zh/cli/10-config-reference.md
@@ -95,11 +95,26 @@ cp examples/personas/daily-driver/AGENTAO.md /path/to/your/project/AGENTAO.md
 
 CLI 跑着的时候改它们会让状态对不上。非要改，先停 CLI。
 
+## 校验你的配置
+
+两个非交互命令可以在不启动 agent 的前提下检查上表中的所有文件：
+
+```bash
+agentao config validate      # 只看配置文件（.env / settings / permissions / mcp / replay / memory）
+agentao config validate --json
+
+agentao doctor               # 额外覆盖插件诊断、ACP schema、可选依赖探测
+agentao doctor --json
+```
+
+可以放进 CI、`make check` 目标，或刚改完上表里某个文件后跑一下。Error（JSON 损坏、MCP 单条非 object、`LLM_TEMPERATURE` 解析失败等）退出 **1**；warning（fresh clone 少 API key、user/project MCP 同名碰撞）保持退出 **0** 以免 CI 误绊。完整说明见[第 12 章](./12-non-interactive#agentao-doctor-健康快照)。
+
 ## 接下来读什么
 
 | 想做的事 | 读 |
 |---|---|
 | 上面任意文件的完整 schema | [`docs/CONFIGURATION.zh.md`](https://github.com/jin-bo/agentao/blob/main/docs/CONFIGURATION.zh.md) |
+| 在 CI 中校验配置文件 | [12. 非交互入口 → `agentao config validate`](./12-non-interactive#agentao-config-validate-显式配置校验) |
 | 有意识地改默认权限规则 | [Part 5.4 · 权限引擎](/zh/part-5/4-permissions) |
 | 给项目写一份 `AGENTAO.md` | [Part 5.6 · 系统提示定制](/zh/part-5/6-system-prompt) |
 

--- a/developer-guide/zh/cli/12-non-interactive.md
+++ b/developer-guide/zh/cli/12-non-interactive.md
@@ -173,6 +173,44 @@ agentao plugin list --json
 
 这会加载插件并输出诊断，适合 CI 或发布前检查。REPL 内的 `/plugins` 是同一类诊断的交互版。
 
+## `agentao doctor` —— 健康快照
+
+```bash
+agentao doctor
+agentao doctor --json
+```
+
+把 harness 已经能给出的所有健康信号汇总到一份报告里：`.env` 的 provider 检查（只看 API key **是否存在**，绝不输出 key 值）、`settings.json`、permissions、MCP、replay 配置、ACP schema 导出状态、项目 + 用户 memory store、插件诊断、可选依赖探测。`--json` 是给 CI / 宿主用的契约面，人类可读输出是终端默认。
+
+输出契约：
+
+- `{"ok": bool, "sections": {...}, "findings": [...]}`
+- `ok` 为 `false` 当且仅当至少一条 finding 的 `"level": "error"`，此时退出码为 **1**。Warning（例如刚 clone 时的 "API key not set"）保持 `ok=true`、退出 **0**，不会误绊 CI。
+- 每条 finding 含 `level`（`info` / `warning` / `error`）、`area`（所属 section）、可读 `message`、`source`（路径或环境变量标签）。
+- Doctor 是**只读**的：不会建 memory DB、不会改文件。探测一个不存在的 `memory.db` 会报 `"absent"`，绝不顺手把空文件创出来。
+- 未知 flag 退出码 **2**（与 `agentao run` 一致）—— 一旦 CI 写错（如 `--jsno`）会立即报错，不会用错误参数静默 exit 0。
+
+## `agentao config validate` —— 显式配置校验
+
+```bash
+agentao config validate
+agentao config validate --json
+```
+
+`doctor` 的窄版伙伴，**只**校验用户可编辑配置：`settings.json`、`.env` provider 变量、`permissions.json`、`mcp.json`、`settings.json` 的 `replay` 段、memory-store 探测。插件发现刻意排除（用 `doctor` 或 `plugin list`）。
+
+会显式报出运行时通常会**默默吞掉**的问题：
+
+- 上述文件的 JSON 损坏 / 顶层非 object 形态；
+- `LLM_TEMPERATURE` / `LLM_MAX_TOKENS` 解析失败；
+- MCP 单条 server 条目非 object，或其 `env` / `headers` / `args` 含非 string（运行时 `expand_env_vars` 会抛 `TypeError`）；
+- 用户级与项目级 `mcp.json` 同名碰撞（运行时会丢掉项目级条目，validate 会 warn 让你知道）；
+- `ReplayConfig.from_mapping` 会静默吞掉的 replay 设置（`max_instances: 0`、非 bool 的 capture flag、未知 flag 键等）。
+
+运行时行为**不变**——`agentao config validate` 是显式校验面。factory 仍是 best-effort，这样宿主带着可选配置坏掉时也不会被卡住启动。
+
+两个命令都支持 `--plugin-dir DIR`（doctor 用它来发现插件），且都依赖 `[cli]` extra；缺依赖时会走标准 missing-dep 守卫并打印安装提示。
+
 ---
 
 ::: tip 真相源头

--- a/developer-guide/zh/cli/index.md
+++ b/developer-guide/zh/cli/index.md
@@ -29,7 +29,7 @@ uv run agentao
 - [**9. 回放与输出**](./9-replay-output) — `/replay` `/copy` `/markdown` · 录会话、复制答案、控制渲染
 - [**10. 配置文件参考**](./10-config-reference) — CLI 读取的所有配置文件、路径与优先级
 - [**11. 会话、子 Agent 与任务**](./11-sessions-agents) — `/sessions` `/agent` `/agents` `/todos` `/tools` · 恢复与并行工作台
-- [**12. 非交互入口**](./12-non-interactive) — `agentao init` `-p` `--resume` `--acp` · 脚本和宿主集成入口
+- [**12. 非交互入口**](./12-non-interactive) — `agentao init` `-p` `--resume` `--acp` `agentao doctor` `agentao config validate` · 脚本、CI 校验、宿主集成入口
 
 ## 怎么读
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -6,6 +6,8 @@
 
 中文版本：[CONFIGURATION.zh.md](CONFIGURATION.zh.md)。Both docs share the same structure, section numbering, and field tables — when editing one, update the other in the same change.
 
+> **Quick check.** To verify any of the files below without booting an agent, run `agentao config validate` (or `agentao doctor` for plugin / ACP / optional-dep coverage as well). Both support `--json`; errors exit 1, warnings exit 0. See [developer-guide CLI ch. 12](https://github.com/jin-bo/agentao/blob/main/developer-guide/en/cli/12-non-interactive.md#agentao-doctor-health-snapshot).
+
 ---
 
 ## 1. Configuration surfaces at a glance

--- a/docs/CONFIGURATION.zh.md
+++ b/docs/CONFIGURATION.zh.md
@@ -6,6 +6,8 @@
 
 英文原版：[CONFIGURATION.md](CONFIGURATION.md)。两份文档结构、段号、字段表完全一致；如果某次改动只更新了其中一份，请同步另一份。
 
+> **快速校验。** 想不启动 agent 直接检查下面任意文件，跑 `agentao config validate`（或 `agentao doctor`，同时还覆盖插件 / ACP / 可选依赖）。两者都支持 `--json`：error 退出 1，warning 退出 0。详见 [developer-guide CLI 第 12 章](https://github.com/jin-bo/agentao/blob/main/developer-guide/zh/cli/12-non-interactive.md#agentao-doctor-健康快照)。
+
 ---
 
 ## 1. 配置面总览

--- a/docs/README.md
+++ b/docs/README.md
@@ -148,6 +148,7 @@ to them when they affect public behavior.
 
 | Document | Scope |
 |----------|-------|
+| [design/codex-reverse-review.md](design/codex-reverse-review.md) | Reverse review of Codex changes: what Agentao should adopt, what is already done, and what to defer |
 | [design/embedded-host-contract.md](design/embedded-host-contract.md) | Host-facing harness contract: schema discipline, event stream MVP, and CLI vs harness boundary |
 | [design/metacognitive-boundary.md](design/metacognitive-boundary.md) | Host-injectable self-vs-project boundary protocol |
 
@@ -158,6 +159,7 @@ These are contributor-oriented design and implementation documents. Some are pla
 Treat these as engineering context, not the canonical user surface:
 
 - [design/embedded-host-contract.md](design/embedded-host-contract.md)
+- [design/codex-reverse-review.md](design/codex-reverse-review.md)
 - [design/metacognitive-boundary.md](design/metacognitive-boundary.md)
 - [implementation/EMBEDDED_HARNESS_CONTRACT_IMPLEMENTATION_PLAN.md](implementation/EMBEDDED_HARNESS_CONTRACT_IMPLEMENTATION_PLAN.md)
 - [implementation/NON_INTERACTIVE_RUN_PLAN.md](implementation/NON_INTERACTIVE_RUN_PLAN.md)

--- a/docs/design/codex-reverse-review.md
+++ b/docs/design/codex-reverse-review.md
@@ -6,6 +6,136 @@ This note records the reverse review of the latest Codex changes against
 Agentao's current architecture. The goal is to identify what Agentao actually
 needs, not to mirror Codex's product shape.
 
+## 2026-05-17 Follow-up: Diagnostics, Not Product Weight
+
+A later review against the 2026-05-17 Codex pull refined the conclusion. The
+important correction is that most of the apparent Codex-inspired work is either
+already present in Agentao or too early for Agentao's current scale.
+
+The current actionable scope is deliberately small:
+
+1. Add `agentao doctor --json`.
+2. Add `agentao config validate`.
+
+Both should be small wiring PRs over existing signals. They should not become a
+new app-server diagnostics subsystem, a stricter runtime startup path, or a
+plugin marketplace project.
+
+### Verified Current State
+
+This section records the code-grounded checks that drive the narrowed scope.
+
+| Area | Current Agentao state |
+|------|-----------------------|
+| `doctor` / `config validate` CLI | Missing from `agentao/cli/`; this is a real gap. |
+| Factory error handling | `agentao/embedding/factory.py` intentionally has best-effort paths that swallow load/open errors. These should remain safe at runtime but become visible through validation. |
+| Permission snapshot | Already shipped. `Agentao.active_permissions()` returns `ActivePermissions(mode, rules, loaded_sources)`, backed by `PermissionEngine.active_permissions()` and `agentao/host/models.py`. No permission-profile rewrite is needed. |
+| Correlation IDs | Partially present. Host projection and replay already carry `session_id`, `turn_id`, `tool_call_id`, and `call_id`. Cross LLM/tool/MCP/ACP trace stitching is not a current P0. |
+| Plugin diagnostics | Already has a base in `agentao/embedding/plugins/diagnostics.py` via `PluginDiagnostics` and `build_diagnostics()`. `doctor` should reuse it. |
+| Tool surface | Small enough that `ToolOutput` artifact/visibility restructuring is not justified without a real consumer. |
+
+### P0: `agentao doctor --json`
+
+Status — implemented 2026-05-16.
+
+Goal: aggregate existing health signals into one operator-facing command.
+
+This command should expose what Agentao already knows:
+
+- plugin diagnostics from `PluginDiagnostics` / `build_diagnostics()`;
+- active permission snapshot from `active_permissions()`;
+- replay schema version / replay configuration visibility;
+- ACP schema export status;
+- config/factory source and validation errors;
+- optional-dependency availability only where the feature is configured or
+  obviously requested.
+
+Non-goals:
+
+- no remote network probes;
+- no marketplace or plugin sharing behavior;
+- no new long-running daemon inspection protocol;
+- no new strict startup semantics;
+- no broad "system audit" beyond Agentao-owned inputs.
+
+Output contract:
+
+- default human-readable output can be added, but `--json` is mandatory for
+  host/CI usage;
+- diagnostics should be redaction-safe by default;
+- warnings and errors should include the source path when available.
+
+### P0: `agentao config validate`
+
+Status — implemented 2026-05-16.
+
+Goal: make configuration problems visible without changing runtime startup
+semantics.
+
+The factory path stays best-effort because Agentao is embedded-host friendly:
+bad optional config, unreadable user memory, or malformed settings should not
+unexpectedly break hosts that inject their own subsystems. Validation is a
+separate explicit command that reports those failures.
+
+Minimum scope:
+
+- validate `.agentao/settings.json` shape and JSON parse errors;
+- validate environment-derived provider fields where relevant;
+- report permission config source parse/load errors;
+- report MCP config parse/load errors;
+- report replay config parse/load errors;
+- report SQLite open failures for project/user memory stores as validation
+  findings instead of silent behavior.
+
+Non-goals:
+
+- no strict-on-startup mode;
+- no Codex-style layered `profile-v2`;
+- no migration of embedded constructor behavior;
+- no broad schema redesign.
+
+### Implementation notes (both commands, landed 2026-05-16)
+
+- Both handlers live in ``agentao/cli/diagnostics_cli.py`` and are wired
+  through the lazy-import surface in ``agentao/cli/__init__.py``; the
+  ``[cli]`` missing-dep guard in :func:`agentao.cli.entrypoint` still applies
+  to them as it does to ``plugin list`` and ``skill list``.
+- Neither command instantiates an :class:`Agentao`; both work off the same
+  on-disk signals the factory consults (``settings.json``, ``permissions.json``,
+  ``mcp.json``, replay block, memory DB probes) plus
+  :func:`agentao.embedding.plugins.diagnostics.build_diagnostics` for plugins.
+- Output is redaction-safe by design: the provider section reports
+  ``api_key_present`` (a boolean) and the model/base URL, but never the key
+  value itself; ``LLM_TEMPERATURE`` / ``LLM_MAX_TOKENS`` values are echoed only
+  in their raw form when they fail to parse, since those are not secrets.
+- ``--json`` returns ``{"ok": bool, "sections": {...}, "findings": [...]}``;
+  ``ok`` is ``False`` exactly when at least one finding has ``level == "error"``,
+  and that case maps to ``exit 1``. Warnings keep ``ok = True`` so a missing
+  API key (a normal fresh-clone state) never flunks CI.
+- ``config validate`` deliberately omits the ``plugins`` section — plugin
+  diagnostics already have a dedicated CLI (``agentao plugin list``) and a
+  doctor section, so duplicating them here would just blur the "config" scope.
+- Tests live in ``tests/test_diagnostics_cli.py`` (23 cases). Each test
+  monkeypatches ``Path.home`` to ``tmp_path`` so the developer's real
+  ``~/.agentao`` is not touched.
+
+### Explicitly Not Doing
+
+These are excluded until a real consumer or bug report creates pressure:
+
+- **Permission profile rewrite.** Agentao already has the lightweight
+  `ActivePermissions` snapshot it needs today.
+- **Structured `ToolOutput` overhaul.** The current tool count and consumers do
+  not justify artifact/visibility metadata across all tools.
+- **Large trace ID refactor.** Existing `session_id` / `turn_id` /
+  `tool_call_id` / `call_id` covers most debugging. Add one cross-layer field
+  later only if host integrations need LLM-to-MCP stitching.
+- **Plugin marketplace / share checkout.** The plugin system should stabilize
+  locally before distribution is expanded.
+- **TUI-style large module split.** Agentao's CLI is already split across
+  `app`, `input_loop`, `session`, and `subcommands`; Codex's TUI refactor was
+  debt repayment for a much larger UI.
+
 ## Summary
 
 Codex's recent architecture work is mostly driven by Codex-specific scale:

--- a/tests/test_diagnostics_cli.py
+++ b/tests/test_diagnostics_cli.py
@@ -1,0 +1,573 @@
+"""Tests for ``agentao doctor`` and ``agentao config validate``.
+
+These commands aggregate or validate existing health signals; they must not
+require an instantiated agent and must not print API keys.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from pathlib import Path
+from typing import Dict
+
+import pytest
+
+from agentao.cli.diagnostics_cli import (
+    DiagnosticReport,
+    Finding,
+    _collect_mcp,
+    _collect_permissions,
+    _collect_provider,
+    _collect_replay,
+    _collect_settings,
+    handle_config_validate_subcommand,
+    handle_doctor_subcommand,
+)
+from agentao.cli.entrypoints import _build_parser
+
+
+# ----------------------------------------------------------------------
+# Helpers
+# ----------------------------------------------------------------------
+
+
+def _ns(json_output: bool = False, **extra) -> argparse.Namespace:
+    return argparse.Namespace(json_output=json_output, **extra)
+
+
+@pytest.fixture
+def isolated_wd(tmp_path, monkeypatch):
+    """Run each test in a clean cwd with no inherited LLM env."""
+    monkeypatch.chdir(tmp_path)
+    # Reset every env var the provider collector reads, so test ordering
+    # never lets credentials from a previous test leak into the snapshot.
+    for var in (
+        "LLM_PROVIDER", "LLM_TEMPERATURE", "LLM_MAX_TOKENS",
+        "OPENAI_API_KEY", "OPENAI_BASE_URL", "OPENAI_MODEL",
+        "DEEPSEEK_API_KEY", "DEEPSEEK_BASE_URL", "DEEPSEEK_MODEL",
+        "ANTHROPIC_API_KEY", "ANTHROPIC_BASE_URL", "ANTHROPIC_MODEL",
+    ):
+        monkeypatch.delenv(var, raising=False)
+    # Re-route ~/.agentao away from the real user home so tests do not
+    # observe (or mutate) the developer's memory store.
+    fake_home = tmp_path / "fake_home"
+    fake_home.mkdir()
+    monkeypatch.setenv("HOME", str(fake_home))
+    monkeypatch.setattr(Path, "home", lambda: fake_home)
+    return tmp_path
+
+
+# ----------------------------------------------------------------------
+# Argument parser wiring
+# ----------------------------------------------------------------------
+
+
+class TestArgParser:
+    def test_doctor_json_flag(self):
+        parser = _build_parser()
+        ns, extras = parser.parse_known_args(["doctor", "--json"])
+        assert ns.subcommand == "doctor"
+        assert ns.json_output is True
+        assert extras == []
+
+    def test_doctor_default_human(self):
+        parser = _build_parser()
+        ns, _ = parser.parse_known_args(["doctor"])
+        assert ns.subcommand == "doctor"
+        assert ns.json_output is False
+
+    def test_config_validate_json(self):
+        parser = _build_parser()
+        ns, _ = parser.parse_known_args(["config", "validate", "--json"])
+        assert ns.subcommand == "config"
+        assert ns.config_action == "validate"
+        assert ns.json_output is True
+
+
+# ----------------------------------------------------------------------
+# Per-collector unit tests
+# ----------------------------------------------------------------------
+
+
+class TestCollectSettings:
+    def test_absent_file_is_not_an_error(self, isolated_wd):
+        report = DiagnosticReport()
+        data = _collect_settings(isolated_wd, report)
+        assert data is None
+        assert report.ok is True
+        assert report.sections["settings"]["status"] == "absent"
+
+    def test_malformed_json_is_an_error(self, isolated_wd):
+        (isolated_wd / ".agentao").mkdir()
+        (isolated_wd / ".agentao" / "settings.json").write_text("{not json", encoding="utf-8")
+
+        report = DiagnosticReport()
+        _collect_settings(isolated_wd, report)
+        assert report.ok is False
+        assert report.sections["settings"]["status"] == "malformed"
+        # The source path must be in the finding so the user can fix it.
+        err = next(f for f in report.findings if f.level == "error")
+        assert err.area == "settings"
+        assert "settings.json" in (err.source or "")
+
+    def test_non_object_top_level_is_an_error(self, isolated_wd):
+        (isolated_wd / ".agentao").mkdir()
+        (isolated_wd / ".agentao" / "settings.json").write_text("[1, 2, 3]", encoding="utf-8")
+
+        report = DiagnosticReport()
+        _collect_settings(isolated_wd, report)
+        assert report.ok is False
+        assert report.sections["settings"]["status"] == "malformed"
+
+    def test_well_formed_settings_is_ok(self, isolated_wd):
+        (isolated_wd / ".agentao").mkdir()
+        (isolated_wd / ".agentao" / "settings.json").write_text(
+            json.dumps({"replay": {"enabled": True}}), encoding="utf-8",
+        )
+
+        report = DiagnosticReport()
+        data = _collect_settings(isolated_wd, report)
+        assert data == {"replay": {"enabled": True}}
+        assert report.ok is True
+        assert report.sections["settings"]["status"] == "ok"
+        assert report.sections["settings"]["keys"] == ["replay"]
+
+
+class TestCollectProvider:
+    def test_missing_api_key_is_warning_not_error(self, isolated_wd):
+        report = DiagnosticReport()
+        _collect_provider(report)
+        # No API key → warning, but the report stays ok=True (warnings do
+        # not flip the gate).
+        assert report.ok is True
+        assert any(
+            f.level == "warning" and f.area == "provider" for f in report.findings
+        )
+
+    def test_api_key_value_is_redacted(self, isolated_wd, monkeypatch):
+        monkeypatch.setenv("OPENAI_API_KEY", "sk-secret-do-not-leak")
+        report = DiagnosticReport()
+        _collect_provider(report)
+
+        section = report.sections["provider"]
+        # The presence flag is reported; the value itself never appears.
+        assert section["api_key_present"] is True
+        serialized = json.dumps(report.to_dict())
+        assert "sk-secret-do-not-leak" not in serialized
+
+    def test_malformed_temperature_is_error(self, isolated_wd, monkeypatch):
+        monkeypatch.setenv("LLM_TEMPERATURE", "not-a-float")
+        report = DiagnosticReport()
+        _collect_provider(report)
+        assert report.ok is False
+        assert any(
+            f.level == "error" and "LLM_TEMPERATURE" in f.message
+            for f in report.findings
+        )
+
+
+class TestCollectPermissions:
+    def test_missing_files_are_silent(self, isolated_wd):
+        report = DiagnosticReport()
+        _collect_permissions(isolated_wd, report)
+        assert report.ok is True
+        section = report.sections["permissions"]
+        assert section["user_status"] == "absent"
+        assert section["project_status"] == "absent"
+
+    def test_malformed_user_permissions_is_error(self, isolated_wd):
+        ur = Path.home() / ".agentao"
+        ur.mkdir(parents=True, exist_ok=True)
+        (ur / "permissions.json").write_text("{broken", encoding="utf-8")
+
+        report = DiagnosticReport()
+        _collect_permissions(isolated_wd, report)
+        assert report.ok is False
+        assert report.sections["permissions"]["user_status"] == "malformed"
+
+    def test_project_scope_permissions_warns(self, isolated_wd):
+        (isolated_wd / ".agentao").mkdir()
+        (isolated_wd / ".agentao" / "permissions.json").write_text(
+            json.dumps({"rules": []}), encoding="utf-8",
+        )
+
+        report = DiagnosticReport()
+        _collect_permissions(isolated_wd, report)
+        # Project-scope file is intentionally ignored — that is a warning, not
+        # an error, but it must be surfaced so the user knows.
+        assert report.ok is True
+        assert report.sections["permissions"]["project_status"] == "ignored"
+        assert any(
+            f.level == "warning" and f.area == "permissions" for f in report.findings
+        )
+
+
+class TestCollectMcp:
+    def test_malformed_mcp_is_error(self, isolated_wd):
+        (isolated_wd / ".agentao").mkdir()
+        (isolated_wd / ".agentao" / "mcp.json").write_text("{not json", encoding="utf-8")
+
+        report = DiagnosticReport()
+        _collect_mcp(isolated_wd, report)
+        assert report.ok is False
+        assert report.sections["mcp"]["project_status"] == "malformed"
+
+    def test_servers_must_be_object(self, isolated_wd):
+        (isolated_wd / ".agentao").mkdir()
+        (isolated_wd / ".agentao" / "mcp.json").write_text(
+            json.dumps({"mcpServers": [1, 2, 3]}), encoding="utf-8",
+        )
+
+        report = DiagnosticReport()
+        _collect_mcp(isolated_wd, report)
+        assert report.ok is False
+        assert report.sections["mcp"]["project_status"] == "malformed"
+
+    def test_individual_server_entry_must_be_object(self, isolated_wd):
+        # Regression: previously this passed as "ok" but would crash the
+        # runtime loader's _expand_config_env(dict(config)) on the string.
+        (isolated_wd / ".agentao").mkdir()
+        (isolated_wd / ".agentao" / "mcp.json").write_text(
+            json.dumps({"mcpServers": {"bad": "oops", "good": {"command": "x"}}}),
+            encoding="utf-8",
+        )
+
+        report = DiagnosticReport()
+        _collect_mcp(isolated_wd, report)
+        assert report.ok is False
+        assert report.sections["mcp"]["project_status"] == "malformed"
+        err = next(f for f in report.findings if f.level == "error" and f.area == "mcp")
+        assert "'bad'" in err.message
+
+    def test_nested_env_must_be_strings(self, isolated_wd):
+        # `expand_env_vars` will TypeError on a non-string; the validator
+        # must catch this before the runtime loader does.
+        (isolated_wd / ".agentao").mkdir()
+        (isolated_wd / ".agentao" / "mcp.json").write_text(
+            json.dumps({
+                "mcpServers": {
+                    "srv": {"command": "x", "env": {"PORT": 3000}},
+                }
+            }),
+            encoding="utf-8",
+        )
+        report = DiagnosticReport()
+        _collect_mcp(isolated_wd, report)
+        assert report.ok is False
+        assert any(
+            "'env'" in f.message and "values must be strings" in f.message
+            for f in report.findings
+        )
+
+    def test_nested_args_must_be_list_of_strings(self, isolated_wd):
+        (isolated_wd / ".agentao").mkdir()
+        (isolated_wd / ".agentao" / "mcp.json").write_text(
+            json.dumps({"mcpServers": {"srv": {"command": "x", "args": ["ok", 5]}}}),
+            encoding="utf-8",
+        )
+        report = DiagnosticReport()
+        _collect_mcp(isolated_wd, report)
+        assert report.ok is False
+        assert any("'args'" in f.message for f in report.findings)
+
+    def test_warns_on_user_project_collision(self, isolated_wd):
+        # Runtime drops the project entry silently — validator must warn so
+        # the user knows their project entry is dead.
+        ur = Path.home() / ".agentao"
+        ur.mkdir(parents=True, exist_ok=True)
+        (ur / "mcp.json").write_text(
+            json.dumps({"mcpServers": {"shared": {"command": "user-bin"}}}),
+            encoding="utf-8",
+        )
+        (isolated_wd / ".agentao").mkdir()
+        (isolated_wd / ".agentao" / "mcp.json").write_text(
+            json.dumps({
+                "mcpServers": {
+                    "shared": {"command": "project-bin"},
+                    "only-project": {"command": "x"},
+                }
+            }),
+            encoding="utf-8",
+        )
+
+        report = DiagnosticReport()
+        _collect_mcp(isolated_wd, report)
+        # Both files are still individually well-formed — only the collision
+        # is flagged, and as a warning (does not flip the error gate).
+        assert report.ok is True
+        assert report.sections["mcp"]["shadowed_project_servers"] == ["shared"]
+        warn = next(
+            f for f in report.findings
+            if f.level == "warning" and f.area == "mcp"
+        )
+        assert "'shared'" in warn.message
+        # `only-project` is unique to the project file; it must NOT appear in
+        # the shadow list.
+        assert "only-project" not in warn.message
+
+
+class TestCollectReplay:
+    def test_default_replay_off(self, isolated_wd):
+        report = DiagnosticReport()
+        _collect_replay(isolated_wd, report, settings_data=None)
+        section = report.sections["replay"]
+        assert section["status"] == "ok"
+        assert section["enabled"] is False
+
+    def test_passes_through_settings_data(self, isolated_wd):
+        # _collect_replay must read the dict it was handed, not re-open
+        # settings.json — that's the whole point of threading it through.
+        report = DiagnosticReport()
+        _collect_replay(
+            isolated_wd,
+            report,
+            settings_data={"replay": {"enabled": True, "max_instances": 5}},
+        )
+        section = report.sections["replay"]
+        assert section["enabled"] is True
+        assert section["max_instances"] == 5
+
+    def test_non_object_replay_is_error(self, isolated_wd):
+        # ReplayConfig.from_mapping coerces this to defaults silently; the
+        # validator must catch it so users notice their settings are ignored.
+        report = DiagnosticReport()
+        _collect_replay(isolated_wd, report, settings_data={"replay": "on"})
+        assert report.ok is False
+        err = next(f for f in report.findings if f.level == "error")
+        assert "must be an object" in err.message
+
+    def test_bad_max_instances_is_error(self, isolated_wd):
+        report = DiagnosticReport()
+        _collect_replay(
+            isolated_wd, report,
+            settings_data={"replay": {"max_instances": "many"}},
+        )
+        assert report.ok is False
+        assert any("max_instances" in f.message for f in report.findings)
+
+    def test_non_positive_max_instances_is_error(self, isolated_wd):
+        # `int(0)` succeeds, but from_mapping silently discards the value
+        # and uses the default. Validate must flag rather than let the
+        # user think their (no-op) setting applied.
+        report = DiagnosticReport()
+        _collect_replay(
+            isolated_wd, report,
+            settings_data={"replay": {"max_instances": 0}},
+        )
+        assert report.ok is False
+        err = next(f for f in report.findings if "max_instances" in f.message)
+        assert ">= 1" in err.message
+
+    def test_non_bool_capture_flag_is_error(self, isolated_wd):
+        report = DiagnosticReport()
+        _collect_replay(
+            isolated_wd, report,
+            settings_data={
+                "replay": {"capture_flags": {"capture_llm_delta": 42}},
+            },
+        )
+        assert report.ok is False
+        assert any("capture_llm_delta" in f.message for f in report.findings)
+
+    def test_unknown_capture_flag_is_warning(self, isolated_wd):
+        report = DiagnosticReport()
+        _collect_replay(
+            isolated_wd, report,
+            settings_data={
+                "replay": {"capture_flags": {"unknown_flag": True}},
+            },
+        )
+        # Unknown keys are silently dropped at runtime, so the runtime is OK
+        # — but validate should still warn the user that the key is dead.
+        assert report.ok is True
+        assert any(
+            f.level == "warning" and "unknown_flag" in f.message
+            for f in report.findings
+        )
+
+
+# ----------------------------------------------------------------------
+# End-to-end command behavior
+# ----------------------------------------------------------------------
+
+
+class TestCollectMemoryStores:
+    def test_probe_does_not_create_files(self, isolated_wd):
+        """Doctor must be read-only — sqlite3.connect on an absent path
+        silently creates an empty file. A previous version did exactly that,
+        bootstrapping a memory DB just by running ``agentao doctor``."""
+        from agentao.cli.diagnostics_cli import _collect_memory_stores
+
+        report = DiagnosticReport()
+        _collect_memory_stores(isolated_wd, report)
+
+        section = report.sections["memory"]
+        assert section["project_status"] == "absent"
+        assert not (isolated_wd / ".agentao" / "memory.db").exists()
+        assert not (isolated_wd / ".agentao").exists()  # parent dir untouched too
+
+    def test_probe_reports_ok_when_db_exists(self, isolated_wd):
+        import sqlite3
+        from agentao.cli.diagnostics_cli import _collect_memory_stores
+
+        (isolated_wd / ".agentao").mkdir()
+        db = isolated_wd / ".agentao" / "memory.db"
+        sqlite3.connect(str(db)).close()
+
+        report = DiagnosticReport()
+        _collect_memory_stores(isolated_wd, report)
+        assert report.sections["memory"]["project_status"] == "ok"
+
+
+class TestHandleDoctor:
+    def test_json_output_is_well_formed(self, isolated_wd, capsys):
+        try:
+            handle_doctor_subcommand(_ns(json_output=True))
+        except SystemExit:
+            # Non-zero exit when a real error is detected. We do not assert
+            # the exit code here — the *shape* of the output is the contract.
+            pass
+        out = capsys.readouterr().out
+        doc = json.loads(out)
+        assert "ok" in doc
+        assert "sections" in doc
+        assert "findings" in doc
+        assert "provider" in doc["sections"]
+        assert "permissions" in doc["sections"]
+        assert "mcp" in doc["sections"]
+        assert "replay" in doc["sections"]
+        assert "acp_schema" in doc["sections"]
+        assert "memory" in doc["sections"]
+        assert "plugins" in doc["sections"]
+        assert "optional_deps" in doc["sections"]
+
+    def test_human_output_includes_section_headers(self, isolated_wd, capsys):
+        try:
+            handle_doctor_subcommand(_ns(json_output=False))
+        except SystemExit:
+            pass
+        out = capsys.readouterr().out
+        # Rich strips style tags so plain text remains.
+        assert "agentao doctor" in out
+        assert "LLM provider" in out
+        assert "Permissions" in out
+        assert "Replay" in out
+
+    def test_error_exit_when_finding_is_error(self, isolated_wd):
+        # Malformed settings.json → error → non-zero exit.
+        (isolated_wd / ".agentao").mkdir()
+        (isolated_wd / ".agentao" / "settings.json").write_text("{broken", encoding="utf-8")
+
+        with pytest.raises(SystemExit) as exc:
+            handle_doctor_subcommand(_ns(json_output=True))
+        assert exc.value.code == 1
+
+    def test_warnings_do_not_flip_exit(self, isolated_wd):
+        # No API key is a warning — must not exit non-zero.
+        handle_doctor_subcommand(_ns(json_output=True))
+
+
+class TestDotenvLoading:
+    def test_doctor_reads_api_key_from_dotenv(self, isolated_wd, capsys, monkeypatch):
+        """When the user runs `agentao init`, the API key lands in `.env`;
+        the diagnostics handlers must honor that the same way the factory
+        does, or they will falsely warn about a missing key right after
+        setup."""
+        # Override LLM_PROVIDER so we know which prefix to write.
+        monkeypatch.setenv("LLM_PROVIDER", "OPENAI")
+        (isolated_wd / ".env").write_text(
+            "OPENAI_API_KEY=sk-from-dotenv\n", encoding="utf-8"
+        )
+
+        handle_doctor_subcommand(_ns(json_output=True))
+        doc = json.loads(capsys.readouterr().out)
+        # The key should be detected as present, and the missing-key warning
+        # must NOT appear.
+        assert doc["sections"]["provider"]["api_key_present"] is True
+        assert not any(
+            "API_KEY is not set" in f.get("message", "") for f in doc["findings"]
+        )
+        # Value itself never leaks into the output.
+        assert "sk-from-dotenv" not in json.dumps(doc)
+
+
+class TestHandleConfigValidate:
+    def test_clean_directory_no_errors(self, isolated_wd, capsys):
+        # No config files at all → no errors, but a missing-API-key warning.
+        handle_config_validate_subcommand(_ns(json_output=True))
+        out = capsys.readouterr().out
+        doc = json.loads(out)
+        assert doc["ok"] is True
+        # Errors gate exit; warnings do not.
+        assert not any(f["level"] == "error" for f in doc["findings"])
+
+    def test_malformed_settings_exits_nonzero(self, isolated_wd):
+        (isolated_wd / ".agentao").mkdir()
+        (isolated_wd / ".agentao" / "settings.json").write_text("{broken", encoding="utf-8")
+        with pytest.raises(SystemExit) as exc:
+            handle_config_validate_subcommand(_ns(json_output=True))
+        assert exc.value.code == 1
+
+    def test_validate_does_not_include_plugin_section(self, isolated_wd, capsys):
+        # config validate is configuration-only; plugin diagnostics live in
+        # `agentao doctor` and `agentao plugin list`.
+        handle_config_validate_subcommand(_ns(json_output=True))
+        out = capsys.readouterr().out
+        doc = json.loads(out)
+        assert "plugins" not in doc["sections"]
+
+
+class TestRejectUnknownArgs:
+    """``agentao doctor`` / ``agentao config`` are automation-oriented; a typo
+    like ``--jsno`` must fail loudly the way ``agentao run`` does, rather than
+    parse_known_args silently dropping it and exit-0'ing on the wrong flag."""
+
+    def _run(self, monkeypatch, argv):
+        import sys as _sys
+        from agentao import cli
+        monkeypatch.setattr(_sys, "argv", argv)
+        # Stub the actual handlers so this test only asserts dispatch.
+        monkeypatch.setattr(
+            cli, "handle_doctor_subcommand",
+            lambda args: pytest.fail("handler should not run with bad args"),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            cli, "handle_config_subcommand",
+            lambda args: pytest.fail("handler should not run with bad args"),
+            raising=False,
+        )
+        with pytest.raises(SystemExit) as exc:
+            cli.entrypoint()
+        return exc.value.code
+
+    def test_doctor_typo_exits_two(self, monkeypatch, capsys):
+        code = self._run(monkeypatch, ["agentao", "doctor", "--jsno"])
+        assert code == 2
+        err = capsys.readouterr().err
+        assert "agentao doctor: unrecognized arguments" in err
+        assert "--jsno" in err
+
+    def test_config_unknown_flag_exits_two(self, monkeypatch, capsys):
+        code = self._run(monkeypatch, ["agentao", "config", "validate", "--bogus"])
+        assert code == 2
+        err = capsys.readouterr().err
+        assert "agentao config: unrecognized arguments" in err
+        assert "--bogus" in err
+
+    def test_doctor_with_only_known_flag_dispatches(self, monkeypatch):
+        """Sanity: a clean invocation still reaches the handler (i.e. the
+        extras gate isn't accidentally rejecting valid input)."""
+        import sys as _sys
+        from agentao import cli
+        called: Dict[str, bool] = {}
+        monkeypatch.setattr(
+            cli, "handle_doctor_subcommand",
+            lambda args: called.setdefault("ran", True),
+            raising=False,
+        )
+        monkeypatch.setattr(_sys, "argv", ["agentao", "doctor", "--json"])
+        cli.entrypoint()
+        assert called.get("ran") is True


### PR DESCRIPTION
## Summary

- New `agentao doctor [--json]`: one operator-facing diagnostics command that aggregates the harness's existing signals — `.env` provider check (API-key *presence*, never the value), `settings.json`, permissions, MCP, replay, ACP schema export, project + user memory stores, plugin diagnostics, and optional-dep probes.
- New `agentao config validate [--json]`: configuration-only validator that flags problems the runtime silently swallows — malformed JSON, non-object MCP server entries, non-string `env`/`headers`/`args`, user/project MCP name collisions, replay values that `ReplayConfig.from_mapping` discards (`max_instances: 0`, non-bool capture flags, unknown flag keys).
- New `collect_full_plugin_diagnostics()` helper in `agentao/embedding/plugins/diagnostics.py` shared by `plugin list` and `doctor` so the two cannot drift on which plugins they consider failed.
- No public Python API or wire-format change.

## Why

`docs/design/codex-reverse-review.md` (2026-05-17 follow-up): a focused, narrow-scope diagnostics wire-up over signals Agentao already produces. Explicit non-goals: no app-server diagnostics subsystem, no stricter startup, no plugin marketplace, no schema bump.

## Contract

- Output: `{"ok": bool, "sections": {...}, "findings": [...]}`. `ok=false` iff ≥1 finding with `level == "error"`; that case maps to exit `1`. Warnings keep `ok=true` and exit `0` (so a missing API key on a fresh clone doesn't trip CI).
- `--json` is the contract surface for CI/hosts; human-readable is the default.
- Read-only by design: probing an absent `memory.db` reports `"absent"` instead of bootstrapping it (regression-tested).
- Unknown flags fail with exit `2` (mirrors `agentao run`), so a CI typo (`--jsno`) surfaces instead of exit-0 against the wrong invocation.
- `.env` is loaded before the provider check, matching `build_from_environment`, so users who ran `agentao init` see their key detected.
- Redaction-safe: API-key value is never printed (tests assert this against an `OPENAI_API_KEY=sk-...` env).

## Validated through 5 rounds of `/codex:review`

Issues caught and fixed across passes (all covered by tests):
1. `.env` was not loaded before the provider check → false missing-key warnings after `agentao init`.
2. Unknown flags were silently dropped (parse_known_args legacy) → CI would exit 0 on `--jsno`.
3. MCP entries had no per-server shape check → `{"bad": "oops"}` crashed `_expand_config_env` at runtime.
4. Replay block was silently coerced by `from_mapping` → `{"replay": "on"}` was accepted as default-on.
5. Nested MCP `env`/`headers`/`args` non-string values would TypeError in `expand_env_vars`.
6. `replay.max_instances` ≤ 0 was discarded silently → user thought their (no-op) setting applied.
7. User/project MCP name collisions: runtime drops project entry with a log warning, but validator wasn't mirroring it.

Pass 5 came back clean.

## Test plan

- [x] `tests/test_diagnostics_cli.py` — 39 cases (shape validation, redaction, exit-code gates, read-only memory probe, unknown-flag rejection, MCP collision warning)
- [x] `tests/test_plugin_lifecycle.py` — unchanged behavior verified for `plugin list` after switching to the shared helper
- [x] mypy `--strict --package agentao.host` clean
- [x] Replay + host schema drift checks pass
- [x] Full test suite locally: 2609 passed, 2 skipped

## Files

- `agentao/cli/diagnostics_cli.py` (new, ~530 LoC)
- `tests/test_diagnostics_cli.py` (new, 39 tests)
- `agentao/embedding/plugins/diagnostics.py` (extract `collect_full_plugin_diagnostics`)
- `agentao/cli/{__init__,entrypoints,subcommands}.py` (wiring + extras gate + `plugin list` refactor to shared helper)
- Docs: `developer-guide/{en,zh}/cli/{index,10-config-reference,12-non-interactive}.md`, `docs/CONFIGURATION.{md,zh.md}`, `docs/README.md`, `docs/design/codex-reverse-review.md`
- `CHANGELOG.md` `[Unreleased]` entry