### PR TITLE
refactor(runtime): split oversized run() and Agentao.__init__

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,193 +7,166 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 **Always use `uv` for package management**, not pip:
 
 ```bash
-# Install dependencies
-uv sync
-
-# Add a new dependency
-uv add package-name
-
-# Run Python scripts
-uv run python script.py
-
-# Run the CLI
-uv run agentao
-# or
-uv run python main.py
+uv sync                    # Install dependencies
+uv add package-name        # Add a new dependency
+uv run python script.py    # Run Python scripts
+uv run agentao             # Run the CLI
 ```
 
-## Running and Testing
+Core deps live in `[project.dependencies]`; the heavyweight UI / format-conversion deps are opt-in extras (`[cli]`, `[web]`, `[i18n]`, `[pdf]`, `[excel]`, `[image]`, `[crypto]`, `[google]`, `[crawl4ai]`, `[tokenizer]`, `[full]`). A bare `pip install agentao` gets a library-only install; `pip install 'agentao[cli]'` is the smallest interactive CLI.
 
-### Start the Agent
+## Running
 
 ```bash
-# Quick start
-./run.sh
-
-# Or directly
-uv run agentao
-
-# Or via Python
-uv run python main.py
+./run.sh                              # Quick start (interactive)
+uv run agentao                        # Interactive CLI
+uv run python -m agentao              # Same, via module entrypoint
+uv run agentao run --prompt "..."     # Non-interactive automation (M0)
+uv run agentao --acp --stdio          # ACP server (Issue 12)
 ```
 
-### Run Tests
+`agentao run` is the canonical non-interactive surface. Exit codes: `0` ok, `1` runtime, `2` invalid usage, `3` permission/interaction, `4` max iterations, `130` interrupted. See `agentao/cli/run.py` and `docs/CONFIGURATION.md`. The legacy `agentao -p "..."` is now a thin shim over `agentao run`.
+
+## Testing
 
 ```bash
-# Run all tests with pytest
-uv run python -m pytest tests/
-
-# Run a specific test file
-uv run python tests/test_imports.py
-uv run python tests/test_tool_confirmation.py
-uv run python tests/test_readchar_confirmation.py
-uv run python tests/test_date_in_prompt.py
-
-# All test files are in tests/ directory
+uv run python -m pytest tests/                       # Default suite
+uv run python -m pytest -m slow                      # Clean-install smoke tests
+uv run python -m pytest tests/cli/                   # CLI subsuite
+uv run python -m pytest tests/test_active_permissions.py   # Single file
 ```
 
-### Configuration
+There are 160+ test files including subdirs (`tests/cli/`, `tests/data/`, `tests/support/`). The `slow` marker is excluded by default (`pyproject.toml :: tool.pytest.ini_options.addopts = "-m 'not slow'"`).
 
-Copy and edit `.env` from `.env.example`:
+## Configuration
+
 ```bash
-cp .env.example .env
-# Edit .env with your API key and settings
+cp .env.example .env       # Edit with OPENAI_API_KEY, OPENAI_BASE_URL, OPENAI_MODEL
 ```
 
-> **Reference for all config files** (`.env`, `.agentao/settings.json`, `permissions.json`, `mcp.json`, `acp.json`, `skills_config.json`, `AGENTAO.md`, memory DBs): see [docs/CONFIGURATION.md](docs/CONFIGURATION.md) for paths, schema, defaults, and precedence rules.
-
-Required: `OPENAI_API_KEY`
-Optional: `OPENAI_BASE_URL`, `OPENAI_MODEL`
+**Reference for all config files** (`.env`, `.agentao/settings.json`, `permissions.json`, `mcp.json`, `acp.json`, `skills_config.json`, `AGENTAO.md`, memory DBs): see [docs/CONFIGURATION.md](docs/CONFIGURATION.md) for paths, schema, defaults, and precedence rules.
 
 ## Architecture
 
-### Three-Layer Design
+Agentao is an **embedded agent harness**: the same runtime drives the interactive CLI, the `agentao run` automation surface, and the ACP server, with hosts free to embed `Agentao(...)` directly. The package boundary between "host-facing contract" and "internal runtime" is load-bearing — see `docs/design/embedded-host-contract.md` and `docs/api/host.md`.
 
-Agentao uses a **Tool-Agent-CLI** architecture:
+### Subpackage map
 
-1. **CLI Layer** (`cli.py`): User interface with Rich, handles commands, manages session state (like `allow_all_tools`)
-2. **Agent Layer** (`agent.py`): Orchestrates LLM, tools, skills, and conversation history
-3. **Tool Layer** (`tools/`): Individual tool implementations following the Tool base class
+| Path | Purpose |
+|---|---|
+| `agentao/agent.py` | `Agentao` class — sync `chat()` and async `arun()`. Construction wires LLM, tools, skills, plugins, permissions, replay. |
+| `agentao/runtime/` | Per-turn machinery extracted from `Agentao` — `ChatLoopRunner` (loop body), `ToolRunner` (4-phase tool pipeline: plan / execute / format / sanitize), `run_llm_call`, model/provider switching. |
+| `agentao/host/` | **Public host contract.** `HostEvent`, `ToolLifecycleEvent`, `SubagentLifecycleEvent`, `PermissionDecisionEvent`, `EventStream`, `ActivePermissions`. Stability boundary for embedded hosts. |
+| `agentao/harness/` | **Deprecated alias for `agentao.host`** (renamed in 0.4.2). Re-exports with old names + `DeprecationWarning`; scheduled for removal in 0.5.0. |
+| `agentao/embedding/` | Host-side construction: `build_from_environment()` (env / dotenv / `.agentao/*.json` reads routed through explicit kwargs), `permission_loader`, `sessions`, `plugins/` (manifest loader, validators, MCP merge, resolvers). |
+| `agentao/plugins/` | Plugin **runtime path** only — models, hooks, skill/agent validators. Loader lives in `embedding/plugins/`. |
+| `agentao/replay/` | `ReplayManager` + recorder/reader/adapter for persistent turn replay (`.agentao/replays/*.jsonl`). Transport `TURN_BEGIN`/`TURN_END` events. |
+| `agentao/acp/` | ACP server (Agent Connection Protocol). `agentao --acp --stdio` mode. Pydantic schemas exported via `agentao.host.export_host_acp_json_schema`. |
+| `agentao/acp_client/` | ACP **client** — talk to other ACP servers from inside Agentao. |
+| `agentao/tools/` | Tool implementations + `Tool` / `AsyncToolBase` base classes (`base.py`). |
+| `agentao/mcp/` | MCP (Model Context Protocol) client — connect to external MCP servers and surface their tools as `mcp_{server}_{tool}`. |
+| `agentao/memory/` | SQLite-backed memory store (`MemoryManager`, `MemoryRetriever`, `MemoryPromptRenderer`). |
+| `agentao/permissions.py` + `permissions_hardline/` | `PermissionEngine` + shell-pattern hardline scanner (heredoc, contexts, decoder). |
+| `agentao/sandbox/` | macOS `sandbox-exec` profile management for shell tool. |
+| `agentao/transport/` | Event transport between Agentao core and CLI/ACP frontends. |
+| `agentao/cli/` | Interactive CLI **package** (was `cli.py` before 0.4.x). `app.py` (`AgentaoCLI`), `entrypoints.py` (argparse + `main`), `run.py` (`agentao run`), `commands/` (per-slash-command handlers), `subcommands.py`, `diagnostics_cli.py`. |
+| `agentao/skills/` | Skill discovery + activation. SKILL.md frontmatter parser. |
+| `agentao/prompts/`, `agentao/agents/`, `agentao/plan/`, `agentao/capabilities/`, `agentao/tooling/`, `agentao/security/`, `agentao/session.py`, `agentao/context_manager.py` | Supporting modules — prompt assembly, sub-agent runners, plan-mode state, capability declarations, tool-arg sanitizers, security utilities, session save/load, context-window compaction. |
 
-```
-User → CLI → Agent → LLM + Tools
-                  ↓
-            SkillManager (loads from skills/)
-```
+### Tool system
 
-### Tool System
-
-All tools inherit from `Tool` base class (`tools/base.py`):
+All tools inherit from `Tool` (sync) or `AsyncToolBase` (async) in `agentao/tools/base.py`. Both are registered through the same `ToolRegistry` which converts them to OpenAI function-calling format.
 
 ```python
 class MyTool(Tool):
-    @property
-    def name(self) -> str:
-        return "my_tool"
-
-    @property
-    def description(self) -> str:
-        return "Description for LLM"
-
-    @property
-    def parameters(self) -> Dict[str, Any]:
-        return {...}  # JSON Schema
-
-    @property
-    def requires_confirmation(self) -> bool:
-        return False  # True for dangerous operations
-
-    def execute(self, **kwargs) -> str:
-        return "Result"
+    name: str
+    description: str
+    parameters: Dict[str, Any]              # JSON Schema
+    requires_confirmation: bool             # True → permission engine gate
+    def execute(self, **kwargs) -> str: ...
 ```
 
-**Tool Registration**: Tools are registered in `agent.py::_register_tools()`. The `ToolRegistry` converts them to OpenAI function calling format.
+`AsyncToolBase` dispatches through `runtime_loop` with a `CancellationToken`; cleanup-ack uses `_bridged()` `finally` + `threading.Event` so the runtime can cancel mid-tool. `RegistrableTool = Tool | AsyncToolBase`.
 
-**Tool Confirmation**: Tools with `requires_confirmation=True` (Shell, Web, File Writing) pause execution and prompt user via `confirmation_callback` passed from CLI.
+**Registration**: in `agent.py::_register_tools()` (line ~522). Built-in tools currently in `agentao/tools/`: `agents.py`, `ask_user.py`, `file_ops.py`, `memory.py`, `plan.py`, `search.py`, `shell.py`, `skill.py`, `todo.py`, `web.py`.
 
-**Tools requiring confirmation:**
-- `run_shell_command` - Shell command execution (allowlist for safe read-only commands)
-- `web_fetch` - Fetch web content (domain-tiered: allowlist/blocklist/ask)
-- `web_search` - Web search
-- `write_file` - File writing/overwriting (prevents data loss)
+**Confirmation / permissions**: tools with `requires_confirmation=True` are gated by `PermissionEngine`, which evaluates rules from `.agentao/permissions.json` (project) + `<home>/.agentao/permissions.json` (user). The engine itself does **no file I/O** — `agentao/embedding/permission_loader.py::load_permission_rules()` reads and passes `(rules, sources)` in. Default presets auto-allow common docs domains (`.github.com`, `.docs.python.org`, …) and auto-deny SSRF targets (`localhost`, `127.0.0.1`, `169.254.169.254`, …).
 
-**Domain-Based Permissions** (`web_fetch`): The `PermissionEngine` supports `"domain"` rules with allowlist/blocklist matching. Default presets auto-allow trusted docs sites (`.github.com`, `.docs.python.org`, etc.) and auto-deny SSRF targets (`localhost`, `127.0.0.1`, `169.254.169.254`, etc.). Customizable via `.agentao/permissions.json`. See `docs/features/TOOL_CONFIRMATION_FEATURE.md` for details.
+### Permission modes (replaces the old `allow_all_tools` flag)
 
-### Skills System
+`/mode read-only | workspace-write | full-access | plan` switches the runtime's permission posture:
 
-**Dynamic Loading**: Skills are auto-discovered from `skills/` directory. Each subdirectory contains:
-- `SKILL.md` - Main file with YAML frontmatter (`name:`, `description:`)
-- `reference/*.md` (optional) - Additional documentation loaded on-demand
+- `read-only` — blocks all write and shell tools.
+- `workspace-write` — allows file writes and safe shell; asks for web (default).
+- `full-access` — allows all tools without prompting.
+- `plan` — LLM plans, does not execute; entered via `/plan`.
 
-**Skill Manager** (`skills/manager.py`):
-- Parses YAML frontmatter from SKILL.md files
-- Maintains `available_skills` dict (all skills)
-- Maintains `active_skills` dict (currently activated)
-- Injects active skill context into system prompt
+State is on `AgentaoCLI` (`agentao/cli/app.py`) and projected into prompts.
 
