### PR TITLE
feat(llm): omit temperature for models that reject it

### DIFF
--- a/agentao/agent.py
+++ b/agentao/agent.py
@@ -421,6 +421,7 @@ class Agentao:
             "base_url": self.llm.base_url,
             "model": self.llm.model,
             "temperature": self.llm.temperature,
+            "omit_temperature": getattr(self.llm, "omit_temperature", False),
             "max_tokens": self.llm.max_tokens,
         }
 
@@ -786,7 +787,10 @@ class Agentao:
             summary = f"Messages: {len(self.messages)}\n"
 
         summary += f"Model: {self.llm.model}\n"
-        summary += f"Temperature: {self.llm.temperature}\n"
+        summary += (
+            "Temperature: off (omitted)\n" if getattr(self.llm, "omit_temperature", False)
+            else f"Temperature: {self.llm.temperature}\n"
+        )
         summary += f"Active skills: {len(self.skill_manager.get_active_skills())}\n"
         summary += f"Saved memories: {memory_count}\n"
         todos = self.todo_tool.get_todos()

--- a/agentao/agents/tools/_wrapper.py
+++ b/agentao/agents/tools/_wrapper.py
@@ -334,6 +334,13 @@ class AgentToolWrapper(Tool):
             defn_temperature if defn_temperature is not None
             else live_cfg.get("temperature")
         )
+        # Inherit the parent's temperature-omission state, but only when the
+        # sub-agent isn't pinning its own temperature (an explicit definition
+        # temperature means "send this value").
+        omit_temperature = (
+            False if defn_temperature is not None
+            else bool(live_cfg.get("omit_temperature", False))
+        )
         max_tokens = live_cfg.get("max_tokens")
 
         max_turns = self._definition.get("max_turns", 15)
@@ -373,6 +380,7 @@ class AgentToolWrapper(Tool):
             # thinking_callback intentionally omitted for sub-agents
         )
 
+        sub_agent.llm.omit_temperature = omit_temperature
         sub_agent.tools = scoped_registry
         sub_agent.project_instructions = self._definition.get("system_instructions")
         sub_agent.skill_manager = SkillManager(skills_dir="/nonexistent")

