### PR TITLE
feat(ask_user): structured options/header/multiple/allow_custom (PR-2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,7 +59,8 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   letting the user type a custom answer. The hints flow through the
   `Transport.ask_user` contract to every transport: the CLI renders a
   numbered menu and accepts a number, comma-separated numbers (when
-  `multiple`), or custom text; the ACP transport forwards them on
+  `multiple`), or custom text — re-prompting when `allow_custom` is false
+  and the entry isn't one of the options; the ACP transport forwards them on
   `_agentao.cn/ask_user` (host-agnostic plain-string options, not
   option-cards) and the host ACP schema's `AcpAskUserParams` gains the
   matching fields (snapshot `docs/schema/host.acp.v1.json` bumped); the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   host path or smuggling a secret.
   Saving a session whose first user message is image+text now derives its
   title from the text part instead of persisting an empty title.
+- **Structured `ask_user`.** The `ask_user` tool now accepts optional
+  `header` / `options` / `multiple` / `allow_custom` hints alongside the
+  free-form `question`, so the model can offer a choice list while still
+  letting the user type a custom answer. The hints flow through the
+  `Transport.ask_user` contract to every transport: the CLI renders a
+  numbered menu and accepts a number, comma-separated numbers (when
+  `multiple`), or custom text; the ACP transport forwards them on
+  `_agentao.cn/ask_user` (host-agnostic plain-string options, not
+  option-cards) and the host ACP schema's `AcpAskUserParams` gains the
+  matching fields (snapshot `docs/schema/host.acp.v1.json` bumped); the
+  replay recorder captures them. The reply stays a single string (a client
+  joins `multiple` selections itself). Backward-compatible: a plain
+  `ask_user(question)` keeps its original wire/recording shape, and legacy
+  1-arg `Callable[[str], str]` callbacks (the deprecated `ask_user_callback`
+  constructor arg, or an `SdkTransport(ask_user=...)` callback) keep working
+  — the structured kwargs are forwarded only to callbacks whose signature
+  accepts them, dropped otherwise.
 
 ## [0.4.7] — 2026-05-17
 

--- a/agentao/acp/schema.py
+++ b/agentao/acp/schema.py
@@ -571,8 +571,21 @@ class AcpRequestPermissionResponse(BaseModel):
 
 
 class AcpAskUserParams(BaseModel):
+    """Params the agent sends to the client for ``_agentao.cn/ask_user``.
+
+    ``question`` is always present. The remaining fields are optional
+    structured hints a client may render as a choice prompt; a client may
+    ignore them and prompt with plain text. The reply is always a single
+    ``text`` string (see :class:`AcpAskUserAnswered`) — for ``multiple``
+    selections the client joins them itself.
+    """
+
     sessionId: str
     question: str
+    header: Optional[str] = None
+    options: Optional[List[str]] = None
+    multiple: bool = False
+    allowCustom: bool = True
 
     model_config = ConfigDict(extra="forbid")
 

--- a/agentao/acp/transport.py
+++ b/agentao/acp/transport.py
@@ -825,13 +825,27 @@ class ACPTransport:
         )
         return False
 
-    def ask_user(self, question: str) -> str:
-        """Ask the ACP client for free-form user input via ``_agentao.cn/ask_user``.
+    def ask_user(
+        self,
+        question: str,
+        *,
+        header: Optional[str] = None,
+        options: Optional[List[str]] = None,
+        multiple: bool = False,
+        allow_custom: bool = True,
+    ) -> str:
+        """Ask the ACP client for user input via ``_agentao.cn/ask_user``.
 
         Sends the extension method as a JSON-RPC request and blocks until
         the client responds.  All failure modes resolve to the sentinel
         string ``"(user unavailable)"`` rather than raising, so a broken
         ask_user path cannot crash a turn in progress.
+
+        The optional structured hints (``header`` / ``options`` /
+        ``multiple`` / ``allow_custom``) are forwarded on the wire; a
+        client may ignore them and prompt with plain text. The reply is
+        always a single ``text`` string (the client joins ``multiple``
+        selections itself).
 
         Returns:
             The user's text answer, or the sentinel on any failure.
@@ -843,10 +857,20 @@ class ACPTransport:
             )
             return ASK_USER_UNAVAILABLE_SENTINEL
 
