### PR TITLE
fix(llm): repair NameError in chat_stream after #50/#51 semantic merge

### DIFF
--- a/agentao/llm/client.py
+++ b/agentao/llm/client.py
@@ -601,7 +601,7 @@ class LLMClient:
                 # temperature unsupported — one-shot fix-up. Only safe at zero
                 # progress (otherwise the retry would re-emit content).
                 if (
-                    not progress_made
+                    not acc.progress_made
                     and not self.omit_temperature
                     and _is_temperature_unsupported(err_str)
                 ):


### PR DESCRIPTION
## Problem

`main` (at \`a09b503\`) is **broken on all Python versions** — `tests/test_llm_client_retry.py::TestChatStreamRetry` fails with `NameError: name 'progress_made' is not defined`.

Root cause is a **semantic merge conflict** between two PRs that were both green in isolation:

- **#50** (`feat(llm): omit temperature for models that reject it`) added a temperature-unsupported fix-up block to `chat_stream()` guarded on the local `progress_made`.
- **#51** (the `chat_stream` refactor) moved progress tracking onto `_StreamAccumulator` (`acc.progress_made`) and removed the `progress_made` local.

Git text-merged both cleanly; the combined code references a name that no longer exists. CI caught it (#51 merged while `UNSTABLE`).

## Fix

One line: point the temperature fix-up at `acc.progress_made`, matching the sibling `max_completion_tokens` fix-up directly above it.

## Verification

- No bare `progress_made` remains (all refs `acc.`-prefixed).
- Full suite serial: **2706 passed, 2 skipped** (the 14 added since the last run are #50's temperature tests, now passing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)