--- a/agentao/cli/_utils.py
+++ b/agentao/cli/_utils.py
@@ -78,7 +78,7 @@ _SLASH_COMMAND_HINTS = {
     '/skills enable': '<skill-name>',
     '/skills disable': '<skill-name>',
     '/context limit': '<tokens>',
-    '/temperature': '<value>',
+    '/temperature': '<value|off|on>',
     '/sessions resume': '<session-id>',
     '/sessions delete': '<session-id>',
     '/mcp add': '<name> <command|url>',

--- a/agentao/cli/commands/provider.py
+++ b/agentao/cli/commands/provider.py
@@ -125,9 +125,23 @@ def handle_temperature_command(cli: AgentaoCLI, args: str) -> None:
     """Handle /temperature command — show or set LLM temperature."""
     args = args.strip()
     if not args:
-        console.print(f"\n[info]Temperature:[/info] [cyan]{cli.agent.llm.temperature}[/cyan]")
-        console.print("[dim]Usage: /temperature <value>  (0.0 - 2.0)[/dim]\n")
+        if getattr(cli.agent.llm, "omit_temperature", False):
+            console.print("\n[info]Temperature:[/info] [cyan]off[/cyan] [dim](omitted from requests)[/dim]")
+        else:
+            console.print(f"\n[info]Temperature:[/info] [cyan]{cli.agent.llm.temperature}[/cyan]")
+        console.print("[dim]Usage: /temperature <value>  (0.0 - 2.0) | off | on[/dim]\n")
         return
+
+    lowered = args.lower()
+    if lowered == "off":
+        cli.agent.llm.omit_temperature = True
+        console.print("\n[success]Temperature off — 'temperature' will be omitted from requests[/success]\n")
+        return
+    if lowered == "on":
+        cli.agent.llm.omit_temperature = False
+        console.print(f"\n[success]Temperature on — sending {cli.agent.llm.temperature}[/success]\n")
+        return
+
     try:
         value = float(args)
     except ValueError:
@@ -138,4 +152,5 @@ def handle_temperature_command(cli: AgentaoCLI, args: str) -> None:
         return
     old = cli.agent.llm.temperature
     cli.agent.llm.temperature = value
+    cli.agent.llm.omit_temperature = False
     console.print(f"\n[success]Temperature changed from {old} to {value}[/success]\n")

--- a/agentao/cli/help_text.py
+++ b/agentao/cli/help_text.py
@@ -24,7 +24,7 @@ All commands start with `/`:
   - `/sessions resume <id>` - Resume a saved session by id prefix
   - `/sessions delete <id>` - Delete a saved session
   - `/sessions delete all` - Delete all saved sessions (requires confirmation)
-- `/temperature [value]` - Show or set LLM temperature (0.0-2.0)
+- `/temperature [value|off|on]` - Show/set LLM temperature (0.0-2.0); `off` omits it for models that reject it
 - `/mode [read-only|workspace-write|full-access]` - Set permission mode
   - `/mode` - Show current mode
   - `/mode read-only` - Block all write & shell tools

--- a/agentao/llm/_retry.py
+++ b/agentao/llm/_retry.py
@@ -116,6 +116,27 @@ def _is_streaming_unsupported(err_str: str) -> bool:
     return any(phrase in err_str for phrase in _STREAMING_UNSUPPORTED_PHRASES)
 
 
+def _is_temperature_unsupported(err_str: str) -> bool:
+    """True when an error says the model rejects the ``temperature`` param.
+
+    Reasoning models (o1/o3/gpt-5, …) return messages like
+    ``Unsupported value: 'temperature' does not support 0.2 with this model``,
+    ``'temperature' is not supported with this model``, or
+    ``temperature is deprecated for this model``. Require the param name *and*
+    a rejection indicator so a generic 400 that merely mentions temperature
+    does not trip the fix-up.
+    """
+    s = err_str.lower()
+    if "temperature" not in s:
+        return False
+    return (
+        "does not support" in s
+        or "not supported" in s
+        or "unsupported" in s
+        or "deprecated" in s
+    )
+
+
 def _compute_backoff_delay(attempt: int, retry_after_header: Optional[str] = None) -> float:
     """Compute the next sleep duration. Honors ``Retry-After`` when present."""
     parsed = _parse_retry_after(retry_after_header)

--- a/agentao/llm/client.py
+++ b/agentao/llm/client.py
@@ -35,6 +35,7 @@ from ._retry import (
     _compute_backoff_delay,
     _interruptible_sleep,
     _is_streaming_unsupported,
+    _is_temperature_unsupported,
     _mark_streamed,
     _parse_retry_after,
 )
@@ -125,6 +126,12 @@ class LLMClient:
 
         # Set to True after detecting the model requires max_completion_tokens
         self._use_max_completion_tokens: bool = False
+
+        # When True, 'temperature' is dropped from requests. Set either by the
+        # user (/temperature off) or auto-latched once the model rejects the
+        # parameter — see the one-shot fix-up in chat()/chat_stream(). Reasoning
+        # models (o1/o3/gpt-5, …) reject any non-default temperature.
+        self.omit_temperature: bool = False
 
         # max_retries=0: defer retry policy to _classify_retry / _compute_backoff_delay
         # so 408/409/425/429/5xx/529 + Retry-After + cancellation are handled
@@ -249,6 +256,7 @@ class LLMClient:
         if model is not None:
             self.model = model
 
+        self.reset_capability_latches()
         self.client = _openai_client_cls()(
             api_key=self.api_key,
             base_url=self.base_url,
@@ -257,6 +265,20 @@ class LLMClient:
         self.logger.info(
             f"LLMClient reconfigured: model={self.model}, base_url={self.base_url}"
         )
+
+    def reset_capability_latches(self) -> None:
+        """Clear auto-detected, model-specific request quirks.
+
+        ``_use_max_completion_tokens`` and ``omit_temperature`` are latched
+        per model on first rejection. They must be cleared whenever the model
+        or provider changes — otherwise a quirk detected for one model (e.g. a
+        reasoning model that rejects ``temperature``) silently sticks to the
+        next model that supports it. A user-set ``/temperature off`` is also
+        cleared here; the model is being swapped, so its premise no longer
+        holds and re-detection re-latches if the new model also rejects it.
+        """
+        self._use_max_completion_tokens = False
+        self.omit_temperature = False
 
     def chat(
         self,
@@ -281,8 +303,9 @@ class LLMClient:
         kwargs = {
             "model": self.model,
             "messages": messages,
-            "temperature": self.temperature,
         }
+        if not self.omit_temperature:
+            kwargs["temperature"] = self.temperature
 
         if tools:
             kwargs["tools"] = tools
@@ -322,6 +345,14 @@ class LLMClient:
                     self.logger.info("Switching to max_completion_tokens for this model")
                     if "max_tokens" in kwargs:
                         kwargs["max_completion_tokens"] = kwargs.pop("max_tokens")
+                    continue
+
+                # temperature unsupported (reasoning models: o1/o3/gpt-5, …) —
+                # one-shot fix-up, same shape as the max_completion_tokens branch.
+                if not self.omit_temperature and _is_temperature_unsupported(str(e)):
+                    self.omit_temperature = True
+                    self.logger.info("Model rejects 'temperature'; omitting it for this client")
+                    kwargs.pop("temperature", None)
                     continue
 
                 retryable, status, retry_after = _classify_retry(e)
@@ -521,10 +552,11 @@ class LLMClient:
         kwargs = {
             "model": self.model,
             "messages": messages,
-            "temperature": self.temperature,
             "stream": True,
             "stream_options": {"include_usage": True},
         }
+        if not self.omit_temperature:
+            kwargs["temperature"] = self.temperature
         if tools:
             kwargs["tools"] = tools
             kwargs["tool_choice"] = "auto"
@@ -638,6 +670,20 @@ class LLMClient:
                     )
                     if "max_tokens" in kwargs:
                         kwargs["max_completion_tokens"] = kwargs.pop("max_tokens")
+                    continue
+
+                # temperature unsupported — one-shot fix-up. Only safe at zero
+                # progress (otherwise the retry would re-emit content).
+                if (
+                    not progress_made
+                    and not self.omit_temperature
+                    and _is_temperature_unsupported(err_str)
+                ):
+                    self.omit_temperature = True
+                    self.logger.info(
+                        "Model rejects 'temperature'; omitting it for this client (stream retry)"
+                    )
+                    kwargs.pop("temperature", None)
                     continue
 
                 # Status-based retry classification — done up front so a

--- a/agentao/runtime/model.py
+++ b/agentao/runtime/model.py
@@ -59,6 +59,9 @@ def set_model(agent: "Agentao", model: str) -> str:
     """
     old_model = agent.llm.model
     agent.llm.model = model
+    # Built-in LLMClient only; injected host clients need not implement it.
+    if hasattr(agent.llm, "reset_capability_latches"):
+        agent.llm.reset_capability_latches()
     agent.context_manager._encoding = _get_tiktoken_encoding(model)
     agent.context_manager._last_api_prompt_tokens = None
     agent.llm.logger.info(f"Model changed from {old_model} to {model}")

--- a/tests/test_llm_client_retry.py
+++ b/tests/test_llm_client_retry.py
@@ -18,6 +18,7 @@ import openai
 import pytest
 
 from agentao.llm import client as client_mod
+from agentao.llm._retry import _is_temperature_unsupported
 from agentao.llm.client import (
     LLMClient,
     MAX_RETRY_ATTEMPTS,
@@ -91,6 +92,26 @@ def _make_chunk(*, content: str | None = None, finish_reason: str | None = None)
 # ---------------------------------------------------------------------------
 # Pure helpers
 # ---------------------------------------------------------------------------
+
+
+class TestIsTemperatureUnsupported:
+    @pytest.mark.parametrize("msg", [
+        "Unsupported value: 'temperature' does not support 0.2 with this model.",
+        "'temperature' is not supported with this model",
+        "temperature is deprecated for this model.",
+        "Error code: 400 - temperature is unsupported here",
+    ])
+    def test_rejection_messages_match(self, msg):
+        assert _is_temperature_unsupported(msg) is True
+
+    @pytest.mark.parametrize("msg", [
+        "rate limit exceeded",
+        "invalid temperature: must be between 0 and 2",
+        "this feature is deprecated",  # no 'temperature' token
+        "max_tokens is not supported, use max_completion_tokens",
+    ])
+    def test_non_rejection_messages_do_not_match(self, msg):
+        assert _is_temperature_unsupported(msg) is False
 
 
 class TestClassifyRetry:
@@ -304,6 +325,54 @@ class TestChatRetry:
         # Only two calls total (the fix-up is the retry, no additional retry loop)
         assert client.client.chat.completions.with_raw_response.create.call_count == 2
 
+    def test_temperature_param_fixup_does_not_consume_retry_budget(self, monkeypatch):
+        # Reasoning models reject 'temperature'. The client should latch
+        # omit_temperature, drop the param, and retry — without burning budget.
+        monkeypatch.setattr(client_mod.time, "sleep", lambda *_a, **_k: None)
+
+        client = _make_client()
+        ok_raw = MagicMock()
+        ok_raw.parse.return_value = _make_completion("after-omit")
+
+        temp_err = ValueError(
+            "Unsupported value: 'temperature' does not support 0.2 with this "
+            "model. Only the default (1) value is supported."
+        )
+        create = MagicMock(side_effect=[temp_err, ok_raw])
+        client.client.chat.completions.with_raw_response.create = create
+
+        response = client.chat(messages=[{"role": "user", "content": "hi"}])
+
+        assert response.choices[0].message.content == "after-omit"
+        assert client.omit_temperature is True
+        assert create.call_count == 2
+        # The retry request must not carry temperature.
+        assert "temperature" not in create.call_args_list[1].kwargs
+
+    def test_omit_temperature_drops_param_from_request(self):
+        # Explicit /temperature off → first request never includes temperature.
+        client = _make_client()
+        client.omit_temperature = True
+        ok_raw = MagicMock()
+        ok_raw.parse.return_value = _make_completion("ok")
+        create = MagicMock(return_value=ok_raw)
+        client.client.chat.completions.with_raw_response.create = create
+
+        client.chat(messages=[{"role": "user", "content": "hi"}])
+
+        assert "temperature" not in create.call_args.kwargs
+
+    def test_model_capability_latches_reset_on_reconfigure(self):
+        # A quirk auto-detected for one model must not stick to the next.
+        client = _make_client()
+        client.omit_temperature = True
+        client._use_max_completion_tokens = True
+
+        client.reconfigure(api_key="k2", base_url="https://other/v1", model="gpt-4o")
+
+        assert client.omit_temperature is False
+        assert client._use_max_completion_tokens is False
+
     def test_session_token_totals_only_count_successful_response(self, monkeypatch):
         # Failed retries shouldn't accidentally accumulate token counts.
         monkeypatch.setattr(client_mod.time, "sleep", lambda *_a, **_k: None)
@@ -355,6 +424,28 @@ class TestChatStreamRetry:
         assert seen == ["hel", "lo"]
         assert response.choices[0].message.content == "hello"
         assert client.client.chat.completions.create.call_count == 2
+
+    def test_temperature_fixup_before_any_chunk(self, monkeypatch):
+        # Temperature rejection at zero progress → drop param, latch, retry.
+        monkeypatch.setattr(client_mod.time, "sleep", lambda *_a, **_k: None)
+
+        client = _make_client()
+        temp_err = ValueError("'temperature' is not supported with this model")
+        ok_chunks = iter([_make_chunk(content="hi", finish_reason="stop")])
+        create = MagicMock(side_effect=[temp_err, ok_chunks])
+        client.client.chat.completions.create = create
+
+        seen: List[str] = []
+        response = client.chat_stream(
+            messages=[{"role": "user", "content": "hi"}],
+            on_text_chunk=seen.append,
+        )
+
+        assert seen == ["hi"]
+        assert response.choices[0].message.content == "hi"
+        assert client.omit_temperature is True
+        assert create.call_count == 2
+        assert "temperature" not in create.call_args_list[1].kwargs
 
     def test_does_not_retry_after_first_chunk(self, monkeypatch):
         # Mid-stream failure must propagate — retrying would re-fire on_text_chunk

--- a/tests/test_model_command.py
+++ b/tests/test_model_command.py
@@ -78,3 +78,21 @@ def test_model_switching_flow(monkeypatch: pytest.MonkeyPatch) -> None:
 
     agent.set_model(original_model)
     assert agent.get_current_model() == original_model
+
+
+def test_llm_config_exposes_omit_temperature() -> None:
+    # Sub-agents inherit temperature omission via _llm_config; /temperature off
+    # on the parent must be visible to sub-agents launched afterwards.
+    agent = _build_agent()
+    assert agent._llm_config["omit_temperature"] is False
+
+    agent.llm.omit_temperature = True
+    assert agent._llm_config["omit_temperature"] is True
+
+
+def test_set_model_resets_omit_temperature() -> None:
+    # A temperature quirk latched for one model must not stick to the next.
+    agent = _build_agent()
+    agent.llm.omit_temperature = True
+    agent.set_model(agent.get_current_model())
+    assert agent.llm.omit_temperature is False


### PR DESCRIPTION
## Summary
- Auto-detect models that reject the `temperature` request param (reasoning models: o1/o3/gpt-5) and drop it, retrying once — reusing the existing one-shot `max_completion_tokens` fix-up shape (latched, no retry-budget cost). Matcher covers "does not support", "not supported", "unsupported", and "deprecated" phrasings.
- Add an explicit `/temperature off|on` switch.
- Reset model-capability latches (`omit_temperature` + `_use_max_completion_tokens`) on `/model` and `/provider` switch so a quirk detected for one model doesn't silently stick to the next.
- Propagate the parent's omission state to sub-agents via `_llm_config`.
- Guard the new attribute/method behind `getattr`/`hasattr` so injected host LLM clients aren't required to implement them (embedded-host contract).

## Test plan
- [x] `tests/test_llm_client_retry.py` — matcher truth table (incl. `deprecated`), non-stream + stream fix-up, explicit-off, latch reset on reconfigure
- [x] `tests/test_model_command.py` — `_llm_config` exposes `omit_temperature`, `set_model` resets the latch
- [x] Full suite: 2706 passed, 2 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)