-        params = {
+        params: Dict[str, Any] = {
             "sessionId": self._session_id,
             "question": question,
         }
+        # Only include structured fields when they carry information, so a
+        # plain ask_user call keeps the same minimal wire shape as before.
+        if header is not None:
+            params["header"] = header
+        if options is not None:
+            params["options"] = options
+        if multiple:
+            params["multiple"] = True
+        if not allow_custom:
+            params["allowCustom"] = False
 
         try:
             pending = self._server.call(METHOD_ASK_USER, params)

--- a/agentao/cli/app.py
+++ b/agentao/cli/app.py
@@ -214,9 +214,24 @@ class AgentaoCLI:
         from .transport import on_llm_text
         on_llm_text(self, chunk)
 
-    def ask_user(self, question: str) -> str:
+    def ask_user(
+        self,
+        question: str,
+        *,
+        header=None,
+        options=None,
+        multiple: bool = False,
+        allow_custom: bool = True,
+    ) -> str:
         from .transport import ask_user
-        return ask_user(self, question)
+        return ask_user(
+            self,
+            question,
+            header=header,
+            options=options,
+            multiple=multiple,
+            allow_custom=allow_custom,
+        )
 
     # ── Session lifecycle delegation ────────────────────────────────────
 

--- a/agentao/cli/transport.py
+++ b/agentao/cli/transport.py
@@ -184,15 +184,65 @@ def on_llm_text(cli: AgentaoCLI, chunk: str) -> None:
     sys.stdout.flush()
 
 
-def ask_user(cli: AgentaoCLI, question: str) -> str:
-    """Pause spinner, display question, read free-form user response."""
+def _resolve_option_selection(
+    response: str, options: list[str], multiple: bool
+) -> str | None:
+    """Map a numeric (or comma-separated numeric) response to option text.
+
+    Returns the resolved answer (option labels joined by ``", "``), or
+    ``None`` when the response is not a clean selection so the caller can
+    fall back to treating it as a custom free-form answer.
+    """
+    tokens = [t.strip() for t in response.split(",") if t.strip()]
+    if not tokens:
+        return None
+    if not multiple and len(tokens) > 1:
+        return None
+    selected: list[str] = []
+    for tok in tokens:
+        if not tok.isdigit():
+            return None
+        idx = int(tok)
+        if not 1 <= idx <= len(options):
+            return None
+        selected.append(options[idx - 1])
+    return ", ".join(selected)
+
+
+def ask_user(
+    cli: AgentaoCLI,
+    question: str,
+    *,
+    header: str | None = None,
+    options: list[str] | None = None,
+    multiple: bool = False,
+    allow_custom: bool = True,
+) -> str:
+    """Pause spinner, display question (with optional choices), read response."""
     if cli.current_status:
         cli.current_status.stop()
     try:
-        console.print(f"\n[bold yellow]🤔 Agent Question[/bold yellow]")
+        title = header.strip() if header and header.strip() else "Agent Question"
+        console.print(f"\n[bold yellow]🤔 {title}[/bold yellow]")
         console.print(f"[yellow]{question}[/yellow]")
+        if options:
+            for i, opt in enumerate(options, 1):
+                console.print(f"  [green]{i}[/green]. {opt}")
+            if multiple:
+                hint = "comma-separated numbers to select multiple"
+            else:
+                hint = "a number to select"
+            if allow_custom:
+                hint += ", or type a custom answer"
+            console.print(f"[dim]Enter {hint}.[/dim]")
         response = console.input("[bold yellow]▶ [/bold yellow]").strip()
-        return response if response else "(no response)"
+        if not response:
+            return "(no response)"
+        if options:
+            resolved = _resolve_option_selection(response, options, multiple)
+            if resolved is not None:
+                return resolved
+        return response
     except (EOFError, KeyboardInterrupt):
         return "(user interrupted)"
     finally:

--- a/agentao/cli/transport.py
+++ b/agentao/cli/transport.py
@@ -235,14 +235,25 @@ def ask_user(
             if allow_custom:
                 hint += ", or type a custom answer"
             console.print(f"[dim]Enter {hint}.[/dim]")
-        response = console.input("[bold yellow]▶ [/bold yellow]").strip()
-        if not response:
-            return "(no response)"
-        if options:
-            resolved = _resolve_option_selection(response, options, multiple)
-            if resolved is not None:
-                return resolved
-        return response
+        # When options are listed and custom answers are disallowed, the
+        # response must resolve to one of them — re-prompt otherwise.
+        # EOF / Ctrl-C still break out via the surrounding except.
+        restricted = bool(options) and not allow_custom
+        while True:
+            response = console.input("[bold yellow]▶ [/bold yellow]").strip()
+            if not response:
+                if restricted:
+                    console.print("[dim]Please choose from the listed options.[/dim]")
+                    continue
+                return "(no response)"
+            if options:
+                resolved = _resolve_option_selection(response, options, multiple)
+                if resolved is not None:
+                    return resolved
+                if restricted:
+                    console.print("[dim]Please choose from the listed options by number.[/dim]")
+                    continue
+            return response
     except (EOFError, KeyboardInterrupt):
         return "(user interrupted)"
     finally:

--- a/agentao/replay/adapter.py
+++ b/agentao/replay/adapter.py
@@ -141,28 +141,60 @@ class ReplayAdapter:
             pass
         return bool(result)
 
-    def ask_user(self, question: str) -> str:
+    def ask_user(
+        self,
+        question: str,
+        *,
+        header=None,
+        options=None,
+        multiple: bool = False,
+        allow_custom: bool = True,
+    ) -> str:
         # v1.1: record both the question and the answer. The answer goes
         # through the scanner + a 500-char truncation policy inside
         # ``sanitize_event`` so an accidental password-in-prompt is
         # redacted on disk.
+        req_payload = {"question": question or ""}
+        # Record structured hints only when present, mirroring the lean
+        # wire shape so a plain ask_user keeps its original payload.
+        if header is not None:
+            req_payload["header"] = header
+        if options is not None:
+            req_payload["options"] = options
+        if multiple:
+            req_payload["multiple"] = True
+        if not allow_custom:
+            req_payload["allow_custom"] = False
         try:
             self._recorder.record(
                 EventKind.ASK_USER_REQUESTED,
                 turn_id=self._current_turn_id(),
                 parent_turn_id=self._current_parent_turn(),
-                payload={"question": question or ""},
+                payload=req_payload,
             )
         except Exception:
             pass
-        answer = self._inner.ask_user(question)
+        # Forward only the structured kwargs that carry information, so a
+        # plain ask_user stays a 1-arg call into the wrapped transport
+        # (preserving compatibility with transports that accept only the
+        # question).
+        fwd: Dict[str, Any] = {}
+        if header is not None:
+            fwd["header"] = header
+        if options is not None:
+            fwd["options"] = options
+        if multiple:
+            fwd["multiple"] = True
+        if not allow_custom:
+            fwd["allow_custom"] = False
+        answer = self._inner.ask_user(question, **fwd)
         try:
             self._recorder.record(
                 EventKind.ASK_USER_ANSWERED,
                 turn_id=self._current_turn_id(),
                 parent_turn_id=self._current_parent_turn(),
                 payload={
-                    "question": question or "",
+                    **req_payload,
                     "answer": answer if isinstance(answer, str) else str(answer),
                 },
             )

--- a/agentao/replay/adapter.py
+++ b/agentao/replay/adapter.py
@@ -156,10 +156,10 @@ class ReplayAdapter:
         # redacted on disk.
         #
         # ``fwd`` holds only the structured kwargs that carry information,
-        # so a plain ask_user stays a 1-arg call into the wrapped transport
-        # (some inner transports accept only the question). The recorded
-        # payload reuses the same set — keeping a plain ask_user's original
-        # ``{"question": ...}`` shape — plus the question itself.
+        # keeping a plain ask_user's recorded payload at its original
+        # ``{"question": ...}`` shape (plus the question itself).
+        from ..transport.sdk import invoke_ask_user_callback
+
         fwd: Dict[str, Any] = {}
         if header is not None:
             fwd["header"] = header
@@ -179,7 +179,20 @@ class ReplayAdapter:
             )
         except Exception:
             pass
-        answer = self._inner.ask_user(question, **fwd)
+        # Forward via signature-aware dispatch so a legacy 1-arg
+        # ``ask_user(self, question)`` inner transport still works even for a
+        # structured prompt (it receives the question alone) instead of
+        # raising ``TypeError`` on the unexpected keywords.
+        answer = invoke_ask_user_callback(
+            self._inner.ask_user,
+            question,
+            {
+                "header": header,
+                "options": options,
+                "multiple": multiple,
+                "allow_custom": allow_custom,
+            },
+        )
         try:
             self._recorder.record(
                 EventKind.ASK_USER_ANSWERED,

--- a/agentao/replay/adapter.py
+++ b/agentao/replay/adapter.py
@@ -154,30 +154,12 @@ class ReplayAdapter:
         # through the scanner + a 500-char truncation policy inside
         # ``sanitize_event`` so an accidental password-in-prompt is
         # redacted on disk.
-        req_payload = {"question": question or ""}
-        # Record structured hints only when present, mirroring the lean
-        # wire shape so a plain ask_user keeps its original payload.
-        if header is not None:
-            req_payload["header"] = header
-        if options is not None:
-            req_payload["options"] = options
-        if multiple:
-            req_payload["multiple"] = True
-        if not allow_custom:
-            req_payload["allow_custom"] = False
-        try:
-            self._recorder.record(
-                EventKind.ASK_USER_REQUESTED,
-                turn_id=self._current_turn_id(),
-                parent_turn_id=self._current_parent_turn(),
-                payload=req_payload,
-            )
-        except Exception:
-            pass
-        # Forward only the structured kwargs that carry information, so a
-        # plain ask_user stays a 1-arg call into the wrapped transport
-        # (preserving compatibility with transports that accept only the
-        # question).
+        #
+        # ``fwd`` holds only the structured kwargs that carry information,
+        # so a plain ask_user stays a 1-arg call into the wrapped transport
+        # (some inner transports accept only the question). The recorded
+        # payload reuses the same set — keeping a plain ask_user's original
+        # ``{"question": ...}`` shape — plus the question itself.
         fwd: Dict[str, Any] = {}
         if header is not None:
             fwd["header"] = header
@@ -187,6 +169,16 @@ class ReplayAdapter:
             fwd["multiple"] = True
         if not allow_custom:
             fwd["allow_custom"] = False
+        req_payload = {"question": question or "", **fwd}
+        try:
+            self._recorder.record(
+                EventKind.ASK_USER_REQUESTED,
+                turn_id=self._current_turn_id(),
+                parent_turn_id=self._current_parent_turn(),
+                payload=req_payload,
+            )
+        except Exception:
+            pass
         answer = self._inner.ask_user(question, **fwd)
         try:
             self._recorder.record(

--- a/agentao/tools/ask_user.py
+++ b/agentao/tools/ask_user.py
@@ -1,18 +1,26 @@
 """Ask user tool for interactive clarification during LLM task execution."""
 
-from typing import Callable, Optional
+from typing import Callable, List, Optional
 
 from .base import Tool
 
 
 class AskUserTool(Tool):
-    """Tool that allows the LLM to ask the user a clarifying question."""
+    """Tool that allows the LLM to ask the user a clarifying question.
+
+    The question may be plain free-form text, or it may carry optional
+    structured hints (``header`` / ``options`` / ``multiple`` /
+    ``allow_custom``) that richer transports can render as a choice
+    prompt. The structured fields are advisory: a transport is free to
+    ignore them and fall back to a plain text prompt, and the answer is
+    always returned as a single string.
+    """
 
     @property
     def is_read_only(self) -> bool:
         return True
 
-    def __init__(self, ask_user_callback: Optional[Callable[[str], str]] = None):
+    def __init__(self, ask_user_callback: Optional[Callable[..., str]] = None):
         self._callback = ask_user_callback
 
     @property
@@ -22,9 +30,11 @@ class AskUserTool(Tool):
     @property
     def description(self) -> str:
         return (
-            "Ask the user a clarifying question and wait for their text response. "
+            "Ask the user a clarifying question and wait for their response. "
             "Use when you need missing information to proceed, or to confirm ambiguous requirements. "
-            "Do NOT use for yes/no confirmations — only use when free-form user input is needed."
+            "Do NOT use for yes/no confirmations — only use when free-form user input is needed. "
+            "Optionally pass `options` to suggest choices (set `multiple` to allow more than one, "
+            "and `allow_custom=false` to restrict the answer to the listed options)."
         )
 
     @property
@@ -36,6 +46,29 @@ class AskUserTool(Tool):
                     "type": "string",
                     "description": "The question to ask the user",
                 },
+                "header": {
+                    "type": "string",
+                    "description": "Optional short label (a few words) categorizing the question.",
+                },
+                "options": {
+                    "type": "array",
+                    "items": {"type": "string"},
+                    "description": (
+                        "Optional list of suggested answers to present as choices. "
+                        "The user may still type a custom answer unless allow_custom is false."
+                    ),
+                },
+                "multiple": {
+                    "type": "boolean",
+                    "description": "Whether the user may select more than one option. Default false.",
+                },
+                "allow_custom": {
+                    "type": "boolean",
+                    "description": (
+                        "Whether the user may type a free-form answer in addition to any options. "
+                        "Default true."
+                    ),
+                },
             },
             "required": ["question"],
         }