-**Activation**: Use `activate_skill` tool or `/skills` command. Active skills add their documentation to the system prompt.
+### System prompt composition
 
-### System Prompt Composition
+Built fresh on every `chat()` in `agent.py::_build_system_prompt()` (line ~605):
 
-The system prompt is dynamically built in `agent.py::_build_system_prompt()`:
+1. `AGENTAO.md` (if present in cwd) — project-specific instructions
+2. Agent instructions — base Agentao capabilities
+3. Current date/time — `YYYY-MM-DD HH:MM:SS (Day)`
+4. Memory blocks — `<memory-stable>` + `<memory-context>` (top-k recall scored against current user message)
+5. Available skills — names + descriptions
+6. Active skills context — full SKILL.md + on-demand `reference/*.md`
 
-1. **AGENTAO.md** (if exists in cwd) - Project-specific instructions
-2. **Agent Instructions** - Base Agentao capabilities
-3. **Current Date/Time** - Auto-injected: `YYYY-MM-DD HH:MM:SS (Day)`
-4. **Available Skills** - List with descriptions
-5. **Active Skills Context** - Full documentation of activated skills
+### Conversation flow
 
-This composition happens on every `chat()` call to keep skills context fresh.
-
-### Conversation Flow
-
-```python
-# agent.py::chat()
-1. User message added to self.messages
-2. System prompt built (includes AGENTAO.md, date, skills)
-3. LLM called with messages + tools
-4. Loop (max 100 iterations):
-   a. If tool_calls: execute each tool
-      - Check requires_confirmation
-      - Call confirmation_callback if needed
-      - Execute tool or cancel based on response
-   b. Add tool results to messages
-   c. Call LLM again with updated messages
-   d. If no tool_calls: return final response
+```
+Agentao.chat() / Agentao.arun()
+  └─ ChatLoopRunner.run()                  # runtime/chat_loop/_runner.py
+       loop (max_iterations):
+         ├─ run_llm_call(messages, tools)  # runtime/llm_call.py
+         ├─ if tool_calls:
+         │    └─ ToolRunner.run()          # runtime/tool_runner.py
+         │         plan → execute → format → sanitize
+         │           (gates: PermissionEngine + confirmation_callback)
+         └─ else: return assistant text
 ```
 
-### Logging System
+`arun()` is the async path; the sync `chat()` wraps it. AsyncTools dispatch on `runtime_loop` so cancellation works inside the LLM-driven turn.
 
-**Complete LLM interaction logging** to `agentao.log`:
-- Every request/response (full content, no truncation)
-- All tool calls with formatted JSON arguments
-- Tool results
-- Token usage
-- Timestamps
+### Skills
 
-Logger is in `llm/client.py`. To debug tool execution or LLM behavior, check this log file.
+Auto-discovered from `skills/`. Each subdir has `SKILL.md` (YAML frontmatter `name:` / `description:`) and optional `reference/*.md` (loaded on activation). The skill manager (`agentao/skills/`) maintains `available_skills` (all) and `active_skills` (this session). Cross-process locking via `filelock` — installs and updates are safe across concurrent CLI processes.
 
-### CLI Commands
+Activate via the `activate_skill` tool or `/skills activate <name>`.
 
-User commands (start with `/`):
-- `/clear` - Clears history AND resets `allow_all_tools` to False
-- `/reset-confirm` - Resets `allow_all_tools` only (keeps history)
-- `/status` - Shows message count, model, active skills, confirmation mode
-- `/model [name]` - List models or switch to specified model
-- `/skills` - List available/active skills
-- `/memory` - Show saved memories
-- `/mcp` - List MCP servers and tools
-- `/context` - Show context-window token usage; `/context limit <n>` overrides max tokens
-- `/compact` - Manually run full history compaction (`compress_messages(is_auto=False)`); handler in `cli/commands/compact.py`
-- `/help` - Show help
+### Memory system
 
-Session state `allow_all_tools` persists across tool confirmations within one session.
+**Architecture:** SQLite-backed storage managed by `MemoryManager` (`agentao/memory/manager.py`).
 
-### MCP (Model Context Protocol) System
+| Database | Path | Content |
+|---|---|---|
+| Project store | `.agentao/memory.db` | Project-scoped persistent memories + session summaries |
+| User store | `<home>/.agentao/memory.db` | Cross-project user-scoped persistent memories |
 
-Agentao supports connecting to external MCP servers that provide additional tools.
+**Three data types:**
 
-**Configuration**: `.agentao/mcp.json` (project) and `<home>/.agentao/mcp.json` (global):
+1. **Persistent memories** (`MemoryRecord`) — rows in `memories`. Soft-deleted. Scoped `user` / `project`. Types: `preference`, `profile`, `project_fact`, `workflow`, `decision`, `constraint`, `note`. Source: `explicit` / `auto` / `crystallized`.
+2. **Session summaries** (`SessionSummaryRecord`) — rows in `session_summaries`. Written by microcompaction / full LLM summarization. Scoped to `session_id`.
+3. **Recall candidates** (`RecallCandidate`) — transient, in-memory. Scored at query time by `MemoryRetriever` (keyword/Jaccard/tag/recency). Never stored.
+
+**Prompt injection (per turn, two blocks):**
+- `<memory-stable>` — stable persistent memories (budget-limited). Session summaries are intentionally excluded — they live in message history as `[Conversation Summary]` blocks.
+- `<memory-context>` — top-k recall candidates against current user message.
+
+**Separation of concerns:** the LLM can only write (`save_memory(key, value, tags?)`). Search, delete, clear are CLI-only (`/memory search|tag|delete|clear|user|project|session|status`) and call `MemoryManager` directly — never exposed as LLM tools.
+
+See `docs/features/memory-management.md`.
+
+### Replay
+
+`ReplayManager` (`agentao/replay/manager.py`) records every turn to `.agentao/replays/*.jsonl` when enabled. Replay state lives **outside** `Agentao` core — Transport emits `TURN_BEGIN` / `TURN_END` events that the manager subscribes to. Configure via `.agentao/settings.json :: replay.{enabled, max_instances}` or `/replay on|off`.
+
+### MCP
+
+External MCP servers via `.agentao/mcp.json` (project) + `<home>/.agentao/mcp.json` (global):
+
 ```json
 {
   "mcpServers": {
@@ -212,181 +185,67 @@ Agentao supports connecting to external MCP servers that provide additional tool
 }
 ```
 
-**Transport types**: `command` (stdio subprocess) or `url` (SSE).
+Transports: `command` (stdio subprocess) or `url` (SSE). Tools are registered as `mcp_{server}_{tool}`. The MCP SDK is async-only; `McpClientManager` runs a dedicated event loop and bridges into sync Agentao via `run_until_complete()`.
 
-**Tool naming**: MCP tools are registered as `mcp_{server}_{tool}` (e.g. `mcp_github_create_issue`).
+Key files: `agentao/mcp/config.py`, `client.py`, `tool.py`.
 
-**Architecture**:
-```
-.agentao/mcp.json → McpConfig → McpClientManager → McpClient (per server)
-                                                          ↓
-                                                   list_tools() / call_tool()
-                                                          ↓
-                                                   McpTool(Tool) → ToolRegistry
-```
+CLI: `/mcp list`, `/mcp add <name> <command|url>`, `/mcp remove <name>`.
 
-**Key files**:
-- `agentao/mcp/config.py` - Config loading, env var expansion
-- `agentao/mcp/client.py` - McpClient (single server), McpClientManager (multi-server)
-- `agentao/mcp/tool.py` - McpTool wrapper adapting MCP tools to Tool base class
+### Logging
 
-**Async bridge**: MCP SDK is async-only; McpClientManager uses a dedicated event loop with `run_until_complete()` to bridge into sync Agentao code.
+`agentao.log` captures every LLM request/response (full content, no truncation), all tool calls with formatted JSON arguments, tool results, token usage, timestamps. Logger lives in `agentao/llm/client.py` — read this file first when debugging tool execution or LLM behavior.
 
-**CLI**: `/mcp list`, `/mcp add <name> <command|url>`, `/mcp remove <name>`
+### CLI slash commands
 
-## Adding New Components
+The authoritative list with full subcommand syntax lives in `agentao/cli/help_text.py`; `/help` renders it. The high-impact commands to know about when reasoning about agent behavior:
 
-### Adding a Tool
+- `/mode read-only|workspace-write|full-access` — permission posture (replaces 0.3.x `allow_all_tools`).
+- `/plan` / `/plan implement` / `/plan show` — plan mode (LLM plans, does not execute).
+- `/clear` — saves current session, clears conversation + **all memories**, starts a new one.
+- `/new` — saves session, starts fresh conversation (keeps memories).
+- `/sessions`, `/sessions resume <id>`, `/sessions delete <id>` — manage saved sessions.
+- `/skills`, `/skills activate <name>`, `/skills disable <name>` — skill state.
+- `/crystallize` — draft a reusable skill from the current session.
+- `/memory list|search|tag|delete|clear|user|project|session|status` — memory management.
+- `/mcp`, `/sandbox`, `/acp`, `/replay` — subsystem control.
+- `/agent <name> <task>`, `/agent bg <name> <task>`, `/agent dashboard` — sub-agent runners.
+- `/tools [name]` — list registered tools or show one tool's schema.
+- `/model`, `/provider`, `/temperature` — LLM config.
+- `/context`, `/compact` — context-window inspection + manual compaction.
 
-1. Create tool class in `agentao/tools/<module>.py`
-2. Implement `Tool` interface (name, description, parameters, execute)
-3. Set `requires_confirmation=True` if dangerous:
-   - Shell commands (arbitrary execution)
-   - Web access (network requests, privacy)
-   - File writing/overwriting (data loss risk)
-   - File deletion (irreversible)
-4. Register in `agent.py::_register_tools()`:
-   ```python
-   from .tools.mymodule import MyTool
-   # In _register_tools():
-   tools_to_register.append(MyTool())
-   ```
+## Adding new components
 
-### Adding a Skill
+### A tool
 
-1. Create directory: `skills/my-skill/`
-2. Create `SKILL.md` with YAML frontmatter:
-   ```yaml
-   ---
-   name: my-skill
-   description: Use when... (trigger conditions)
-   ---
+1. Create `agentao/tools/<module>.py` and implement `Tool` (or `AsyncToolBase` for async).
+2. Set `requires_confirmation=True` for anything dangerous: arbitrary shell, network requests, file writes, deletions.
+3. Register in `agent.py::_register_tools()`.
 
-   # Skill Documentation
-   ...
-   ```
-3. (Optional) Add `reference/*.md` files for on-demand loading
-4. Restart agent - skill auto-discovered
+### A skill
 
-Reference files are loaded only when skill is activated (saves memory).
+1. Create `skills/<my-skill>/SKILL.md` with YAML frontmatter (`name:`, `description:` — the trigger text the model sees).
+2. Optionally add `reference/*.md` files (loaded only on activation, saves memory).
+3. Restart the agent or run `/skills reload`.
 
-## Important Patterns
+## Common gotchas
 
-### Confirmation Callback Pattern
+- **`cli.py` was split into the `cli/` package** in 0.4.x. Older docs and design notes may still say `cli.py` — grep `agentao/cli/` for the actual handler.
+- **`agentao.harness` → `agentao.host`** rename in 0.4.2. The old name is a deprecated alias scheduled for removal in 0.5.0. Use `agentao.host.HostEvent`, `export_host_acp_json_schema`, etc.
+- **`allow_all_tools` is gone.** Use `/mode full-access` (or the equivalent host-API call) instead.
+- **`agentao -p` is a shim** over `agentao run`. New automation should target `agentao run` directly — that's where the spec schema, Jinja2 templating, and exit codes are documented.
+- **`Agentao` constructor takes 8 legacy callbacks** (`confirmation_callback`, `step_callback`, …) that emit `DeprecationWarning`. They will be removed in 0.5.0 — `agentao.embedding.compat` is the documented migration surface.
+- **Don't intuition-audit architecture.** Before recommending borrowed patterns or claiming a gap exists, grep agentao to verify; subpackage `__init__.py` docstrings document intentional shims and rename trails.
 
-CLI creates callback and passes to Agent:
-```python
-# cli.py
-def confirm_tool_execution(self, name, desc, args) -> bool:
-    # Show menu, get user choice
-    # Return True/False
+## Key dependencies
 
-self.agent = Agentao(
-    confirmation_callback=self.confirm_tool_execution
-)
-```
+Core (`pyproject.toml :: project.dependencies`):
+- `openai>=1.0.0` — LLM client (OpenAI-compatible)
+- `httpx>=0.25.0` — HTTP client
+- `pydantic>=2` — schemas (host contract, ACP, run-spec)
+- `pyyaml>=6.0.3` — SKILL.md frontmatter, plugin manifests
+- `mcp>=1.26.0` — MCP client SDK
+- `python-dotenv>=1.0.0` — `.env` loading
+- `filelock>=1.4.0` — cross-process locking for skill registry
+- `jinja2>=3.0.0` — `agentao run` spec templating (StrictUndefined)
 
-Agent checks before tool execution:
-```python
-# agent.py
-if tool.requires_confirmation and self.confirmation_callback:
-    confirmed = self.confirmation_callback(name, desc, args)
-    if not confirmed:
-        result = "Tool execution cancelled by user"
-```
-
-### Single-Key Input
-
-Uses `readchar` library for instant response:
-```python
-import readchar
-key = readchar.readkey()  # No Enter needed
-```
-
-Supports: `1`, `2`, `3`, `Esc`, `Ctrl+C`. Invalid keys are silently ignored.
-
-### Memory System
-
-**Architecture:** SQLite-backed storage managed by `MemoryManager` (`agentao/memory/manager.py`).
-
-**SQLite databases:**
-
-| Database | Path | Content |
-|----------|------|---------|
-| Project store | `.agentao/memory.db` | Project-scoped persistent memories + session summaries |
-| User store | `<home>/.agentao/memory.db` | Cross-project user-scoped persistent memories |
-
-**Three data types:**
-
-1. **Persistent memories** (`MemoryRecord`) — rows in the `memories` table. Soft-deleted (never physically removed). Scoped to `user` or `project`. Types: `preference`, `profile`, `project_fact`, `workflow`, `decision`, `constraint`, `note`. Source: `explicit` (LLM-written) or `auto`/`crystallized`. Fields: `id`, `scope`, `type`, `key_normalized`, `title`, `content`, `tags`, `keywords`, `source`, `confidence`, `sensitivity`, `created_at`, `updated_at`, `deleted_at`.
-
-2. **Session summaries** (`SessionSummaryRecord`) — rows in the `session_summaries` table. Written by the context-compression pipeline (microcompaction / full LLM summarization) to preserve conversation continuity across compaction events. Scoped to a `session_id`.
-
-3. **Recall candidates** (`RecallCandidate`) — transient, in-memory only. Scored at query time by `MemoryRetriever` using a keyword/Jaccard/tag/recency formula. Never stored.
-
-**Prompt injection (per turn, two blocks):**
-- `<memory-stable>` — rendered by `MemoryPromptRenderer.render_stable_block()`: stable persistent memories only (budget-limited, selection policy applied). Session summaries are intentionally excluded — they already live in the conversation message history as `[Conversation Summary]` blocks.
-- `<memory-context>` — rendered by `render_dynamic_block()`: top-k recall candidates scored against the current user message.
-
-**LLM tool (write-only):**
-- `save_memory(key, value, tags?)` — the only memory tool exposed to the LLM
-
-**CLI commands (full management):**
-- `/memory` / `/memory list` — list all entries
-- `/memory search <query>` — keyword search across title, value, tags
-- `/memory tag <tag>` — filter by tag
-- `/memory user` / `/memory project` — show a single scope
-- `/memory delete <key>` — soft-delete by title
-- `/memory clear` — soft-delete all entries + clear session summaries (with confirmation)
-- `/memory session` — show current session summary
-- `/memory status` — entry counts, session size, archive count
-
-**Separation of concerns:** The LLM can only write (`save_memory`). Search, delete, and clear are CLI-only operations that call `MemoryManager` methods directly — they are never exposed to the LLM as callable tools.
-
-See `docs/features/memory-management.md` for detailed documentation.
-
-## File Organization
-
-```
-agentao/
-├── agentao/           # Main package
-│   ├── agent.py        # Core orchestration
-│   ├── cli.py          # CLI interface with Rich
-│   ├── llm/
-│   │   └── client.py   # OpenAI client wrapper
-│   ├── tools/          # Tool implementations
-│   │   ├── base.py     # Tool base class + registry
-│   │   ├── file_ops.py # Read, write, edit, list
-│   │   ├── search.py   # Glob, grep
-│   │   ├── shell.py    # Shell execution
-│   │   ├── web.py      # Fetch, search
-│   │   ├── memory.py   # Persistent memory
-│   │   ├── agents.py   # Helper agents
-│   │   └── skill.py    # Skill activation
-│   ├── mcp/            # MCP (Model Context Protocol) support
-│   │   ├── config.py   # Config loading + env var expansion
-│   │   ├── client.py   # McpClient + McpClientManager
-│   │   └── tool.py     # McpTool wrapper for Tool interface
-│   └── skills/
-│       └── manager.py  # Skill loading + management
-├── skills/             # Skill definitions (SKILL.md files)
-├── tests/              # Test files (test_*.py)
-├── docs/               # Documentation
-│   ├── features/       # Feature documentation
-│   ├── updates/        # Update logs
-│   ├── implementation/ # Technical implementation details
-│   └── dev-notes/      # Development notes (archived)
-├── CLAUDE.md           # Claude Code guidance
-├── AGENTAO.md        # Project-specific instructions
-└── main.py            # Entry point
-```
-
-## Key Dependencies
-
-- `openai` - LLM client (OpenAI-compatible APIs)
-- `rich` - CLI interface (markdown, panels, prompts)
-- `readchar` - Single-key input (no Enter needed)
-- `httpx` - HTTP client for web tools
-- `beautifulsoup4` - HTML parsing
-- `python-dotenv` - Environment configuration
-- `mcp` - Model Context Protocol client SDK
+Extras: see Package Management section above; full list in `pyproject.toml :: project.optional-dependencies`.

--- a/agentao/agent.py
+++ b/agentao/agent.py
@@ -182,117 +182,35 @@ class Agentao:
         # falls back to Path.cwd()); ACP sessions land it under the frozen,
         # client-supplied project cwd instead of the subprocess's cwd — which
         # for ACP launches is often "/" and read-only.
-        if llm_client is not None:
-            self.llm = llm_client
-        else:
-            if not api_key or not base_url or not model:
-                raise ValueError(
-                    "Agentao(): api_key, base_url, and model are required "
-                    "when llm_client is not supplied. Pass them explicitly, "
-                    "inject a pre-built llm_client=, or use "
-                    "agentao.embedding.build_from_environment() for "
-                    "CLI-style env auto-discovery."
-                )
-            llm_kwargs: Dict[str, Any] = dict(
-                api_key=api_key,
-                base_url=base_url,
-                model=model,
-                log_file=str(self.working_directory / "agentao.log"),
-                logger=logger,
-            )
-            if temperature is not None:
-                llm_kwargs["temperature"] = temperature
-            if max_tokens is not None:
-                llm_kwargs["max_tokens"] = max_tokens
-            self.llm = LLMClient(**llm_kwargs)
-        # When the host has constructed and pre-loaded its own
-        # ``SkillManager``, skip the auto-discovery scan entirely.
-        if skill_manager is not None:
-            self.skill_manager = skill_manager
-        else:
-            self.skill_manager = SkillManager(
-                working_directory=self._working_directory,
-            )
-        from .memory import MemoryManager, MemoryRetriever, SQLiteMemoryStore
-        from .memory.render import MemoryPromptRenderer
-        if memory_manager is not None:
-            self._memory_manager = memory_manager
-        else:
-            # Pure-injection / bare-construction path: project scope only.
-            # The CLI / ACP factory passes an explicitly-built MemoryManager
-            # with both project and user stores resolved from the
-            # surrounding environment, so cross-project user memory only
-            # surfaces through that path.
-            self._memory_manager = MemoryManager(
-                project_store=SQLiteMemoryStore.open_or_memory(
-                    self.working_directory / ".agentao" / "memory.db"
-                ),
-            )
-        self.memory_tool = SaveMemoryTool(memory_manager=self._memory_manager)
-        self.memory_retriever = MemoryRetriever(self._memory_manager)
-        self.memory_renderer = MemoryPromptRenderer()
+        self.llm = self._resolve_llm_client(
+            llm_client,
+            api_key=api_key,
+            base_url=base_url,
+            model=model,
+            temperature=temperature,
+            max_tokens=max_tokens,
+            logger=logger,
+        )
+        self._init_skill_and_memory(skill_manager, memory_manager)
         self._last_user_message: str = ""
         self._stable_block_chars: int = 0  # size of last rendered <memory-stable> block
         self.todo_tool = TodoWriteTool()
         self.permission_engine = permission_engine
 
         # Resolve transport: explicit > compat shim from old callbacks > NullTransport.
-        _has_legacy = any([
-            confirmation_callback, step_callback, thinking_callback, ask_user_callback,
-            output_callback, tool_complete_callback, llm_text_callback,
-            on_max_iterations_callback,
-        ])
-        if transport is not None:
-            if _has_legacy:
-                # Mid-migration footgun: a host that wires a Transport
-                # *and* passes legacy callbacks would silently drop the
-                # callbacks — the explicit transport always wins. Warn
-                # so the host can delete the dead kwargs.
-                warnings.warn(
-                    "Agentao(): legacy callback kwargs were passed alongside "
-                    "transport=, so the callbacks are ignored. Drop them — "
-                    "the transport= path supersedes them.",
-                    DeprecationWarning,
-                    stacklevel=2,
-                )
-            self.transport = transport
-        elif _has_legacy:
-            warnings.warn(
-                "Agentao(): the legacy callback kwargs "
-                "(confirmation_callback, step_callback, thinking_callback, "
-                "ask_user_callback, output_callback, tool_complete_callback, "
-                "llm_text_callback, on_max_iterations_callback) are deprecated "
-                "and will be removed in 0.5.0. Build an SdkTransport directly "
-                "or call agentao.embedding.compat.build_compat_transport(...) "
-                "and pass transport= instead.",
-                DeprecationWarning,
-                stacklevel=2,
-            )
-            self.transport = build_compat_transport(
-                confirmation_callback=confirmation_callback,
-                step_callback=step_callback,
-                thinking_callback=thinking_callback,
-                ask_user_callback=ask_user_callback,
-                output_callback=output_callback,
-                tool_complete_callback=tool_complete_callback,
-                llm_text_callback=llm_text_callback,
-                on_max_iterations_callback=on_max_iterations_callback,
-            )
-        else:
-            self.transport = NullTransport()
-
-        # Store legacy callback attrs for backward compat (read-only; transport is the live wire)
-        self.confirmation_callback = confirmation_callback
-        self.step_callback = step_callback
-        self.thinking_callback = thinking_callback
-        self.ask_user_callback = ask_user_callback
-        self.output_callback = output_callback
-        self.tool_complete_callback = tool_complete_callback
-        self.llm_text_callback = llm_text_callback
-        self.on_max_iterations_callback = on_max_iterations_callback
-
-        # Reasoning prompt is shown only when a dedicated thinking callback is registered
-        self._has_thinking_handler = thinking_callback is not None
+        self._resolve_transport(
+            transport,
+            {
+                "confirmation_callback": confirmation_callback,
+                "step_callback": step_callback,
+                "thinking_callback": thinking_callback,
+                "ask_user_callback": ask_user_callback,
+                "output_callback": output_callback,
+                "tool_complete_callback": tool_complete_callback,
+                "llm_text_callback": llm_text_callback,
+                "on_max_iterations_callback": on_max_iterations_callback,
+            },
+        )
 
         # Initialize context manager
         self.context_manager = ContextManager(
@@ -364,26 +282,7 @@ class Agentao:
         # so the sub-agent wrapper captures a live ``HostSubagentEmitter``
         # instead of ``None`` — otherwise no subagent lifecycle events
         # ever reach the public stream for normal Agentao instances.
-        from .host.projection import (
-            HostPermissionEmitter,
-            HostSubagentEmitter,
-            HostToolEmitter,
-        )
-        self._host_tool_emitter = HostToolEmitter(
-            self._host_events,
-            session_id_provider=lambda: self._session_id,
-            turn_id_provider=lambda: self._current_turn_id,
-        )
-        self._host_permission_emitter = HostPermissionEmitter(
-            self._host_events,
-            session_id_provider=lambda: self._session_id,
-            turn_id_provider=lambda: self._current_turn_id,
-            active_permissions_provider=self.active_permissions,
-        )
-        self._host_subagent_emitter = HostSubagentEmitter(
-            self._host_events,
-            parent_session_id_provider=lambda: self._session_id,
-        )
+        self._init_host_emitters()
 
         # Initialize agent manager and register agent tools. Built-in
         # sub-agents are opt-in so the default tool schema stays compact;
@@ -407,6 +306,165 @@ class Agentao:
             host_tool_emitter=self._host_tool_emitter,
             host_permission_emitter=self._host_permission_emitter,
         )
+
+    def _init_host_emitters(self) -> None:
+        """Build the tool / permission / subagent host-event emitters.
+
+        Must run before ``_register_agent_tools`` so the sub-agent wrapper
+        captures a live ``HostSubagentEmitter`` rather than ``None``.
+        """
+        from .host.projection import (
+            HostPermissionEmitter,
+            HostSubagentEmitter,
+            HostToolEmitter,
+        )
+        self._host_tool_emitter = HostToolEmitter(
+            self._host_events,
+            session_id_provider=lambda: self._session_id,
+            turn_id_provider=lambda: self._current_turn_id,
+        )
+        self._host_permission_emitter = HostPermissionEmitter(
+            self._host_events,
+            session_id_provider=lambda: self._session_id,
+            turn_id_provider=lambda: self._current_turn_id,
+            active_permissions_provider=self.active_permissions,
+        )
+        self._host_subagent_emitter = HostSubagentEmitter(
+            self._host_events,
+            parent_session_id_provider=lambda: self._session_id,
+        )
+
+    def _init_skill_and_memory(
+        self,
+        skill_manager: Optional[SkillManager],
+        memory_manager: Optional["MemoryManager"],
+    ) -> None:
+        """Wire the skill manager, memory store, and memory tooling.
+
+        Both subsystems honour host injection: a pre-loaded
+        ``SkillManager`` skips the disk auto-discovery scan, and an
+        injected ``MemoryManager`` (CLI/ACP factory) carries both project
+        and user stores — bare construction falls back to project scope.
+        """
+        # When the host has constructed and pre-loaded its own
+        # ``SkillManager``, skip the auto-discovery scan entirely.
+        if skill_manager is not None:
+            self.skill_manager = skill_manager
+        else:
+            self.skill_manager = SkillManager(
+                working_directory=self._working_directory,
+            )
+        from .memory import MemoryManager, MemoryRetriever, SQLiteMemoryStore
+        from .memory.render import MemoryPromptRenderer
+        if memory_manager is not None:
+            self._memory_manager = memory_manager
+        else:
+            # Pure-injection / bare-construction path: project scope only.
+            # The CLI / ACP factory passes an explicitly-built MemoryManager
+            # with both project and user stores resolved from the
+            # surrounding environment, so cross-project user memory only
+            # surfaces through that path.
+            self._memory_manager = MemoryManager(
+                project_store=SQLiteMemoryStore.open_or_memory(
+                    self.working_directory / ".agentao" / "memory.db"
+                ),
+            )
+        self.memory_tool = SaveMemoryTool(memory_manager=self._memory_manager)
+        self.memory_retriever = MemoryRetriever(self._memory_manager)
+        self.memory_renderer = MemoryPromptRenderer()
+
+    def _resolve_llm_client(
+        self,
+        llm_client: Optional[LLMClient],
+        *,
+        api_key: Optional[str],
+        base_url: Optional[str],
+        model: Optional[str],
+        temperature: Optional[float],
+        max_tokens: Optional[int],
+        logger: Optional[logging.Logger],
+    ) -> LLMClient:
+        """Return the injected client, or build one from raw provider config.
+
+        The log file is anchored to ``working_directory`` so it always
+        resolves to an absolute, writable path (ACP launches run from a
+        read-only ``/``).
+        """
+        if llm_client is not None:
+            return llm_client
+        if not api_key or not base_url or not model:
+            raise ValueError(
+                "Agentao(): api_key, base_url, and model are required "
+                "when llm_client is not supplied. Pass them explicitly, "
+                "inject a pre-built llm_client=, or use "
+                "agentao.embedding.build_from_environment() for "
+                "CLI-style env auto-discovery."
+            )
+        llm_kwargs: Dict[str, Any] = dict(
+            api_key=api_key,
+            base_url=base_url,
+            model=model,
+            log_file=str(self.working_directory / "agentao.log"),
+            logger=logger,
+        )
+        if temperature is not None:
+            llm_kwargs["temperature"] = temperature
+        if max_tokens is not None:
+            llm_kwargs["max_tokens"] = max_tokens
+        return LLMClient(**llm_kwargs)
+
+    def _resolve_transport(self, transport, callbacks: Dict[str, Any]) -> None:
+        """Resolve the live transport and stash the legacy callback attrs.
+
+        Precedence: an explicit ``transport=`` wins; otherwise a compat
+        shim is built from any of the eight deprecated callbacks; failing
+        both, a silent ``NullTransport`` (headless mode). ``callbacks`` is
+        keyed by the deprecated kwarg names so it can splat straight into
+        :func:`build_compat_transport`.
+        """
+        _has_legacy = any(callbacks.values())
+        if transport is not None:
+            if _has_legacy:
+                # Mid-migration footgun: a host that wires a Transport
+                # *and* passes legacy callbacks would silently drop the
+                # callbacks — the explicit transport always wins. Warn
+                # so the host can delete the dead kwargs.
+                warnings.warn(
+                    "Agentao(): legacy callback kwargs were passed alongside "
+                    "transport=, so the callbacks are ignored. Drop them — "
+                    "the transport= path supersedes them.",
+                    DeprecationWarning,
+                    stacklevel=3,
+                )
+            self.transport = transport
+        elif _has_legacy:
+            warnings.warn(
+                "Agentao(): the legacy callback kwargs "
+                "(confirmation_callback, step_callback, thinking_callback, "
+                "ask_user_callback, output_callback, tool_complete_callback, "
+                "llm_text_callback, on_max_iterations_callback) are deprecated "
+                "and will be removed in 0.5.0. Build an SdkTransport directly "
+                "or call agentao.embedding.compat.build_compat_transport(...) "
+                "and pass transport= instead.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            self.transport = build_compat_transport(**callbacks)
+        else:
+            self.transport = NullTransport()
+
+        # Store legacy callback attrs for backward compat (read-only; transport is the live wire)
+        self.confirmation_callback = callbacks["confirmation_callback"]
+        self.step_callback = callbacks["step_callback"]
+        self.thinking_callback = callbacks["thinking_callback"]
+        self.ask_user_callback = callbacks["ask_user_callback"]
+        self.output_callback = callbacks["output_callback"]
+        self.tool_complete_callback = callbacks["tool_complete_callback"]
+        self.llm_text_callback = callbacks["llm_text_callback"]
+        self.on_max_iterations_callback = callbacks["on_max_iterations_callback"]
+
+        # Reasoning prompt is shown only when a dedicated thinking callback is registered
+        self._has_thinking_handler = callbacks["thinking_callback"] is not None
 
     @property
     def _llm_config(self) -> Dict[str, Any]:

--- a/agentao/cli/_utils.py
+++ b/agentao/cli/_utils.py
@@ -90,20 +90,54 @@ _SLASH_COMMAND_HINTS = {
 
 
 class _SlashCompleter(Completer):
+    """Slash-command completer that preserves draft tail.
+
+    Two behaviors that matter for the "typed prose first, then prepended
+    a slash command" workflow:
+
+    - Exact match of an arg-taking command (e.g. ``/agent bg``) yields a
+      display-only hint that inserts nothing. The previous version
+      inserted the literal hint string (`` <agent-name> <task>``) into
+      the buffer, which collided with any draft after the cursor.
+    - Prefix completion of an arg-taking command appends a trailing
+      space unless the cursor is already followed by whitespace. This
+      keeps ``/ageplease refactor`` → ``/agent please refactor`` instead
+      of the broken ``/agentplease refactor``.
+    """
+
     def get_completions(self, document, complete_event):
-        text = document.text_before_cursor
-        if not text.startswith('/'):
+        text_before = document.text_before_cursor
+        if not text_before.startswith('/'):
             return
-        # If the typed text exactly matches a command, show its argument hint
-        stripped = text.rstrip()
+
+        text_after = document.text_after_cursor
+        stripped = text_before.rstrip()
+
+        # Exact match → display-only hint. Inserting ``''`` keeps the
+        # popup informational without rewriting the buffer.
         if stripped in _SLASH_COMMAND_HINTS:
             hint = _SLASH_COMMAND_HINTS[stripped]
-            yield Completion(f' {hint}', start_position=0, display_meta='arg')
+            yield Completion(
+                text='',
+                start_position=0,
+                display=hint,
+                display_meta='arg',
+            )
             return
-        # Prefix completion for command names
+
+        # Prefix completion for command names.
         for cmd in _SLASH_COMMANDS:
-            if cmd.startswith(text):
-                yield Completion(cmd, start_position=-len(text))
+            if not cmd.startswith(text_before):
+                continue
+            takes_args = cmd in _SLASH_COMMAND_HINTS
+            needs_space = takes_args and not (
+                text_after and text_after[0].isspace()
+            )
+            suffix = ' ' if needs_space else ''
+            yield Completion(
+                text=cmd + suffix,
+                start_position=-len(text_before),
+            )
 
 
 def _display_layered_entries(entries, header: str, console) -> None:

--- a/agentao/llm/_stream_response.py
+++ b/agentao/llm/_stream_response.py
@@ -17,7 +17,43 @@ structure plumbing kept separate so the network/retry path in
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
+
+
+class _StreamAccumulator:
+    """Mutable per-attempt state for one streaming chat completion.
+
+    Holds the partial content / reasoning / tool-call data accumulated as
+    stream chunks arrive, plus ``progress_made`` (set once ``on_text_chunk``
+    has fired with non-empty text). ``chat_stream`` creates a fresh
+    accumulator per retry attempt; ``_consume_stream`` fills it and
+    ``build()`` materialises the duck-type response.
+    """
+
+    def __init__(self, model: str) -> None:
+        self.content_parts: List[str] = []
+        self.reasoning_parts: List[str] = []
+        self.tool_calls_data: Dict[int, Dict[str, str]] = {}
+        self.finish_reason: str = "stop"
+        self.response_model: str = model
+        self.usage_data: Any = None
+        # True only after on_text_chunk has fired with non-empty text — i.e.,
+        # an LLM_TEXT event has reached the host. Role-only first chunks,
+        # usage-only chunks, and tool-call/reasoning-only chunks all consume
+        # iterations without exposing anything to the host, so they must NOT
+        # block the pre-output retry path.
+        self.progress_made: bool = False
+
+    def build(self) -> "_StreamResponse":
+        """Materialise the accumulated deltas into a duck-type response."""
+        return _StreamResponse(
+            model=self.response_model,
+            content="".join(self.content_parts) if self.content_parts else None,
+            tool_calls_data=self.tool_calls_data,
+            finish_reason=self.finish_reason,
+            usage=self.usage_data,
+            reasoning_content="".join(self.reasoning_parts) if self.reasoning_parts else None,
+        )
 
 
 class _StreamFunction:

--- a/agentao/llm/client.py
+++ b/agentao/llm/client.py
@@ -38,7 +38,7 @@ from ._retry import (
     _mark_streamed,
     _parse_retry_after,
 )
-from ._stream_response import _StreamResponse
+from ._stream_response import _StreamAccumulator, _StreamResponse
 
 # `openai` is deferred (P0.5): merely importing ``LLMClient`` should not pull
 # in the OpenAI SDK. Hosts that inject their own ``llm_client=`` never load
@@ -508,12 +508,7 @@ class LLMClient:
         """
         # Gemini: bypass streaming to preserve thought_signature on tool calls
         if self._is_gemini():
-            response = self.chat(messages, tools=tools, max_tokens=max_tokens)
-            if on_text_chunk:
-                content = response.choices[0].message.content
-                if content:
-                    on_text_chunk(content)
-            return response
+            return self._emit_nonstreaming(messages, tools, max_tokens, on_text_chunk)
 
         self.request_count += 1
         request_id = f"req_{self.request_count}"
@@ -538,96 +533,27 @@ class LLMClient:
         deadline = time.monotonic() + MAX_TOTAL_RETRY_SECONDS
         attempt = 0  # number of retries performed; first try is attempt 0
         while True:
-            content_parts: List[str] = []
-            reasoning_parts: List[str] = []
-            tool_calls_data: Dict[int, Dict[str, str]] = {}
-            finish_reason = "stop"
-            response_model = self.model
-            usage_data = None
-            # True only after on_text_chunk has fired with non-empty text — i.e.,
-            # an LLM_TEXT event has reached the host. Role-only first chunks,
-            # usage-only chunks, and tool-call/reasoning-only chunks all consume
-            # iterations without exposing anything to the host, so they must
-            # NOT block the pre-output retry path.
-            progress_made = False
-
+            acc = _StreamAccumulator(self.model)
             try:
-                stream = self.client.chat.completions.create(**kwargs)
-
-                for chunk in stream:
-                    if cancellation_token and cancellation_token.is_cancelled:
-                        break
-                    # Capture usage from final usage-only chunk (stream_options include_usage)
-                    if hasattr(chunk, "usage") and chunk.usage:
-                        usage_data = chunk.usage
-                    if not chunk.choices:
-                        continue
-                    choice = chunk.choices[0]
-                    delta = choice.delta
-
-                    # Accumulate text content and fire callback
-                    if delta and delta.content:
-                        content_parts.append(delta.content)
-                        if on_text_chunk:
-                            on_text_chunk(delta.content)
-                            progress_made = True
-
-                    # Accumulate reasoning_content (DeepSeek/MiniMax/Kimi-style thinking
-                    # field). Non-streaming exposes it on message.reasoning_content;
-                    # without this branch the streaming path would silently drop it.
-                    if delta and getattr(delta, "reasoning_content", None):
-                        reasoning_parts.append(delta.reasoning_content)
-
-                    # Accumulate tool call deltas
-                    if delta and delta.tool_calls:
-                        for tc_delta in delta.tool_calls:
-                            idx = tc_delta.index
-                            if idx not in tool_calls_data:
-                                tool_calls_data[idx] = {"id": "", "name": "", "arguments": ""}
-                            if tc_delta.id:
-                                tool_calls_data[idx]["id"] = tc_delta.id
-                            if tc_delta.function:
-                                if tc_delta.function.name:
-                                    tool_calls_data[idx]["name"] += tc_delta.function.name
-                                if tc_delta.function.arguments:
-                                    tool_calls_data[idx]["arguments"] += tc_delta.function.arguments
-                                # Gemini thinking models: preserve thought_signature
-                                thought_sig = getattr(tc_delta.function, "thought_signature", None)
-                                if thought_sig is not None:
-                                    tool_calls_data[idx]["thought_signature"] = thought_sig
-
-                    if choice.finish_reason:
-                        finish_reason = choice.finish_reason
-
-                    if hasattr(chunk, "model") and chunk.model:
-                        response_model = chunk.model
-
-                # Accumulate session token totals
-                if usage_data is not None:
-                    self.total_prompt_tokens += getattr(usage_data, "prompt_tokens", 0) or 0
-                    self.total_completion_tokens += getattr(usage_data, "completion_tokens", 0) or 0
-
-                # Build a duck-type response that agent.py can consume like a ChatCompletion
-                response = _StreamResponse(
-                    model=response_model,
-                    content="".join(content_parts) if content_parts else None,
-                    tool_calls_data=tool_calls_data,
-                    finish_reason=finish_reason,
-                    usage=usage_data,
-                    reasoning_content="".join(reasoning_parts) if reasoning_parts else None,
+                response = self._consume_stream(
+                    kwargs, acc, on_text_chunk, cancellation_token,
                 )
-
                 self._log_response(request_id, response)
                 return response
 
             except Exception as e:
+                # The error handling stays lexically inside the ``except``
+                # block on purpose: its bare ``raise`` statements rely on the
+                # active exception bound here, and ``acc.progress_made`` (set
+                # by ``_consume_stream`` before it propagated) decides whether
+                # a retry would duplicate already-emitted content.
                 err_str = str(e).lower()
 
                 # max_tokens vs max_completion_tokens param mismatch — one-shot
                 # fix-up. Only safe at zero progress (otherwise we'd re-emit
                 # content via on_text_chunk). Latched flag prevents loops.
                 if (
-                    not progress_made
+                    not acc.progress_made
                     and not self._use_max_completion_tokens
                     and "max_tokens" in err_str
                     and "max_completion_tokens" in err_str
@@ -652,7 +578,7 @@ class LLMClient:
                 # streaming is unsupported (never bare "stream"/"streaming",
                 # which also matches "upstream" in 502/503 proxy errors).
                 if (
-                    not progress_made
+                    not acc.progress_made
                     and not retryable
                     and _is_streaming_unsupported(err_str)
                 ):
@@ -661,12 +587,9 @@ class LLMClient:
                         "falling back to non-streaming"
                     )
                     try:
-                        response = self.chat(messages, tools=tools, max_tokens=max_tokens)
-                        if on_text_chunk:
-                            content = response.choices[0].message.content
-                            if content:
-                                on_text_chunk(content)
-                        return response
+                        return self._emit_nonstreaming(
+                            messages, tools, max_tokens, on_text_chunk,
+                        )
                     except Exception as fallback_e:
                         import traceback
                         self.logger.error(
@@ -682,14 +605,14 @@ class LLMClient:
                 # Attach .streamed so callers (and the runtime's
                 # LLM_CALL_COMPLETED error payload) can distinguish "host
                 # already saw partial chunks" from "nothing reached the host".
-                _mark_streamed(e, progress_made)
+                _mark_streamed(e, acc.progress_made)
                 if (
                     not retryable
-                    or progress_made
+                    or acc.progress_made
                     or attempt >= MAX_RETRY_ATTEMPTS - 1
                 ):
                     import traceback
-                    if progress_made and retryable:
+                    if acc.progress_made and retryable:
                         self.logger.error(
                             f"[{request_id}] mid-stream failure (cannot retry safely): "
                             f"{str(e)}\n{traceback.format_exc()}"
@@ -722,6 +645,98 @@ class LLMClient:
                     )
                     raise
                 attempt += 1
+
+    def _consume_stream(
+        self,
+        kwargs: Dict[str, Any],
+        acc: "_StreamAccumulator",
+        on_text_chunk: Optional[Any],
+        cancellation_token: Optional[Any],
+    ) -> "_StreamResponse":
+        """Run one streaming attempt, accumulating chunks into ``acc``.
+
+        Returns the built duck-type response on success. On error it
+        propagates the exception after ``acc`` already reflects any partial
+        progress (notably ``acc.progress_made``), so ``chat_stream``'s
+        retry handler can tell whether a retry would duplicate
+        already-emitted content.
+        """
+        stream = self.client.chat.completions.create(**kwargs)
+
+        for chunk in stream:
+            if cancellation_token and cancellation_token.is_cancelled:
+                break
+            # Capture usage from final usage-only chunk (stream_options include_usage)
+            if hasattr(chunk, "usage") and chunk.usage:
+                acc.usage_data = chunk.usage
+            if not chunk.choices:
+                continue
+            choice = chunk.choices[0]
+            delta = choice.delta
+
+            # Accumulate text content and fire callback
+            if delta and delta.content:
+                acc.content_parts.append(delta.content)
+                if on_text_chunk:
+                    on_text_chunk(delta.content)
+                    acc.progress_made = True
+
+            # Accumulate reasoning_content (DeepSeek/MiniMax/Kimi-style thinking
+            # field). Non-streaming exposes it on message.reasoning_content;
+            # without this branch the streaming path would silently drop it.
+            if delta and getattr(delta, "reasoning_content", None):
+                acc.reasoning_parts.append(delta.reasoning_content)
+
+            # Accumulate tool call deltas
+            if delta and delta.tool_calls:
+                for tc_delta in delta.tool_calls:
+                    idx = tc_delta.index
+                    if idx not in acc.tool_calls_data:
+                        acc.tool_calls_data[idx] = {"id": "", "name": "", "arguments": ""}
+                    if tc_delta.id:
+                        acc.tool_calls_data[idx]["id"] = tc_delta.id
+                    if tc_delta.function:
+                        if tc_delta.function.name:
+                            acc.tool_calls_data[idx]["name"] += tc_delta.function.name
+                        if tc_delta.function.arguments:
+                            acc.tool_calls_data[idx]["arguments"] += tc_delta.function.arguments
+                        # Gemini thinking models: preserve thought_signature
+                        thought_sig = getattr(tc_delta.function, "thought_signature", None)
+                        if thought_sig is not None:
+                            acc.tool_calls_data[idx]["thought_signature"] = thought_sig
+
+            if choice.finish_reason:
+                acc.finish_reason = choice.finish_reason
+
+            if hasattr(chunk, "model") and chunk.model:
+                acc.response_model = chunk.model
+
+        # Accumulate session token totals
+        if acc.usage_data is not None:
+            self.total_prompt_tokens += getattr(acc.usage_data, "prompt_tokens", 0) or 0
+            self.total_completion_tokens += getattr(acc.usage_data, "completion_tokens", 0) or 0
+
+        # Build a duck-type response that agent.py can consume like a ChatCompletion
+        return acc.build()
+
+    def _emit_nonstreaming(
+        self,
+        messages: List[Dict[str, Any]],
+        tools: Optional[List[Dict[str, Any]]],
+        max_tokens: Optional[int],
+        on_text_chunk: Optional[Any],
+    ) -> Any:
+        """Run the non-streaming ``chat()`` and replay its full content
+        through ``on_text_chunk`` so streaming callers behave identically.
+
+        Shared by the Gemini bypass and the streaming-unsupported fallback.
+        """
+        response = self.chat(messages, tools=tools, max_tokens=max_tokens)
+        if on_text_chunk:
+            content = response.choices[0].message.content
+            if content:
+                on_text_chunk(content)
+        return response
 
     def _log_response(self, request_id: str, response: Any) -> None:
         """Log LLM response details.

--- a/agentao/runtime/chat_loop/_runner.py
+++ b/agentao/runtime/chat_loop/_runner.py
@@ -48,6 +48,74 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
         self._stop_reentry_cap: int = stop_reentry_cap
 
     # ------------------------------------------------------------------
+    # Loop-step decisions
+    # ------------------------------------------------------------------
+
+    class _Step:
+        """A branch helper's verdict on how ``run()`` should proceed.
+
+        ``action`` is one of:
+          - ``"return"``   — end the turn, hand ``value`` back to the caller.
+          - ``"continue"`` — restart ``while True`` (Stop-hook re-entry);
+            ``iteration`` is reset to 0 by ``run()``.
+          - ``"proceed"``  — fall straight through to the next LLM call
+            (max-iter ``continue`` / ``new_instruction`` actions).
+          - ``"loop"``     — normal end of a tool-call iteration; carries the
+            refreshed skill/memory bookkeeping back into the loop.
+        """
+
+        __slots__ = (
+            "action", "value", "messages_with_system",
+            "system_prompt", "active_skills", "memory_version",
+        )
+
+        def __init__(
+            self,
+            action: str,
+            *,
+            value: Optional[str] = None,
+            messages_with_system=None,
+            system_prompt=None,
+            active_skills=None,
+            memory_version=None,
+        ) -> None:
+            self.action = action
+            self.value = value
+            self.messages_with_system = messages_with_system
+            self.system_prompt = system_prompt
+            self.active_skills = active_skills
+            self.memory_version = memory_version
+
+    # Per-site differences in Stop-hook handling. The three sites
+    # (max-iterations / doom-loop / final-response) share one code path
+    # (``_resolve_stop_hook``); only the log text, the ``force_continue``
+    # telemetry label, and whether ``additional_contexts`` ride on the
+    # answer differ.
+    _STOP_SITES = {
+        "max_iterations": {
+            "reentry_cap_log": "Stop hook reentry cap (%d) hit at max-iterations; ending turn.",
+            "force_continue_log": (
+                "Stop hook force_continue at max-iterations; "
+                "resetting iteration counter (outcome=continue_at_max_iter)."
+            ),
+            "force_continue_outcome": "continue_at_max_iter",
+            "echo_additional_contexts": False,
+        },
+        "doom_loop": {
+            "reentry_cap_log": "Stop hook reentry cap (%d) hit at doom-loop; ending turn.",
+            "force_continue_log": "Stop hook force_continue at doom-loop",
+            "force_continue_outcome": "continue",
+            "echo_additional_contexts": False,
+        },
+        "final_response": {
+            "reentry_cap_log": "Stop hook reentry cap (%d) hit; ending turn.",
+            "force_continue_log": None,
+            "force_continue_outcome": "continue",
+            "echo_additional_contexts": True,
+        },
+    }
+
+    # ------------------------------------------------------------------
     # Public entry point
     # ------------------------------------------------------------------
 
@@ -99,118 +167,22 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
         assistant_message = None
         while True:
             if iteration >= max_iterations:
-                pending = []
-                if assistant_message and getattr(assistant_message, "tool_calls", None):
-                    for tc in assistant_message.tool_calls:
-                        pending.append({"name": tc.function.name, "args": tc.function.arguments})
-
-                _handler = getattr(agent.transport, "on_max_iterations", None)
-                result = _handler(max_iterations, pending) if callable(_handler) else {"action": "stop"}
-                action = result.get("action", "stop")
-                if action == "continue":
-                    iteration = 0
-                elif action == "new_instruction":
-                    iteration = 0
-                    new_msg = result.get("message", "")
-                    if new_msg:
-                        agent.messages.append({"role": "user", "content": new_msg})
-                        messages_with_system = [
-                            {"role": "system", "content": system_prompt}
-                        ] + agent.messages
-                else:  # "stop"
-                    # Finalize max-iter inside the loop body so a Stop
-                    # hook ``force_continue`` can re-enter ``while True``.
-                    agent.llm.logger.warning(
-                        f"Maximum tool call iterations ({max_iterations}) reached"
-                    )
-                    assistant_content_max = (
-                        assistant_message.content if assistant_message else None
-                    ) or "Maximum tool call iterations reached."
-                    reasoning_content_max = (
-                        getattr(assistant_message, "reasoning_content", None)
-                        if assistant_message else None
-                    )
-                    final_msg_max: Dict[str, Any] = {
-                        "role": "assistant",
-                        "content": assistant_content_max,
-                    }
-                    _attach_reasoning(final_msg_max, reasoning_content_max)
-                    if sanitize_assistant_message(final_msg_max):
-                        agent.llm.logger.warning(
-                            "Sanitised lone surrogates in max-iteration assistant message"
-                        )
-
-                    stop_result = self._dispatch_stop(
-                        turn_end_reason="max_iterations",
-                        last_assistant_message=assistant_content_max,
-                    )
-
-                    if stop_result.blocking_error:
-                        blocked = f"[Blocked by Stop hook] {stop_result.blocking_error}"
-                        final_msg_max["content"] = blocked
-                        agent.messages.append(final_msg_max)
-                        self._emit_stop_hook_fired(
-                            outcome="block",
-                            turn_end_reason="max_iterations",
-                            stop_result=stop_result,
-                        )
-                        return blocked
-
-                    if stop_result.force_continue:
-                        # Cap check FIRST — without it a cap-hit would
-                        # fall through to allow and silently mask the
-                        # pathological hook.
-                        if self._stop_reentries >= self._stop_reentry_cap:
-                            agent.llm.logger.warning(
-                                "Stop hook reentry cap (%d) hit at max-iterations; ending turn.",
-                                self._stop_reentry_cap,
-                            )
-                            agent.messages.append(final_msg_max)
-                            self._emit_stop_hook_fired(
-                                outcome="reentry_capped",
-                                turn_end_reason="max_iterations",
-                                stop_result=stop_result,
-                            )
-                            return assistant_content_max
-                        follow_up = (
-                            stop_result.follow_up_message
-                            or stop_result.stop_reason
-                            or "Stop hook requested continuation"
-                        )
-                        self._stop_reentries += 1
-                        agent.llm.logger.warning(
-                            "Stop hook force_continue at max-iterations; "
-                            "resetting iteration counter (outcome=continue_at_max_iter)."
-                        )
-                        agent.messages.append(final_msg_max)
-                        agent.messages.append({
-                            "role": "user",
-                            "content": (
-                                "<system-reminder>Stop hook injected this</system-reminder>\n"
-                                f"{follow_up}"
-                            ),
-                        })
-                        messages_with_system = [
-                            {"role": "system", "content": system_prompt}
-                        ] + agent.messages
-                        iteration = 0
-                        self._emit_stop_hook_fired(
-                            outcome="continue_at_max_iter",
-                            turn_end_reason="max_iterations",
-                            stop_result=stop_result,
-                        )
-                        continue
-
-                    # Max-iter does not echo additional_contexts —
-                    # decorating the cap fallback string would be
-                    # unhelpful UX.
-                    agent.messages.append(final_msg_max)
-                    self._emit_stop_hook_fired(
-                        outcome="allow",
-                        turn_end_reason="max_iterations",
-                        stop_result=stop_result,
-                    )
-                    return assistant_content_max
+                step = self._handle_iteration_cap(
+                    max_iterations=max_iterations,
+                    assistant_message=assistant_message,
+                    messages_with_system=messages_with_system,
+                    system_prompt=system_prompt,
+                )
+                if step.action == "return":
+                    return step.value
+                # Both "proceed" (transport continue / new_instruction) and
+                # "continue" (Stop-hook re-entry) reset the budget; only the
+                # latter restarts the loop instead of falling through.
+                messages_with_system = step.messages_with_system
+                system_prompt = step.system_prompt
+                iteration = 0
+                if step.action == "continue":
+                    continue
 
             iteration += 1
             agent.llm.logger.info(f"LLM iteration {iteration}/{max_iterations}")
@@ -248,274 +220,374 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
             assistant_message = response.choices[0].message
 
             if assistant_message.tool_calls:
-                agent.llm.logger.info(
-                    f"Processing {len(assistant_message.tool_calls)} tool call(s) "
-                    f"in iteration {iteration}"
+                step = self._handle_tool_calls(
+                    assistant_message=assistant_message,
+                    iteration=iteration,
+                    token=token,
+                    messages_with_system=messages_with_system,
+                    system_prompt=system_prompt,
+                    active_skills=current_active_skills,
+                    memory_version=current_memory_version,
                 )
-
-                # Pre-pass: clean surrogates and repair tool names so
-                # the history serializer and the runner see identical
-                # ids/names/arguments (frozen SDK objects otherwise
-                # diverge between the two paths).
-                clean_tool_calls, tcs_changed = (
-                    agent.tool_runner.normalize_tool_calls(
-                        assistant_message.tool_calls
-                    )
+                if step.action == "return":
+                    return step.value
+                messages_with_system = step.messages_with_system
+                system_prompt = step.system_prompt
+                if step.action == "continue":  # doom-loop Stop-hook re-entry
+                    iteration = 0
+                    continue
+                # "loop" — normal end of a tool iteration
+                current_active_skills = step.active_skills
+                current_memory_version = step.memory_version
+            else:
+                step = self._handle_final_response(
+                    assistant_message=assistant_message,
+                    iteration=iteration,
+                    system_prompt=system_prompt,
                 )
+                if step.action == "continue":  # Stop-hook re-entry
+                    messages_with_system = step.messages_with_system
+                    system_prompt = step.system_prompt
+                    iteration = 0
+                    continue
+                return step.value
 
-                reasoning_content = getattr(assistant_message, "reasoning_content", None)
-                if reasoning_content:
-                    agent.transport.emit(AgentEvent(EventType.THINKING, {"text": reasoning_content}))
+    # ------------------------------------------------------------------
+    # Loop-branch helpers
+    # ------------------------------------------------------------------
 
-                reasoning = (assistant_message.content or "").strip()
-                if reasoning:
-                    agent.transport.emit(AgentEvent(EventType.THINKING, {"text": reasoning}))
+    def _handle_iteration_cap(
+        self,
+        *,
+        max_iterations: int,
+        assistant_message,
+        messages_with_system: list,
+        system_prompt: str,
+    ) -> "ChatLoopRunner._Step":
+        """Resolve the iteration-budget exhaustion at the top of the loop.
 
-                assistant_msg: Dict[str, Any] = {
-                    "role": "assistant",
-                    "content": assistant_message.content or "",
-                    "tool_calls": [
-                        _serialize_tool_call(tc, logger=agent.llm.logger)
-                        for tc in clean_tool_calls
-                    ],
-                }
-                _attach_reasoning(assistant_msg, reasoning_content)
+        Consults ``transport.on_max_iterations`` and, on ``"stop"``,
+        finalizes the turn through the shared Stop-hook path (which may
+        itself force a re-entry).
+        """
+        agent = self._agent
+        pending = []
+        if assistant_message and getattr(assistant_message, "tool_calls", None):
+            for tc in assistant_message.tool_calls:
+                pending.append({"name": tc.function.name, "args": tc.function.arguments})
 
-                msg_sanitized = sanitize_assistant_message(assistant_msg)
-                if tcs_changed or msg_sanitized:
-                    agent.llm.logger.warning(
-                        "Sanitised lone surrogates in outbound assistant "
-                        "message (iteration %d)",
-                        iteration,
-                    )
-                agent.messages.append(assistant_msg)
-
-                doom_triggered, tool_results = agent.tool_runner.execute(
-                    clean_tool_calls,
-                    cancellation_token=token,
-                )
-                agent.messages.extend(tool_results)
-                # Turn-level telemetry: count tool calls the LLM made
-                # this iteration; run_turn reset this to 0 and TURN_END
-                # reports the total.
-                agent._turn_tool_count = (
-                    getattr(agent, "_turn_tool_count", 0) + len(clean_tool_calls)
-                )
-                if doom_triggered:
-                    doom_content = (assistant_msg.get("content") or "").strip()
-                    assistant_content_doom = (
-                        doom_content
-                        or "Tool execution halted by doom-loop detection."
-                    )
-                    final_msg_doom: Dict[str, Any] = {
-                        "role": "assistant",
-                        "content": assistant_content_doom,
-                    }
-                    _attach_reasoning(final_msg_doom, reasoning_content)
-                    if sanitize_assistant_message(final_msg_doom):
-                        agent.llm.logger.warning(
-                            "Sanitised lone surrogates in doom-loop assistant message"
-                        )
-
-                    stop_result = self._dispatch_stop(
-                        turn_end_reason="doom_loop",
-                        last_assistant_message=assistant_content_doom,
-                    )
-
-                    if stop_result.blocking_error:
-                        blocked = f"[Blocked by Stop hook] {stop_result.blocking_error}"
-                        final_msg_doom["content"] = blocked
-                        agent.messages.append(final_msg_doom)
-                        self._emit_stop_hook_fired(
-                            outcome="block",
-                            turn_end_reason="doom_loop",
-                            stop_result=stop_result,
-                        )
-                        return blocked
-
-                    if stop_result.force_continue:
-                        if self._stop_reentries >= self._stop_reentry_cap:
-                            agent.llm.logger.warning(
-                                "Stop hook reentry cap (%d) hit at doom-loop; ending turn.",
-                                self._stop_reentry_cap,
-                            )
-                            agent.messages.append(final_msg_doom)
-                            self._emit_stop_hook_fired(
-                                outcome="reentry_capped",
-                                turn_end_reason="doom_loop",
-                                stop_result=stop_result,
-                            )
-                            return assistant_content_doom
-                        follow_up = (
-                            stop_result.follow_up_message
-                            or stop_result.stop_reason
-                            or "Stop hook requested continuation"
-                        )
-                        self._stop_reentries += 1
-                        # ToolRunner's doom counter is NOT reset here —
-                        # re-tripping doom is a reasonable outcome of
-                        # "host insisted on continuing despite the model
-                        # misbehaving."
-                        agent.llm.logger.warning(
-                            "Stop hook force_continue at doom-loop"
-                        )
-                        agent.messages.append(final_msg_doom)
-                        agent.messages.append({
-                            "role": "user",
-                            "content": (
-                                "<system-reminder>Stop hook injected this</system-reminder>\n"
-                                f"{follow_up}"
-                            ),
-                        })
-                        messages_with_system = [
-                            {"role": "system", "content": system_prompt}
-                        ] + agent.messages
-                        iteration = 0
-                        self._emit_stop_hook_fired(
-                            outcome="continue",
-                            turn_end_reason="doom_loop",
-                            stop_result=stop_result,
-                        )
-                        continue
-
-                    # Doom-loop does not echo additional_contexts —
-                    # decorating the halt-detection fallback would be
-                    # unhelpful UX.
-                    agent.messages.append(final_msg_doom)
-                    self._emit_stop_hook_fired(
-                        outcome="allow",
-                        turn_end_reason="doom_loop",
-                        stop_result=stop_result,
-                    )
-                    return assistant_content_doom
-                if token.is_cancelled:
-                    raise AgentCancelledError(token.reason)
-
-                new_active_skills = frozenset(agent.skill_manager.get_active_skills().keys())
-                new_memory_version = agent.memory_manager.write_version
-                if (
-                    new_active_skills != current_active_skills
-                    or new_memory_version != current_memory_version
-                ):
-                    self._emit_skill_and_memory_diffs(
-                        prev_active=current_active_skills,
-                        new_active=new_active_skills,
-                        prev_memory_version=current_memory_version,
-                        new_memory_version=new_memory_version,
-                    )
-                    current_active_skills = new_active_skills
-                    current_memory_version = new_memory_version
-                    system_prompt = agent._build_system_prompt()
+        _handler = getattr(agent.transport, "on_max_iterations", None)
+        result = _handler(max_iterations, pending) if callable(_handler) else {"action": "stop"}
+        action = result.get("action", "stop")
+        if action == "continue":
+            return ChatLoopRunner._Step(
+                "proceed",
+                messages_with_system=messages_with_system,
+                system_prompt=system_prompt,
+            )
+        if action == "new_instruction":
+            new_msg = result.get("message", "")
+            if new_msg:
+                agent.messages.append({"role": "user", "content": new_msg})
                 messages_with_system = [
                     {"role": "system", "content": system_prompt}
                 ] + agent.messages
-            else:
-                agent.llm.logger.info(f"Reached final response in iteration {iteration}")
-                reasoning_content = getattr(assistant_message, "reasoning_content", None)
-                assistant_content = assistant_message.content or ""
-                if not assistant_content.strip():
-                    # Some models (byte-level reasoning backends — Kimi,
-                    # GLM, Qwen-via-Ollama) end a turn with empty/whitespace
-                    # content and no tool calls. Persisting "" leaves a
-                    # contentless assistant message that strict API proxies
-                    # reject on the next turn. Substitute a neutral marker.
-                    assistant_content = (
-                        "[No text response]"
-                        if reasoning_content
-                        else "[No response]"
-                    )
-                    agent.llm.logger.warning(
-                        "Empty final assistant content in iteration %d; "
-                        "substituted placeholder to keep history valid",
-                        iteration,
-                    )
-                final_msg: Dict[str, Any] = {"role": "assistant", "content": assistant_content}
-                _attach_reasoning(final_msg, reasoning_content)
-                if sanitize_assistant_message(final_msg):
-                    agent.llm.logger.warning(
-                        "Sanitised lone surrogates in final assistant message "
-                        "(iteration %d)", iteration,
-                    )
+            return ChatLoopRunner._Step(
+                "proceed",
+                messages_with_system=messages_with_system,
+                system_prompt=system_prompt,
+            )
 
-                # Dispatch Stop before appending so blocking_error can
-                # rewrite final_msg.content without leaving the original
-                # answer in history.
-                stop_result = self._dispatch_stop(
-                    turn_end_reason="final_response",
-                    last_assistant_message=assistant_content,
+        # action == "stop": finalize max-iter inside the loop body so a
+        # Stop hook ``force_continue`` can re-enter ``while True``.
+        agent.llm.logger.warning(
+            f"Maximum tool call iterations ({max_iterations}) reached"
+        )
+        assistant_content_max = (
+            assistant_message.content if assistant_message else None
+        ) or "Maximum tool call iterations reached."
+        reasoning_content_max = (
+            getattr(assistant_message, "reasoning_content", None)
+            if assistant_message else None
+        )
+        final_msg_max: Dict[str, Any] = {
+            "role": "assistant",
+            "content": assistant_content_max,
+        }
+        _attach_reasoning(final_msg_max, reasoning_content_max)
+        if sanitize_assistant_message(final_msg_max):
+            agent.llm.logger.warning(
+                "Sanitised lone surrogates in max-iteration assistant message"
+            )
+        return self._resolve_stop_hook(
+            turn_end_reason="max_iterations",
+            assistant_content=assistant_content_max,
+            final_msg=final_msg_max,
+            system_prompt=system_prompt,
+        )
+
+    def _handle_tool_calls(
+        self,
+        *,
+        assistant_message,
+        iteration: int,
+        token: CancellationToken,
+        messages_with_system: list,
+        system_prompt: str,
+        active_skills: frozenset,
+        memory_version: int,
+    ) -> "ChatLoopRunner._Step":
+        """Serialize, execute, and account for one batch of tool calls.
+
+        Returns a ``"return"`` / ``"continue"`` step when the doom-loop
+        Stop-hook fires, otherwise a ``"loop"`` step carrying the
+        refreshed skill/memory bookkeeping. Raises ``AgentCancelledError``
+        if cancellation landed during execution.
+        """
+        agent = self._agent
+        agent.llm.logger.info(
+            f"Processing {len(assistant_message.tool_calls)} tool call(s) "
+            f"in iteration {iteration}"
+        )
+
+        # Pre-pass: clean surrogates and repair tool names so the history
+        # serializer and the runner see identical ids/names/arguments
+        # (frozen SDK objects otherwise diverge between the two paths).
+        clean_tool_calls, tcs_changed = (
+            agent.tool_runner.normalize_tool_calls(assistant_message.tool_calls)
+        )
+
+        reasoning_content = getattr(assistant_message, "reasoning_content", None)
+        if reasoning_content:
+            agent.transport.emit(AgentEvent(EventType.THINKING, {"text": reasoning_content}))
+
+        reasoning = (assistant_message.content or "").strip()
+        if reasoning:
+            agent.transport.emit(AgentEvent(EventType.THINKING, {"text": reasoning}))
+
+        assistant_msg: Dict[str, Any] = {
+            "role": "assistant",
+            "content": assistant_message.content or "",
+            "tool_calls": [
+                _serialize_tool_call(tc, logger=agent.llm.logger)
+                for tc in clean_tool_calls
+            ],
+        }
+        _attach_reasoning(assistant_msg, reasoning_content)
+
+        msg_sanitized = sanitize_assistant_message(assistant_msg)
+        if tcs_changed or msg_sanitized:
+            agent.llm.logger.warning(
+                "Sanitised lone surrogates in outbound assistant "
+                "message (iteration %d)",
+                iteration,
+            )
+        agent.messages.append(assistant_msg)
+
+        doom_triggered, tool_results = agent.tool_runner.execute(
+            clean_tool_calls,
+            cancellation_token=token,
+        )
+        agent.messages.extend(tool_results)
+        # Turn-level telemetry: count tool calls the LLM made this
+        # iteration; run_turn reset this to 0 and TURN_END reports the total.
+        agent._turn_tool_count = (
+            getattr(agent, "_turn_tool_count", 0) + len(clean_tool_calls)
+        )
+        if doom_triggered:
+            doom_content = (assistant_msg.get("content") or "").strip()
+            assistant_content_doom = (
+                doom_content
+                or "Tool execution halted by doom-loop detection."
+            )
+            final_msg_doom: Dict[str, Any] = {
+                "role": "assistant",
+                "content": assistant_content_doom,
+            }
+            _attach_reasoning(final_msg_doom, reasoning_content)
+            if sanitize_assistant_message(final_msg_doom):
+                agent.llm.logger.warning(
+                    "Sanitised lone surrogates in doom-loop assistant message"
                 )
+            # ToolRunner's doom counter is NOT reset across a Stop-hook
+            # force_continue — re-tripping doom is a reasonable outcome of
+            # "host insisted on continuing despite the model misbehaving."
+            return self._resolve_stop_hook(
+                turn_end_reason="doom_loop",
+                assistant_content=assistant_content_doom,
+                final_msg=final_msg_doom,
+                system_prompt=system_prompt,
+            )
+        if token.is_cancelled:
+            raise AgentCancelledError(token.reason)
 
-                if stop_result.blocking_error:
-                    blocked = f"[Blocked by Stop hook] {stop_result.blocking_error}"
-                    final_msg["content"] = blocked
-                    agent.messages.append(final_msg)
-                    self._emit_stop_hook_fired(
-                        outcome="block",
-                        turn_end_reason="final_response",
-                        stop_result=stop_result,
-                    )
-                    return blocked
+        new_active_skills = frozenset(agent.skill_manager.get_active_skills().keys())
+        new_memory_version = agent.memory_manager.write_version
+        if (
+            new_active_skills != active_skills
+            or new_memory_version != memory_version
+        ):
+            self._emit_skill_and_memory_diffs(
+                prev_active=active_skills,
+                new_active=new_active_skills,
+                prev_memory_version=memory_version,
+                new_memory_version=new_memory_version,
+            )
+            active_skills = new_active_skills
+            memory_version = new_memory_version
+            system_prompt = agent._build_system_prompt()
+        messages_with_system = [
+            {"role": "system", "content": system_prompt}
+        ] + agent.messages
+        return ChatLoopRunner._Step(
+            "loop",
+            messages_with_system=messages_with_system,
+            system_prompt=system_prompt,
+            active_skills=active_skills,
+            memory_version=memory_version,
+        )
 
-                if stop_result.force_continue:
-                    follow_up = (
-                        stop_result.follow_up_message
-                        or stop_result.stop_reason
-                        or "Stop hook requested continuation"
-                    )
-                    if self._stop_reentries >= self._stop_reentry_cap:
-                        agent.llm.logger.warning(
-                            "Stop hook reentry cap (%d) hit; ending turn.",
-                            self._stop_reentry_cap,
-                        )
-                        agent.messages.append(final_msg)
-                        self._emit_stop_hook_fired(
-                            outcome="reentry_capped",
-                            turn_end_reason="final_response",
-                            stop_result=stop_result,
-                        )
-                        return assistant_content
-                    self._stop_reentries += 1
-                    # Preserve the answer being continued from.
-                    agent.messages.append(final_msg)
-                    agent.messages.append({
-                        "role": "user",
-                        "content": (
-                            "<system-reminder>Stop hook injected this</system-reminder>\n"
-                            f"{follow_up}"
-                        ),
-                    })
-                    messages_with_system = [
-                        {"role": "system", "content": system_prompt}
-                    ] + agent.messages
-                    iteration = 0  # honest budget reset for the new sub-turn
-                    self._emit_stop_hook_fired(
-                        outcome="continue",
-                        turn_end_reason="final_response",
-                        stop_result=stop_result,
-                    )
-                    continue
+    def _handle_final_response(
+        self,
+        *,
+        assistant_message,
+        iteration: int,
+        system_prompt: str,
+    ) -> "ChatLoopRunner._Step":
+        """Finalize a turn that ended without tool calls."""
+        agent = self._agent
+        agent.llm.logger.info(f"Reached final response in iteration {iteration}")
+        reasoning_content = getattr(assistant_message, "reasoning_content", None)
+        assistant_content = assistant_message.content or ""
+        if not assistant_content.strip():
+            # Some models (byte-level reasoning backends — Kimi, GLM,
+            # Qwen-via-Ollama) end a turn with empty/whitespace content and
+            # no tool calls. Persisting "" leaves a contentless assistant
+            # message that strict API proxies reject on the next turn.
+            # Substitute a neutral marker.
+            assistant_content = (
+                "[No text response]"
+                if reasoning_content
+                else "[No response]"
+            )
+            agent.llm.logger.warning(
+                "Empty final assistant content in iteration %d; "
+                "substituted placeholder to keep history valid",
+                iteration,
+            )
+        final_msg: Dict[str, Any] = {"role": "assistant", "content": assistant_content}
+        _attach_reasoning(final_msg, reasoning_content)
+        if sanitize_assistant_message(final_msg):
+            agent.llm.logger.warning(
+                "Sanitised lone surrogates in final assistant message "
+                "(iteration %d)", iteration,
+            )
+        return self._resolve_stop_hook(
+            turn_end_reason="final_response",
+            assistant_content=assistant_content,
+            final_msg=final_msg,
+            system_prompt=system_prompt,
+        )
 
-                # additional_contexts ride on the answer as a
-                # ``<stop-hook>`` block unless the hook set
-                # ``suppressOutput: true`` (Agentao extension to the
-                # Claude semantic, which documents only stdout suppression).
-                if (
-                    stop_result.additional_contexts
-                    and not stop_result.suppress_output
-                ):
-                    extra = "\n".join(
-                        f"<stop-hook>\n{ctx}\n</stop-hook>"
-                        for ctx in stop_result.additional_contexts
-                    )
-                    final_msg["content"] = f"{assistant_content}\n{extra}"
-                    assistant_content = final_msg["content"]
+    def _resolve_stop_hook(
+        self,
+        *,
+        turn_end_reason: str,
+        assistant_content: str,
+        final_msg: Dict[str, Any],
+        system_prompt: str,
+    ) -> "ChatLoopRunner._Step":
+        """Dispatch the Stop hook and translate its verdict into a step.
+
+        Shared by all three turn-ending sites (max-iterations, doom-loop,
+        final-response); per-site differences live in ``_STOP_SITES``.
+        ``final_msg`` is appended to history here (after a possible
+        ``blocking_error`` / ``additional_contexts`` rewrite) so the
+        original answer never leaks into history on a block.
+        """
+        agent = self._agent
+        site = self._STOP_SITES[turn_end_reason]
+        stop_result = self._dispatch_stop(
+            turn_end_reason=turn_end_reason,
+            last_assistant_message=assistant_content,
+        )
+
+        if stop_result.blocking_error:
+            blocked = f"[Blocked by Stop hook] {stop_result.blocking_error}"
+            final_msg["content"] = blocked
+            agent.messages.append(final_msg)
+            self._emit_stop_hook_fired(
+                outcome="block",
+                turn_end_reason=turn_end_reason,
+                stop_result=stop_result,
+            )
+            return ChatLoopRunner._Step("return", value=blocked)
+
+        if stop_result.force_continue:
+            # Cap check FIRST — without it a cap-hit would fall through to
+            # allow and silently mask the pathological hook.
+            if self._stop_reentries >= self._stop_reentry_cap:
+                agent.llm.logger.warning(site["reentry_cap_log"], self._stop_reentry_cap)
                 agent.messages.append(final_msg)
                 self._emit_stop_hook_fired(
-                    outcome="allow",
-                    turn_end_reason="final_response",
+                    outcome="reentry_capped",
+                    turn_end_reason=turn_end_reason,
                     stop_result=stop_result,
                 )
-                return assistant_content
+                return ChatLoopRunner._Step("return", value=assistant_content)
+            follow_up = (
+                stop_result.follow_up_message
+                or stop_result.stop_reason
+                or "Stop hook requested continuation"
+            )
+            self._stop_reentries += 1
+            if site["force_continue_log"]:
+                agent.llm.logger.warning(site["force_continue_log"])
+            agent.messages.append(final_msg)
+            agent.messages.append({
+                "role": "user",
+                "content": (
+                    "<system-reminder>Stop hook injected this</system-reminder>\n"
+                    f"{follow_up}"
+                ),
+            })
+            messages_with_system = [
+                {"role": "system", "content": system_prompt}
+            ] + agent.messages
+            self._emit_stop_hook_fired(
+                outcome=site["force_continue_outcome"],
+                turn_end_reason=turn_end_reason,
+                stop_result=stop_result,
+            )
+            return ChatLoopRunner._Step(
+                "continue",
+                messages_with_system=messages_with_system,
+                system_prompt=system_prompt,
+            )
+
+        # allow: additional_contexts ride on the answer as a ``<stop-hook>``
+        # block unless the hook set ``suppressOutput: true`` (Agentao
+        # extension to the Claude semantic, which documents only stdout
+        # suppression). Only final-response echoes them — decorating a
+        # max-iter / doom-loop fallback string would be unhelpful UX.
+        if (
+            site["echo_additional_contexts"]
+            and stop_result.additional_contexts
+            and not stop_result.suppress_output
+        ):
+            extra = "\n".join(
+                f"<stop-hook>\n{ctx}\n</stop-hook>"
+                for ctx in stop_result.additional_contexts
+            )
+            final_msg["content"] = f"{assistant_content}\n{extra}"
+            assistant_content = final_msg["content"]
+        agent.messages.append(final_msg)
+        self._emit_stop_hook_fired(
+            outcome="allow",
+            turn_end_reason=turn_end_reason,
+            stop_result=stop_result,
+        )
+        return ChatLoopRunner._Step("return", value=assistant_content)
 
     # ------------------------------------------------------------------
     # Plugin-hook dispatch

--- a/tests/cli/test_slash_completer.py
+++ b/tests/cli/test_slash_completer.py
@@ -1,0 +1,138 @@
+"""Tests for ``_SlashCompleter`` — draft-preservation behavior.
+
+Covers the two papercuts that motivated the rewrite:
+
+1. Exact-match arg hint must not insert placeholder text into the buffer
+   (would clobber any draft tail after the cursor).
+2. Prefix completion of arg-taking commands must add a trailing space so
+   ``/ageplease refactor`` completes to ``/agent please refactor``
+   instead of the broken ``/agentplease refactor``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+prompt_toolkit = pytest.importorskip("prompt_toolkit")
+from prompt_toolkit.document import Document  # noqa: E402
+
+from agentao.cli._utils import _SlashCompleter  # noqa: E402
+
+
+def _complete(buffer: str, cursor: int | None = None) -> list:
+    """Run the completer against ``buffer`` with cursor at ``cursor`` (default: end)."""
+    if cursor is None:
+        cursor = len(buffer)
+    doc = Document(text=buffer, cursor_position=cursor)
+    return list(_SlashCompleter().get_completions(doc, complete_event=None))
+
+
+def _texts(completions) -> list[str]:
+    return [c.text for c in completions]
+
+
+# ---------------------------------------------------------------------------
+# Bug 1: exact match yields display-only hint, never inserts placeholder text.
+# ---------------------------------------------------------------------------
+
+
+def test_exact_match_arg_command_yields_display_only_hint():
+    completions = _complete("/agent bg")
+    assert len(completions) == 1
+    c = completions[0]
+    assert c.text == ""               # nothing inserted
+    assert c.start_position == 0
+    assert c.display_meta_text == "arg"
+    # ``display`` is FormattedText-like; flatten via ``.display`` raw access.
+    display = c.display if isinstance(c.display, str) else "".join(
+        seg[1] for seg in c.display
+    )
+    assert display == "<agent-name> <task>"
+
+
+def test_exact_match_with_draft_tail_does_not_clobber_buffer():
+    """Cursor in middle of buffer, before-cursor exact-matches a hint command."""
+    buffer = "/crystallize feedback please refactor X across the codebase"
+    cursor = len("/crystallize feedback")
+    completions = _complete(buffer, cursor=cursor)
+    assert len(completions) == 1
+    c = completions[0]
+    # If accepted, replaces 0 chars with '' — buffer stays exactly as-is.
+    assert c.text == ""
+    assert c.start_position == 0
+
+
+# ---------------------------------------------------------------------------
+# Bug 2: prefix completion of arg-taking command appends trailing space
+#        unless cursor is already followed by whitespace.
+# ---------------------------------------------------------------------------
+
+
+def test_prefix_completion_arg_command_appends_trailing_space():
+    completions = _complete("/age")
+    texts = _texts(completions)
+    # Both ``/agent`` (no hint → no space) and arg-taking subcommands appear.
+    assert "/agent" in texts                        # /agent itself takes no arg
+    assert "/agent bg " in texts                    # /agent bg takes args → space
+    assert "/agent cancel " in texts                # /agent cancel takes args
+
+
+def test_prefix_completion_non_arg_command_no_trailing_space():
+    completions = _complete("/cle")
+    texts = _texts(completions)
+    assert "/clear" in texts
+    assert "/clear " not in texts                   # no args → no trailing space
+
+
+def test_prefix_completion_preserves_draft_tail():
+    """The classic ``/ageplease refactor`` → ``/agent please refactor`` case.
+
+    Buffer is ``/ageplease refactor`` with cursor at position 4 (after ``/age``).
+    Completion should insert ``/agent `` (with trailing space) and replace
+    the 4 chars before the cursor — leaving ``please refactor`` untouched.
+    """
+    buffer = "/ageplease refactor"
+    cursor = 4                                      # right after ``/age``
+    completions = _complete(buffer, cursor=cursor)
+    texts = _texts(completions)
+    # /agent bg / cancel / delete / status are the arg-taking ones — all should
+    # have a trailing space because text_after = "please refactor" (no leading WS).
+    arg_taking = [t for t in texts if t in {
+        "/agent bg ", "/agent cancel ", "/agent delete ", "/agent status ",
+    }]
+    assert arg_taking, f"expected arg-taking subcommands with trailing space, got {texts}"
+
+
+def test_prefix_completion_skips_trailing_space_if_already_whitespace_after_cursor():
+    """If user already typed the space, don't double it up.
+
+    Buffer ``/age please refactor`` with cursor after ``/age`` (position 4).
+    text_after starts with a space, so the completer should NOT add another.
+    """
+    buffer = "/age please refactor"
+    cursor = 4
+    completions = _complete(buffer, cursor=cursor)
+    texts = _texts(completions)
+    # Arg-taking subcommands should now appear WITHOUT trailing space.
+    assert "/agent bg" in texts
+    assert "/agent bg " not in texts
+    assert "/agent cancel" in texts
+    assert "/agent cancel " not in texts
+
+
+# ---------------------------------------------------------------------------
+# Negative cases.
+# ---------------------------------------------------------------------------
+
+
+def test_non_slash_input_yields_nothing():
+    assert _complete("hello world") == []
+    assert _complete("") == []
+
+
+def test_command_without_hint_completes_plainly():
+    """``/help`` is not in _SLASH_COMMAND_HINTS — no trailing space."""
+    completions = _complete("/hel")
+    texts = _texts(completions)
+    assert "/help" in texts
+    assert "/help " not in texts


### PR DESCRIPTION
## Summary

Split the two longest methods in the runtime into focused helpers. Pure structural refactor — **behavior preserved** (full suite: 2692 passed, 2 skipped, matching baseline).

### `runtime/chat_loop/_runner.py` — `ChatLoopRunner.run()`
- Collapsed the 432-line `while True` loop body into a ~95-line orchestrator.
- Extracted `_handle_iteration_cap` / `_handle_tool_calls` / `_handle_final_response` / `_resolve_stop_hook`.
- The Stop-hook handling that was **triplicated** across max-iterations / doom-loop / final-response is now unified in `_resolve_stop_hook`, with per-site differences in a `_STOP_SITES` table.
- Branch helpers communicate back via a small `_Step` decision object (mirrors the existing `_LlmOutcome` pattern in the same file).

### `agent.py` — `Agentao.__init__`
- Lifted the linear subsystem wiring out of the constructor (270 → ~135 lines) into `_resolve_llm_client` / `_resolve_transport` / `_init_skill_and_memory` / `_init_host_emitters`.
- **Public constructor signature unchanged** (host contract preserved).
- `DeprecationWarning` `stacklevel` bumped to 3 for the added call frame so warnings still point at the host caller.

## Verification
- Full default suite: **2692 passed, 2 skipped, 9 deselected** (unchanged from baseline), run multiple times.
- `/code-review --fix` (high effort, 7 angles): one cleanup applied (removed an unused `stacklevel` knob), no correctness findings.
- `/codex:review`: no comments — "behavior-preserving refactors … no discrete regressions."

🤖 Generated with [Claude Code](https://claude.com/claude-code)