### PR TITLE
chore: bump to 0.4.8.dev0

### DIFF
--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.7"
+__version__ = "0.4.8.dev0"
 
 
 def _ensure_utf8() -> None:


### PR DESCRIPTION
## Summary

Post-0.4.7 development-version bump. Single-file change to `agentao/__init__.py`:
`__version__ = "0.4.7"` → `"0.4.8.dev0"`.

Mirrors the [d6721c5](https://github.com/jin-bo/agentao/commit/d6721c5) / [2be0385](https://github.com/jin-bo/agentao/commit/2be0385) / [6ced162](https://github.com/jin-bo/agentao/commit/6ced162) pattern from previous releases.

## Why

`publish.yml` strict-checks `__version__` against the tag at publish time. Keeping `"0.4.7"` on `main` would mean:
- any accidental `gh release create v0.4.8` on a future commit before the next release-prep PR would still satisfy the equality check
- the on-disk version stops reflecting "this is post-0.4.7 development"

Bumping to `0.4.8.dev0` makes both correct: the next 0.4.8 release-prep PR will bump it again to `"0.4.8"`.

## Test plan

- [ ] CI green (schema drift / typing gate / 3.10·3.11·3.12 / examples / smoke / build)
- [ ] No further action — this PR only changes the version string

🤖 Generated with [Claude Code](https://claude.com/claude-code)