@@ -44,7 +77,20 @@ class AskUserTool(Tool):
     def requires_confirmation(self) -> bool:
         return False
 
-    def execute(self, question: str) -> str:
+    def execute(
+        self,
+        question: str,
+        header: Optional[str] = None,
+        options: Optional[List[str]] = None,
+        multiple: bool = False,
+        allow_custom: bool = True,
+    ) -> str:
         if self._callback:
-            return self._callback(question)
+            return self._callback(
+                question,
+                header=header,
+                options=options,
+                multiple=multiple,
+                allow_custom=allow_custom,
+            )
         return "[ask_user: not available in non-interactive mode]"

--- a/agentao/tools/ask_user.py
+++ b/agentao/tools/ask_user.py
@@ -86,11 +86,19 @@ class AskUserTool(Tool):
         allow_custom: bool = True,
     ) -> str:
         if self._callback:
-            return self._callback(
+            # Forward the structured hints only to callbacks that accept
+            # them, so a legacy 1-arg ``AskUserTool(lambda q: ...)`` keeps
+            # working instead of raising ``TypeError`` on the new kwargs.
+            from ..transport.sdk import invoke_ask_user_callback
+
+            return invoke_ask_user_callback(
+                self._callback,
                 question,
-                header=header,
-                options=options,
-                multiple=multiple,
-                allow_custom=allow_custom,
+                {
+                    "header": header,
+                    "options": options,
+                    "multiple": multiple,
+                    "allow_custom": allow_custom,
+                },
             )
         return "[ask_user: not available in non-interactive mode]"

--- a/agentao/transport/base.py
+++ b/agentao/transport/base.py
@@ -1,6 +1,6 @@
 """Transport protocol — the single interface between Agentao runtime and UI/transport."""
 
-from typing import Callable, Protocol, runtime_checkable
+from typing import Callable, List, Optional, Protocol, runtime_checkable
 
 from .events import AgentEvent
 
@@ -68,8 +68,30 @@ class Transport(Protocol):
         """
         ...
 
-    def ask_user(self, question: str) -> str:
-        """Ask the user a free-form question and return their answer."""
+    def ask_user(
+        self,
+        question: str,
+        *,
+        header: Optional[str] = None,
+        options: Optional[List[str]] = None,
+        multiple: bool = False,
+        allow_custom: bool = True,
+    ) -> str:
+        """Ask the user a question and return their answer.
+
+        ``question`` is always free-form text. The keyword-only fields are
+        optional structured hints a transport may render as a choice
+        prompt:
+
+        - ``header`` — short label categorizing the question.
+        - ``options`` — suggested answers to present as choices.
+        - ``multiple`` — whether more than one option may be selected.
+        - ``allow_custom`` — whether a free-form answer is allowed in
+          addition to any options.
+
+        The structured fields are advisory; a transport may ignore them
+        and prompt with plain text. The answer is always a single string.
+        """
         ...
 
     def on_max_iterations(self, count: int, messages: list) -> dict:

--- a/agentao/transport/non_interactive.py
+++ b/agentao/transport/non_interactive.py
@@ -90,7 +90,15 @@ class NonInteractiveTransport(SdkTransport):
         self._cancel(f"permission_required: {tool_name}")
         return False
 
-    def ask_user(self, question: str) -> str:
+    def ask_user(
+        self,
+        question: str,
+        *,
+        header: Optional[str] = None,
+        options: Optional[List[str]] = None,
+        multiple: bool = False,
+        allow_custom: bool = True,
+    ) -> str:
         if self.rejection is None:
             self.rejection = {
                 "type": "interaction_required",

--- a/agentao/transport/null.py
+++ b/agentao/transport/null.py
@@ -1,6 +1,6 @@
 """NullTransport — silent default used when no transport is configured."""
 
-from typing import Callable
+from typing import Callable, List, Optional
 
 from .broadcast import EventBroadcaster
 from .events import AgentEvent
@@ -28,7 +28,15 @@ class NullTransport:
     def confirm_tool(self, tool_name: str, description: str, args: dict) -> bool:
         return True
 
-    def ask_user(self, question: str) -> str:
+    def ask_user(
+        self,
+        question: str,
+        *,
+        header: Optional[str] = None,
+        options: Optional[List[str]] = None,
+        multiple: bool = False,
+        allow_custom: bool = True,
+    ) -> str:
         return "[ask_user: not available in non-interactive mode]"
 
     def on_max_iterations(self, count: int, messages: list) -> dict:

--- a/agentao/transport/sdk.py
+++ b/agentao/transport/sdk.py
@@ -29,7 +29,18 @@ def _invoke_ask_user_callback(callback: Callable[..., str], question: str, struc
         return callback(question)
     if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()):
         return callback(question, **structured)
-    accepted = {k: v for k, v in structured.items() if k in params}
+    # Only forward a field the callback can actually accept *by keyword* —
+    # a positional-only parameter that happens to share a name would raise
+    # TypeError if passed as a keyword.
+    keyword_ok = {
+        inspect.Parameter.POSITIONAL_OR_KEYWORD,
+        inspect.Parameter.KEYWORD_ONLY,
+    }
+    accepted = {
+        k: v
+        for k, v in structured.items()
+        if k in params and params[k].kind in keyword_ok
+    }
     return callback(question, **accepted)
 
 

--- a/agentao/transport/sdk.py
+++ b/agentao/transport/sdk.py
@@ -4,12 +4,33 @@ Also provides ``build_compat_transport`` to wrap the legacy 8-callback
 API that existed before the Transport abstraction was introduced.
 """
 
+import inspect
 import warnings
 from typing import Any, Callable, Dict, List, Optional
 
 from .broadcast import EventBroadcaster
 from .events import AgentEvent, EventType
 from .null import NullTransport
+
+
+def _invoke_ask_user_callback(callback: Callable[..., str], question: str, structured: Dict[str, Any]) -> str:
+    """Call a user-supplied ``ask_user`` callback, forwarding structured
+    kwargs only when the callback can accept them.
+
+    This keeps legacy 1-arg ``Callable[[str], str]`` callbacks working: a
+    callback whose signature names none of the structured fields (and has
+    no ``**kwargs``) is called with the question alone, so the structured
+    hints are silently dropped rather than raising ``TypeError``.
+    """
+    try:
+        params = inspect.signature(callback).parameters
+    except (TypeError, ValueError):
+        # Un-introspectable callable (some builtins / C funcs) — assume legacy.
+        return callback(question)
+    if any(p.kind is inspect.Parameter.VAR_KEYWORD for p in params.values()):
+        return callback(question, **structured)
+    accepted = {k: v for k, v in structured.items() if k in params}
+    return callback(question, **accepted)
 
 
 class SdkTransport:
@@ -42,7 +63,7 @@ class SdkTransport:
         self,
         on_event: Optional[Callable[[AgentEvent], None]] = None,
         confirm_tool: Optional[Callable[[str, str, Dict[str, Any]], bool]] = None,
-        ask_user: Optional[Callable[[str], str]] = None,
+        ask_user: Optional[Callable[..., str]] = None,
         on_max_iterations: Optional[Callable[[int, List], dict]] = None,
     ) -> None:
         self._on_event = on_event
@@ -69,9 +90,26 @@ class SdkTransport:
             return self._confirm_tool(tool_name, description, args)
         return True  # auto-approve when no callback
 
-    def ask_user(self, question: str) -> str:
+    def ask_user(
+        self,
+        question: str,
+        *,
+        header: Optional[str] = None,
+        options: Optional[List[str]] = None,
+        multiple: bool = False,
+        allow_custom: bool = True,
+    ) -> str:
         if self._ask_user:
-            return self._ask_user(question)
+            return _invoke_ask_user_callback(
+                self._ask_user,
+                question,
+                {
+                    "header": header,
+                    "options": options,
+                    "multiple": multiple,
+                    "allow_custom": allow_custom,
+                },
+            )
         return "[ask_user: not available in non-interactive mode]"
 
     def on_max_iterations(self, count: int, messages: list) -> dict:

--- a/agentao/transport/sdk.py
+++ b/agentao/transport/sdk.py
@@ -13,14 +13,16 @@ from .events import AgentEvent, EventType
 from .null import NullTransport
 
 
-def _invoke_ask_user_callback(callback: Callable[..., str], question: str, structured: Dict[str, Any]) -> str:
+def invoke_ask_user_callback(callback: Callable[..., str], question: str, structured: Dict[str, Any]) -> str:
     """Call a user-supplied ``ask_user`` callback, forwarding structured
     kwargs only when the callback can accept them.
 
-    This keeps legacy 1-arg ``Callable[[str], str]`` callbacks working: a
-    callback whose signature names none of the structured fields (and has
-    no ``**kwargs``) is called with the question alone, so the structured
-    hints are silently dropped rather than raising ``TypeError``.
+    Shared by :class:`SdkTransport` and :class:`agentao.tools.ask_user.AskUserTool`
+    so both honour the same backward-compatibility rule: a legacy 1-arg
+    ``Callable[[str], str]`` callback (whose signature names none of the
+    structured fields and has no ``**kwargs``) is called with the question
+    alone, so the structured hints are silently dropped rather than raising
+    ``TypeError``.
     """
     try:
         params = inspect.signature(callback).parameters
@@ -111,7 +113,7 @@ class SdkTransport:
         allow_custom: bool = True,
     ) -> str:
         if self._ask_user:
-            return _invoke_ask_user_callback(
+            return invoke_ask_user_callback(
                 self._ask_user,
                 question,
                 {

--- a/docs/schema/host.acp.v1.json
+++ b/docs/schema/host.acp.v1.json
@@ -95,7 +95,45 @@
     },
     "AcpAskUserParams": {
       "additionalProperties": false,
+      "description": "Params the agent sends to the client for ``_agentao.cn/ask_user``.\n\n``question`` is always present. The remaining fields are optional\nstructured hints a client may render as a choice prompt; a client may\nignore them and prompt with plain text. The reply is always a single\n``text`` string (see :class:`AcpAskUserAnswered`) \u2014 for ``multiple``\nselections the client joins them itself.",
       "properties": {
+        "allowCustom": {
+          "default": true,
+          "title": "Allowcustom",
+          "type": "boolean"
+        },
+        "header": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Header"
+        },
+        "multiple": {
+          "default": false,
+          "title": "Multiple",
+          "type": "boolean"
+        },
+        "options": {
+          "anyOf": [
+            {
+              "items": {
+                "type": "string"
+              },
+              "type": "array"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Options"
+        },
         "question": {
           "title": "Question",
           "type": "string"

--- a/tests/test_ask_user_structured.py
+++ b/tests/test_ask_user_structured.py
@@ -271,3 +271,54 @@ class TestAcpTransportWireShape:
             "question": "Q",
             "options": ["a"],
         }
+
+
+# ---------------------------------------------------------------------------
+# Replay adapter forwarding (signature-aware)
+# ---------------------------------------------------------------------------
+
+
+class TestReplayAdapterForwarding:
+    def _adapter(self, inner, tmp_path):
+        from agentao.replay.adapter import ReplayAdapter
+        from agentao.replay.recorder import ReplayRecorder
+
+        rec = ReplayRecorder.create("sess", tmp_path)
+        return ReplayAdapter(inner, rec), rec
+
+    def test_structured_prompt_into_one_arg_inner_does_not_break(self, tmp_path) -> None:
+        # A legacy 1-arg inner transport must receive only the question even
+        # when the prompt is structured (Codex round-2 P2).
+        seen: List[Any] = []
+
+        class LegacyInner:
+            def emit(self, e): pass
+            def ask_user(self, q):  # noqa: ANN001 - legacy 1-arg shape
+                seen.append(q)
+                return "legacy-ok"
+
+        adapter, rec = self._adapter(LegacyInner(), tmp_path)
+        adapter.begin_turn("t")
+        answer = adapter.ask_user("Pick", options=["a", "b"], multiple=True, allow_custom=False)
+        adapter.end_turn("")
+        rec.close()
+        assert answer == "legacy-ok"
+        assert seen == ["Pick"]
+
+    def test_structured_prompt_into_conforming_inner_forwards_all(self, tmp_path) -> None:
+        captured: Dict[str, Any] = {}
+
+        class ConformingInner:
+            def emit(self, e): pass
+            def ask_user(self, q, *, header=None, options=None, multiple=False, allow_custom=True):
+                captured.update(
+                    header=header, options=options, multiple=multiple, allow_custom=allow_custom
+                )
+                return "ok"
+
+        adapter, rec = self._adapter(ConformingInner(), tmp_path)
+        adapter.begin_turn("t")
+        adapter.ask_user("Pick", header="H", options=["a"], multiple=True, allow_custom=False)
+        adapter.end_turn("")
+        rec.close()
+        assert captured == {"header": "H", "options": ["a"], "multiple": True, "allow_custom": False}

--- a/tests/test_ask_user_structured.py
+++ b/tests/test_ask_user_structured.py
@@ -103,6 +103,22 @@ class TestInvokeAskUserCallback:
         # it must be called with the question alone.
         assert _invoke_ask_user_callback(str, "Q", STRUCTURED) == "Q"
 
+    def test_positional_only_named_field_is_not_passed_by_keyword(self) -> None:
+        # A positional-only parameter sharing a structured field name must
+        # not be forwarded by keyword (would raise TypeError).
+        ns: Dict[str, Any] = {}
+        exec(
+            "def cb(question, header, /):\n"
+            "    return f'{question}:{header}'",
+            ns,
+        )
+        # `header` is positional-only → dropped, so cb is called with the
+        # question alone, which raises its own TypeError (missing header) —
+        # but crucially NOT the 'positional-only passed as keyword' error.
+        with pytest.raises(TypeError) as exc:
+            _invoke_ask_user_callback(ns["cb"], "Q", STRUCTURED)
+        assert "positional-only" not in str(exc.value)
+
 
 class TestSdkTransport:
     def test_one_arg_callback_via_transport(self) -> None:
@@ -142,6 +158,38 @@ class TestResolveOptionSelection:
 
     def test_empty_is_none(self) -> None:
         assert _resolve_option_selection("   ", ["a"], False) is None
+
+
+class TestCliAskUserPrompt:
+    def _stub_cli(self):
+        from types import SimpleNamespace
+
+        return SimpleNamespace(current_status=None)
+
+    def test_allow_custom_false_reprompts_until_valid(self, monkeypatch) -> None:
+        from agentao.cli import transport as cli_transport
+
+        responses = iter(["banana", "9", "2"])  # invalid custom, out-of-range, then valid
+        monkeypatch.setattr(cli_transport.console, "input", lambda *a, **k: next(responses))
+        result = cli_transport.ask_user(
+            self._stub_cli(), "Pick", options=["a", "b"], allow_custom=False
+        )
+        assert result == "b"
+
+    def test_allow_custom_true_accepts_free_form(self, monkeypatch) -> None:
+        from agentao.cli import transport as cli_transport
+
+        monkeypatch.setattr(cli_transport.console, "input", lambda *a, **k: "my custom")
+        result = cli_transport.ask_user(
+            self._stub_cli(), "Pick", options=["a", "b"], allow_custom=True
+        )
+        assert result == "my custom"
+
+    def test_plain_question_returns_text(self, monkeypatch) -> None:
+        from agentao.cli import transport as cli_transport
+
+        monkeypatch.setattr(cli_transport.console, "input", lambda *a, **k: "  hello  ")
+        assert cli_transport.ask_user(self._stub_cli(), "Q?") == "hello"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_ask_user_structured.py
+++ b/tests/test_ask_user_structured.py
@@ -19,7 +19,7 @@ from agentao.acp.schema import AcpAskUserParams
 from agentao.acp.transport import ACPTransport
 from agentao.cli.transport import _resolve_option_selection
 from agentao.tools.ask_user import AskUserTool
-from agentao.transport.sdk import SdkTransport, _invoke_ask_user_callback
+from agentao.transport.sdk import SdkTransport, invoke_ask_user_callback
 
 
 # ---------------------------------------------------------------------------
@@ -67,6 +67,13 @@ class TestAskUserTool:
     def test_execute_no_callback_returns_sentinel(self) -> None:
         assert "not available" in AskUserTool().execute("hi")
 
+    def test_execute_legacy_one_arg_callback_does_not_break(self) -> None:
+        # A directly-constructed tool with the legacy 1-arg callback shape
+        # must not TypeError when execute() forwards the structured kwargs.
+        tool = AskUserTool(lambda q: f"ok:{q}")
+        assert tool.execute("hi") == "ok:hi"
+        assert tool.execute("hi", options=["a", "b"], multiple=True) == "ok:hi"
+
 
 # ---------------------------------------------------------------------------
 # Backward-compatible callback invocation
@@ -79,11 +86,11 @@ STRUCTURED = {"header": "H", "options": ["x"], "multiple": True, "allow_custom":
 class TestInvokeAskUserCallback:
     def test_legacy_one_arg_callback_drops_structured(self) -> None:
         # A legacy Callable[[str], str] must not TypeError on structured kwargs.
-        assert _invoke_ask_user_callback(lambda q: f"got:{q}", "Q", STRUCTURED) == "got:Q"
+        assert invoke_ask_user_callback(lambda q: f"got:{q}", "Q", STRUCTURED) == "got:Q"
 
     def test_var_keyword_callback_receives_all(self) -> None:
         captured: Dict[str, Any] = {}
-        _invoke_ask_user_callback(
+        invoke_ask_user_callback(
             lambda q, **kw: captured.update(kw) or "", "Q", STRUCTURED
         )
         assert captured == STRUCTURED
@@ -95,13 +102,13 @@ class TestInvokeAskUserCallback:
             captured["options"] = options
             return ""
 
-        _invoke_ask_user_callback(cb, "Q", STRUCTURED)
+        invoke_ask_user_callback(cb, "Q", STRUCTURED)
         assert captured == {"options": ["x"]}
 
     def test_uninspectable_callable_falls_back_to_one_arg(self) -> None:
         # ``str`` is a builtin whose signature can't be introspected here;
         # it must be called with the question alone.
-        assert _invoke_ask_user_callback(str, "Q", STRUCTURED) == "Q"
+        assert invoke_ask_user_callback(str, "Q", STRUCTURED) == "Q"
 
     def test_positional_only_named_field_is_not_passed_by_keyword(self) -> None:
         # A positional-only parameter sharing a structured field name must
@@ -116,7 +123,7 @@ class TestInvokeAskUserCallback:
         # question alone, which raises its own TypeError (missing header) —
         # but crucially NOT the 'positional-only passed as keyword' error.
         with pytest.raises(TypeError) as exc:
-            _invoke_ask_user_callback(ns["cb"], "Q", STRUCTURED)
+            invoke_ask_user_callback(ns["cb"], "Q", STRUCTURED)
         assert "positional-only" not in str(exc.value)
 
 

--- a/tests/test_ask_user_structured.py
+++ b/tests/test_ask_user_structured.py
@@ -1,0 +1,218 @@
+"""Tests for structured ask_user (options / header / multiple / allow_custom).
+
+The structured fields are advisory hints that flow from the tool through
+the Transport contract to each transport implementation. The key contract
+is backward compatibility: legacy 1-arg ``Callable[[str], str]`` callbacks
+must keep working, and a plain ask_user must keep its original wire shape.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from agentao.acp.protocol import METHOD_ASK_USER
+from agentao.acp.schema import AcpAskUserParams
+from agentao.acp.transport import ACPTransport
+from agentao.cli.transport import _resolve_option_selection
+from agentao.tools.ask_user import AskUserTool
+from agentao.transport.sdk import SdkTransport, _invoke_ask_user_callback
+
+
+# ---------------------------------------------------------------------------
+# Tool
+# ---------------------------------------------------------------------------
+
+
+class TestAskUserTool:
+    def test_schema_advertises_structured_fields(self) -> None:
+        props = AskUserTool().parameters["properties"]
+        assert set(props) == {"question", "header", "options", "multiple", "allow_custom"}
+        assert props["options"]["type"] == "array"
+        assert props["options"]["items"]["type"] == "string"
+
+    def test_execute_forwards_structured_kwargs(self) -> None:
+        seen: Dict[str, Any] = {}
+
+        def cb(question: str, **kw: Any) -> str:
+            seen["question"] = question
+            seen.update(kw)
+            return "ok"
+
+        result = AskUserTool(cb).execute(
+            "Pick one", header="Setup", options=["a", "b"], multiple=True, allow_custom=False
+        )
+        assert result == "ok"
+        assert seen == {
+            "question": "Pick one",
+            "header": "Setup",
+            "options": ["a", "b"],
+            "multiple": True,
+            "allow_custom": False,
+        }
+
+    def test_execute_plain_question_uses_defaults(self) -> None:
+        seen: Dict[str, Any] = {}
+        AskUserTool(lambda q, **kw: seen.update(kw) or "x").execute("hi")
+        assert seen == {
+            "header": None,
+            "options": None,
+            "multiple": False,
+            "allow_custom": True,
+        }
+
+    def test_execute_no_callback_returns_sentinel(self) -> None:
+        assert "not available" in AskUserTool().execute("hi")
+
+
+# ---------------------------------------------------------------------------
+# Backward-compatible callback invocation
+# ---------------------------------------------------------------------------
+
+
+STRUCTURED = {"header": "H", "options": ["x"], "multiple": True, "allow_custom": False}
+
+
+class TestInvokeAskUserCallback:
+    def test_legacy_one_arg_callback_drops_structured(self) -> None:
+        # A legacy Callable[[str], str] must not TypeError on structured kwargs.
+        assert _invoke_ask_user_callback(lambda q: f"got:{q}", "Q", STRUCTURED) == "got:Q"
+
+    def test_var_keyword_callback_receives_all(self) -> None:
+        captured: Dict[str, Any] = {}
+        _invoke_ask_user_callback(
+            lambda q, **kw: captured.update(kw) or "", "Q", STRUCTURED
+        )
+        assert captured == STRUCTURED
+
+    def test_named_param_callback_receives_only_named(self) -> None:
+        captured: Dict[str, Any] = {}
+
+        def cb(question: str, options: Any = None) -> str:
+            captured["options"] = options
+            return ""
+
+        _invoke_ask_user_callback(cb, "Q", STRUCTURED)
+        assert captured == {"options": ["x"]}
+
+    def test_uninspectable_callable_falls_back_to_one_arg(self) -> None:
+        # ``str`` is a builtin whose signature can't be introspected here;
+        # it must be called with the question alone.
+        assert _invoke_ask_user_callback(str, "Q", STRUCTURED) == "Q"
+
+
+class TestSdkTransport:
+    def test_one_arg_callback_via_transport(self) -> None:
+        t = SdkTransport(ask_user=lambda q: f"answer:{q}")
+        assert t.ask_user("Q", options=["a"], multiple=True) == "answer:Q"
+
+    def test_structured_callback_via_transport(self) -> None:
+        captured: Dict[str, Any] = {}
+        t = SdkTransport(ask_user=lambda q, **kw: captured.update(kw) or "ok")
+        t.ask_user("Q", header="H", options=["a", "b"], multiple=True, allow_custom=False)
+        assert captured == {"header": "H", "options": ["a", "b"], "multiple": True, "allow_custom": False}
+
+    def test_no_callback_returns_sentinel(self) -> None:
+        assert "not available" in SdkTransport().ask_user("Q", options=["a"])
+
+
+# ---------------------------------------------------------------------------
+# CLI option resolution
+# ---------------------------------------------------------------------------
+
+
+class TestResolveOptionSelection:
+    def test_single_number(self) -> None:
+        assert _resolve_option_selection("2", ["a", "b", "c"], False) == "b"
+
+    def test_multiple_numbers(self) -> None:
+        assert _resolve_option_selection("1,3", ["a", "b", "c"], True) == "a, c"
+
+    def test_multiple_when_not_allowed_is_custom(self) -> None:
+        assert _resolve_option_selection("1,2", ["a", "b"], False) is None
+
+    def test_non_numeric_is_custom(self) -> None:
+        assert _resolve_option_selection("hello", ["a", "b"], False) is None
+
+    def test_out_of_range_is_custom(self) -> None:
+        assert _resolve_option_selection("9", ["a", "b"], False) is None
+
+    def test_empty_is_none(self) -> None:
+        assert _resolve_option_selection("   ", ["a"], False) is None
+
+
+# ---------------------------------------------------------------------------
+# ACP schema
+# ---------------------------------------------------------------------------
+
+
+class TestAcpAskUserParams:
+    def test_defaults(self) -> None:
+        p = AcpAskUserParams(sessionId="s", question="q")
+        assert p.header is None
+        assert p.options is None
+        assert p.multiple is False
+        assert p.allowCustom is True
+
+    def test_structured(self) -> None:
+        p = AcpAskUserParams(
+            sessionId="s", question="q", header="H", options=["a"], multiple=True, allowCustom=False
+        )
+        assert p.options == ["a"]
+        assert p.allowCustom is False
+
+    def test_extra_forbidden(self) -> None:
+        with pytest.raises(ValidationError):
+            AcpAskUserParams(sessionId="s", question="q", apiKey="secret")  # type: ignore[call-arg]
+
+
+# ---------------------------------------------------------------------------
+# ACP transport wire shape
+# ---------------------------------------------------------------------------
+
+
+def _acp_transport_with_capture() -> tuple[ACPTransport, List[Dict[str, Any]]]:
+    captured: List[Dict[str, Any]] = []
+    server = MagicMock()
+    pending = MagicMock()
+    pending.wait.return_value = {"outcome": "answered", "text": "ans"}
+
+    def _call(method: str, params: Dict[str, Any]) -> Any:
+        captured.append({"method": method, "params": params})
+        return pending
+
+    server.call.side_effect = _call
+    return ACPTransport(server, "sess"), captured
+
+
+class TestAcpTransportWireShape:
+    def test_plain_question_minimal_wire(self) -> None:
+        t, captured = _acp_transport_with_capture()
+        assert t.ask_user("Q") == "ans"
+        assert captured[0]["method"] == METHOD_ASK_USER
+        assert captured[0]["params"] == {"sessionId": "sess", "question": "Q"}
+
+    def test_structured_question_full_wire(self) -> None:
+        t, captured = _acp_transport_with_capture()
+        t.ask_user("Q", header="H", options=["a", "b"], multiple=True, allow_custom=False)
+        assert captured[0]["params"] == {
+            "sessionId": "sess",
+            "question": "Q",
+            "header": "H",
+            "options": ["a", "b"],
+            "multiple": True,
+            "allowCustom": False,
+        }
+
+    def test_default_structured_values_omitted(self) -> None:
+        # multiple=False / allow_custom=True are defaults → not on the wire.
+        t, captured = _acp_transport_with_capture()
+        t.ask_user("Q", options=["a"])
+        assert captured[0]["params"] == {
+            "sessionId": "sess",
+            "question": "Q",
+            "options": ["a"],
+        }


### PR DESCRIPTION
## Summary

PR-2 from `docs/design/deepchat-acp-patch-revision.md` (A2). Adds optional **structured hints** to the `ask_user` tool and threads them through the `Transport` contract to every transport: `header`, `options`, `multiple`, `allow_custom`. The model can offer a choice list while the user may still type a custom answer.

- **Tool** (`tools/ask_user.py`): new optional params on the schema + `execute`.
- **Transport contract** (`transport/base.py`): keyword-only structured args; updated in `null` / `sdk` / `non_interactive` / CLI / ACP / replay transports.
- **CLI** (`cli/transport.py`): renders a numbered menu; accepts a number, comma-separated numbers (when `multiple`), or custom text — re-prompting when `allow_custom=false` and the entry isn't an option.
- **ACP**: `_agentao.cn/ask_user` forwards host-agnostic plain-string options; `AcpAskUserParams` gains the fields (`docs/schema/host.acp.v1.json` snapshot bumped). Reply stays a single string.
- **Replay**: records the structured hints; plain `ask_user` keeps its original `{"question": ...}` payload.

## Backward compatibility

- A plain `ask_user(question)` keeps its original minimal wire/recording shape.
- Legacy 1-arg `Callable[[str], str]` callbacks (the deprecated `ask_user_callback` constructor arg, `SdkTransport(ask_user=...)`, a directly-constructed `AskUserTool`, or a 1-arg replay inner transport) keep working — structured kwargs are forwarded only to callbacks whose signature accepts them (introspected), dropped otherwise.

## Testing

- New `tests/test_ask_user_structured.py`; full suite green (2776 passed).
- Reviewed with `/code-review --fix` + 3 rounds of codex review (final: clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)