### PR TITLE
feat(paths): robust home resolution when $HOME is unset (PR-3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,7 +23,12 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `$HOME` / `USERPROFILE` and finally the system temp dir, so an
   environment that can't resolve a home directory (stripped service
   accounts, some container/CI sandboxes, headless ACP launches) no longer
-  raises `RuntimeError`. `user_root()` now routes through it, and the
+  raises `RuntimeError`. The fallback is a *private, per-user* temp
+  subdirectory created `0700` and validated for ownership/permissions
+  (a pre-existing world/group-accessible path is abandoned for a fresh
+  `mkdtemp`), so a co-tenant on a shared host can't plant config/plugins
+  at a predictable path for us to load. `user_root()` now routes through
+  it, and the
   scattered direct `Path.home()` call sites (memory dictionary/skills
   paths, the skills registry, plugin discovery, the sandbox config, the
   log-handler fallback, the CLI history file) go through `user_home()` /

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,20 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   `SyntaxWarning` at the import chokepoint (jieba pulls in `finalseg` at
   module top, so one wrap covers all three warnings). No behavior change;
   other warnings are untouched.
+- **Robust home-directory resolution when `$HOME` is unset.** Added
+  `agentao.paths.user_home()` — `Path.home()` with a fallback to
+  `$HOME` / `USERPROFILE` and finally the system temp dir, so an
+  environment that can't resolve a home directory (stripped service
+  accounts, some container/CI sandboxes, headless ACP launches) no longer
+  raises `RuntimeError`. `user_root()` now routes through it, and the
+  scattered direct `Path.home()` call sites (memory dictionary/skills
+  paths, the skills registry, plugin discovery, the sandbox config, the
+  log-handler fallback, the CLI history file) go through `user_home()` /
+  `user_root()` — fixing the import-time crash risk where module-level
+  `~/.agentao` constants resolved `Path.home()` at import. Subsystem
+  constructors still take explicit roots (unchanged from the Issue 5
+  no-implicit-fallback contract); this only hardens the path helpers
+  themselves.
 
 ### Added
 

--- a/agentao/cli/app.py
+++ b/agentao/cli/app.py
@@ -28,6 +28,7 @@ from prompt_toolkit.styles import Style
 from .._env import safe_load_dotenv
 
 from ..agent import Agentao
+from ..paths import user_root
 from .display import DisplayController
 from ..embedding import build_from_environment
 from ..transport import AgentEvent
@@ -106,7 +107,7 @@ class AgentaoCLI:
         def _pt_newline(event):
             event.current_buffer.insert_text('\n')
 
-        _history_file = os.path.expanduser("~/.agentao/history")
+        _history_file = str(user_root() / "history")
         os.makedirs(os.path.dirname(_history_file), exist_ok=True)
         self._prompt_session = PromptSession(
             history=FileHistory(_history_file),

--- a/agentao/embedding/plugins/manager.py
+++ b/agentao/embedding/plugins/manager.py
@@ -7,6 +7,7 @@ import logging
 from pathlib import Path
 from typing import Any
 
+from agentao.paths import user_home, user_root
 from agentao.plugins.models import (
     LoadedPlugin,
     PluginCandidate,
@@ -46,7 +47,7 @@ def _find_project_root(start: Path) -> Path:
     Falls back to *start* itself if no project-level ``.agentao`` is
     found.
     """
-    home = Path.home().resolve()
+    home = user_home().resolve()
     current = start.resolve()
     while True:
         if current != home and (current / ".agentao").is_dir():
@@ -92,7 +93,7 @@ class PluginManager:
         candidates: list[PluginCandidate] = []
 
         # 1. global
-        global_dir = Path.home() / ".agentao" / "plugins"
+        global_dir = user_root() / "plugins"
         candidates.extend(self._scan_dir(global_dir, "global"))
 
         # 2. project
@@ -393,7 +394,7 @@ class PluginManager:
         Project config has higher priority — if it explicitly enables a
         plugin that global config disables, the plugin stays enabled.
         """
-        global_cfg = self._read_config(Path.home() / ".agentao" / "plugins_config.json")
+        global_cfg = self._read_config(user_root() / "plugins_config.json")
         project_cfg = self._read_config(self._cwd / ".agentao" / "plugins_config.json")
 
         disabled: set[str] = set()

--- a/agentao/llm/client.py
+++ b/agentao/llm/client.py
@@ -40,6 +40,7 @@ from ._retry import (
     _parse_retry_after,
 )
 from ._stream_response import _StreamAccumulator, _StreamResponse
+from ..paths import user_root
 
 # `openai` is deferred (P0.5): merely importing ``LLMClient`` should not pull
 # in the OpenAI SDK. Hosts that inject their own ``llm_client=`` never load
@@ -208,7 +209,7 @@ class LLMClient:
                 primary, maxBytes=10_000_000, backupCount=5, encoding="utf-8"
             )
         except OSError as primary_err:
-            fallback = Path.home() / ".agentao" / "agentao.log"
+            fallback = user_root() / "agentao.log"
             if fallback == primary:
                 # Already tried; nothing else to fall back to.
                 print(

--- a/agentao/memory/crystallizer.py
+++ b/agentao/memory/crystallizer.py
@@ -10,6 +10,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional, Tuple
 
+from ..paths import user_root
 from .models import (
     CrystallizationProposal,
     MemoryRecord,
@@ -254,7 +255,7 @@ class MemoryCrystallizer:
 
 
 # Mirror SkillManager path conventions
-_GLOBAL_SKILLS_DIR = Path.home() / ".agentao" / "skills"
+_GLOBAL_SKILLS_DIR = user_root() / "skills"
 
 SUGGEST_SYSTEM_PROMPT = """\
 You are a skill extraction assistant for Agentao, an AI coding agent.
@@ -501,7 +502,7 @@ def load_skill_creator_guidance() -> str:
     candidate = _BUNDLED_SKILLS_DIR / "skill-creator" / "SKILL.md"
     if not candidate.exists():
         # Also try ~/.agentao/skills as a fallback (installed location).
-        alt = Path.home() / ".agentao" / "skills" / "skill-creator" / "SKILL.md"
+        alt = user_root() / "skills" / "skill-creator" / "SKILL.md"
         if not alt.exists():
             return ""
         candidate = alt

--- a/agentao/memory/retriever.py
+++ b/agentao/memory/retriever.py
@@ -6,7 +6,6 @@ import traceback
 import warnings
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from pathlib import Path
 from typing import Dict, List, Optional, Set, TYPE_CHECKING
 
 # `jieba` is deferred (P0.5): importing this module is on the path of
@@ -59,6 +58,7 @@ def __getattr__(name: str):
 
 
 from agentao.logging_utils import capture_third_party_output
+from agentao.paths import user_root
 
 from .models import MemoryRecord, RecallCandidate
 
@@ -72,7 +72,7 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 _JIEBA_INITIALIZED = False
-_USERDICT_PATH = Path.home() / ".agentao" / "userdict.txt"
+_USERDICT_PATH = user_root() / "userdict.txt"
 
 
 def _initialize_jieba_with_logging() -> None:

--- a/agentao/paths.py
+++ b/agentao/paths.py
@@ -7,6 +7,7 @@ multiple call sites. Importing this module is cheap (no side effects).
 from __future__ import annotations
 
 import getpass
+import os
 import tempfile
 from pathlib import Path
 
@@ -26,9 +27,9 @@ def user_home() -> Path:
     back to a writable location so user-scope state still has a home.
 
     The fallback is a *per-user* subdirectory of the system temp dir: the
-    temp root itself is shared between users, so namespacing it by login
-    name avoids one account's ``~/.agentao`` state (history, registries)
-    colliding with another's on a multi-tenant host.
+    temp root itself is shared between users, so namespacing it avoids one
+    account's ``~/.agentao`` state (history, registries) colliding with
+    another's on a multi-tenant host.
 
     Resolved lazily on each call so tests that monkeypatch ``Path.home``
     see the patched value.
@@ -39,11 +40,26 @@ def user_home() -> Path:
         # When Path.home() raises, the home env vars are necessarily unset
         # (it consults exactly those before failing), so the only useful
         # last resort is the temp dir — namespaced per user.
-        try:
-            who = getpass.getuser()
-        except Exception:
-            who = "unknown"
-        return Path(tempfile.gettempdir()) / f"agentao-{who}"
+        return Path(tempfile.gettempdir()) / f"agentao-{_fallback_user_id()}"
+
+
+def _fallback_user_id() -> str:
+    """A stable per-user discriminator for the no-home temp fallback.
+
+    ``getpass.getuser()`` can fail in exactly the stripped environments
+    that trigger the fallback (no ``LOGNAME``/``USER`` env vars and no
+    password-database entry), so fall through to the numeric uid — which
+    is always available on POSIX and unique per account — before a shared
+    placeholder. (Windows has no ``getuid`` but effectively never reaches
+    this path, since ``USERPROFILE`` is set there.)
+    """
+    try:
+        return getpass.getuser()
+    except Exception:
+        getuid = getattr(os, "getuid", None)
+        if getuid is not None:
+            return str(getuid())
+        return "unknown"
 
 
 def user_root() -> Path:

--- a/agentao/paths.py
+++ b/agentao/paths.py
@@ -6,7 +6,7 @@ multiple call sites. Importing this module is cheap (no side effects).
 
 from __future__ import annotations
 
-import os
+import getpass
 import tempfile
 from pathlib import Path
 
@@ -14,16 +14,21 @@ USER_DIR_NAME = ".agentao"
 
 
 def user_home() -> Path:
-    """Return the user's home directory, robust to an unset ``$HOME``.
+    """Return the user's home directory, robust to an unresolvable home.
 
-    ``Path.home()`` raises ``RuntimeError`` when it cannot resolve a home
-    directory — ``$HOME`` (and on Windows ``USERPROFILE``) is unset *and*
-    there is no password-database entry for the current uid. This happens
-    in stripped service accounts, some container and CI sandboxes, and
+    ``Path.home()`` (i.e. ``Path("~").expanduser()``) raises
+    ``RuntimeError`` when it cannot resolve a home directory — ``$HOME``
+    (or ``USERPROFILE`` on Windows) is unset *and* there is no
+    password-database entry for the current user. This happens in
+    stripped service accounts, some container and CI sandboxes, and
     headless launches (e.g. an ACP client spawning us with a minimal
     environment). Rather than let that crash an import or a turn, fall
-    back to the system temp directory so user-scope state still has a
-    writable home to land in.
+    back to a writable location so user-scope state still has a home.
+
+    The fallback is a *per-user* subdirectory of the system temp dir: the
+    temp root itself is shared between users, so namespacing it by login
+    name avoids one account's ``~/.agentao`` state (history, registries)
+    colliding with another's on a multi-tenant host.
 
     Resolved lazily on each call so tests that monkeypatch ``Path.home``
     see the patched value.
@@ -31,14 +36,14 @@ def user_home() -> Path:
     try:
         return Path.home()
     except RuntimeError:
-        # Last resort: a guaranteed-writable location. Prefer an explicit
-        # env var if one is set but unparsed by Path.home() on this
-        # platform, else the system temp dir.
-        for var in ("HOME", "USERPROFILE"):
-            value = os.environ.get(var)
-            if value:
-                return Path(value)
-        return Path(tempfile.gettempdir())
+        # When Path.home() raises, the home env vars are necessarily unset
+        # (it consults exactly those before failing), so the only useful
+        # last resort is the temp dir — namespaced per user.
+        try:
+            who = getpass.getuser()
+        except Exception:
+            who = "unknown"
+        return Path(tempfile.gettempdir()) / f"agentao-{who}"
 
 
 def user_root() -> Path:

--- a/agentao/paths.py
+++ b/agentao/paths.py
@@ -14,6 +14,10 @@ from pathlib import Path
 
 USER_DIR_NAME = ".agentao"
 
+# Process-stable cache for the no-home fallback (see ``user_home``). Only
+# the degraded fallback populates it; a resolvable home never touches it.
+_FALLBACK_HOME: Path | None = None
+
 
 def user_home() -> Path:
     """Return the user's home directory, robust to an unresolvable home.
@@ -48,8 +52,15 @@ def user_home() -> Path:
         # When Path.home() raises, the home env vars are necessarily unset
         # (it consults exactly those before failing), so the only useful
         # last resort is the temp dir — namespaced per user and locked down.
-        candidate = Path(tempfile.gettempdir()) / f"agentao-{_fallback_user_id()}"
-        return _private_dir_or_mkdtemp(candidate)
+        # Cache it for the process: the unsafe-candidate branch resolves to a
+        # fresh ``mkdtemp`` each call, so without caching, two ``user_root()``
+        # callers (e.g. global skill registry vs. install dir) could end up
+        # on different roots within one run.
+        global _FALLBACK_HOME
+        if _FALLBACK_HOME is None:
+            candidate = Path(tempfile.gettempdir()) / f"agentao-{_fallback_user_id()}"
+            _FALLBACK_HOME = _private_dir_or_mkdtemp(candidate)
+        return _FALLBACK_HOME
 
 
 def _fallback_user_id() -> str:

--- a/agentao/paths.py
+++ b/agentao/paths.py
@@ -6,16 +6,47 @@ multiple call sites. Importing this module is cheap (no side effects).
 
 from __future__ import annotations
 
+import os
+import tempfile
 from pathlib import Path
 
 USER_DIR_NAME = ".agentao"
 
 
+def user_home() -> Path:
+    """Return the user's home directory, robust to an unset ``$HOME``.
+
+    ``Path.home()`` raises ``RuntimeError`` when it cannot resolve a home
+    directory — ``$HOME`` (and on Windows ``USERPROFILE``) is unset *and*
+    there is no password-database entry for the current uid. This happens
+    in stripped service accounts, some container and CI sandboxes, and
+    headless launches (e.g. an ACP client spawning us with a minimal
+    environment). Rather than let that crash an import or a turn, fall
+    back to the system temp directory so user-scope state still has a
+    writable home to land in.
+
+    Resolved lazily on each call so tests that monkeypatch ``Path.home``
+    see the patched value.
+    """
+    try:
+        return Path.home()
+    except RuntimeError:
+        # Last resort: a guaranteed-writable location. Prefer an explicit
+        # env var if one is set but unparsed by Path.home() on this
+        # platform, else the system temp dir.
+        for var in ("HOME", "USERPROFILE"):
+            value = os.environ.get(var)
+            if value:
+                return Path(value)
+        return Path(tempfile.gettempdir())
+
+
 def user_root() -> Path:
     """Return ``~/.agentao`` — the user-scope config / state directory.
 
-    Resolved lazily on each call so tests that monkeypatch ``Path.home``
-    see the patched value. Callers that need to capture a stable
-    snapshot should bind the return value once and pass it explicitly.
+    Resolved lazily on each call (via :func:`user_home`) so tests that
+    monkeypatch ``Path.home`` see the patched value. Callers that need to
+    capture a stable snapshot should bind the return value once and pass
+    it explicitly.
     """
-    return Path.home() / USER_DIR_NAME
+    return user_home() / USER_DIR_NAME

--- a/agentao/paths.py
+++ b/agentao/paths.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import getpass
 import os
+import stat
 import tempfile
 from pathlib import Path
 
@@ -26,10 +27,17 @@ def user_home() -> Path:
     environment). Rather than let that crash an import or a turn, fall
     back to a writable location so user-scope state still has a home.
 
-    The fallback is a *per-user* subdirectory of the system temp dir: the
-    temp root itself is shared between users, so namespacing it avoids one
-    account's ``~/.agentao`` state (history, registries) colliding with
-    another's on a multi-tenant host.
+    The fallback is a *private, per-user* subdirectory of the system temp
+    dir. The temp root is world-writable and shared between users, so the
+    directory is created ``0700`` and validated to be owned by the current
+    user with no group/other access before it is trusted — otherwise a
+    local attacker could pre-create the predictable path and have us load
+    their ``plugins`` / ``skills`` / ``sandbox.json`` as user-scope state.
+    A pre-existing path that fails that check is abandoned for a fresh
+    private ``mkdtemp`` rather than trusted.
+
+    The normal path (a resolvable home) does no filesystem I/O; only the
+    degraded fallback creates/validates the directory.
 
     Resolved lazily on each call so tests that monkeypatch ``Path.home``
     see the patched value.
@@ -39,8 +47,9 @@ def user_home() -> Path:
     except RuntimeError:
         # When Path.home() raises, the home env vars are necessarily unset
         # (it consults exactly those before failing), so the only useful
-        # last resort is the temp dir — namespaced per user.
-        return Path(tempfile.gettempdir()) / f"agentao-{_fallback_user_id()}"
+        # last resort is the temp dir — namespaced per user and locked down.
+        candidate = Path(tempfile.gettempdir()) / f"agentao-{_fallback_user_id()}"
+        return _private_dir_or_mkdtemp(candidate)
 
 
 def _fallback_user_id() -> str:
@@ -60,6 +69,41 @@ def _fallback_user_id() -> str:
         if getuid is not None:
             return str(getuid())
         return "unknown"
+
+
+def _private_dir_or_mkdtemp(path: Path) -> Path:
+    """Return ``path`` after ensuring it is a directory private to this user.
+
+    Creates ``path`` with ``0700`` perms. If it already exists, it is
+    trusted only when it is a real directory (not a symlink), owned by the
+    current user, with no group/other access — the lockdown that keeps a
+    co-tenant on a shared host from planting config we would load. If the
+    path can't be created or fails that check, fall back to a freshly
+    created private ``mkdtemp`` directory (guaranteed ``0700`` and unique).
+    """
+    try:
+        path.mkdir(mode=0o700, parents=True, exist_ok=True)
+        if _is_private_to_current_user(path):
+            return path
+    except OSError:
+        pass
+    return Path(tempfile.mkdtemp(prefix="agentao-"))
+
+
+def _is_private_to_current_user(path: Path) -> bool:
+    """True if ``path`` is a non-symlink dir owned by us with no g/o access."""
+    try:
+        info = path.lstat()
+    except OSError:
+        return False
+    if not stat.S_ISDIR(info.st_mode):
+        return False  # symlink or non-directory — do not trust
+    if info.st_mode & (stat.S_IRWXG | stat.S_IRWXO):
+        return False  # group/other access — not private
+    getuid = getattr(os, "getuid", None)
+    if getuid is not None and info.st_uid != getuid():
+        return False  # owned by another user
+    return True
 
 
 def user_root() -> Path:

--- a/agentao/sandbox/policy.py
+++ b/agentao/sandbox/policy.py
@@ -36,6 +36,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
+from ..paths import user_root
+
 
 _BUILTIN_PROFILES_DIR = Path(__file__).parent / "profiles"
 
@@ -246,7 +248,7 @@ def load_sandbox_config(*, project_root: Optional[Path] = None) -> Dict[str, Any
     fail-closed instead of quietly falling back to the default-disabled
     config.
     """
-    global_path = Path.home() / ".agentao" / "sandbox.json"
+    global_path = user_root() / "sandbox.json"
     project_cwd = project_root if project_root is not None else Path.cwd()
     project_path = project_cwd / ".agentao" / "sandbox.json"
 

--- a/agentao/skills/manager.py
+++ b/agentao/skills/manager.py
@@ -8,8 +8,10 @@ from typing import Dict, List, Optional, Set
 
 import yaml
 
+from ..paths import user_root
+
 # Global skills directory (shared across all projects). Cwd-independent.
-_GLOBAL_SKILLS_DIR = Path.home() / ".agentao" / "skills"
+_GLOBAL_SKILLS_DIR = user_root() / "skills"
 
 # Bundled skills shipped with the package (skill-creator lives here after install)
 _BUNDLED_SKILLS_DIR = Path(__file__).parent.parent.parent / "skills"

--- a/agentao/skills/registry.py
+++ b/agentao/skills/registry.py
@@ -6,6 +6,8 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import TYPE_CHECKING, Dict, List, Optional
 
+from ..paths import user_home, user_root
+
 # `filelock` is deferred (P0.5): the registry is only touched when an
 # embedded host (or the CLI) installs / updates skills. Plain ``Agentao()``
 # construction never reaches the lock path, so the wheel cost stays out of
@@ -119,7 +121,7 @@ def _find_project_root(start: Optional[Path] = None) -> Optional[Path]:
 
     Returns ``None`` if no marker is found before reaching the filesystem root.
     """
-    home = Path.home().resolve()
+    home = user_home().resolve()
     current = (start or Path.cwd()).resolve()
     # Markers that are ambiguous at $HOME (config dirs / bare repos).
     _HOME_SKIP = {".agentao", ".git"}
@@ -151,7 +153,7 @@ def registry_path_for_scope(scope: str, cwd: Optional[Path] = None) -> Path:
     is run from.
     """
     if scope == "global":
-        return Path.home() / ".agentao" / "skills_registry.json"
+        return user_root() / "skills_registry.json"
     root = _find_project_root(cwd)
     if root is None:
         root = cwd or Path.cwd()
@@ -166,7 +168,7 @@ def install_dir_for_scope(
     For project scope, resolves upward to the project root.
     """
     if scope == "global":
-        return Path.home() / ".agentao" / "skills" / skill_name
+        return user_root() / "skills" / skill_name
     root = _find_project_root(cwd)
     if root is None:
         root = cwd or Path.cwd()

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -9,6 +9,7 @@ letting that crash an import or a turn.
 from __future__ import annotations
 
 import getpass
+import os
 import tempfile
 from pathlib import Path
 
@@ -43,9 +44,20 @@ class TestUserHome:
         b = user_home()
         assert a != b
 
-    def test_fallback_survives_getuser_failure(self, monkeypatch) -> None:
+    def test_fallback_uses_uid_when_getuser_fails(self, monkeypatch) -> None:
+        # In a fully stripped account getpass.getuser() raises too; fall
+        # through to the numeric uid (stable + unique per POSIX user)
+        # rather than a shared placeholder.
         monkeypatch.setattr(Path, "home", staticmethod(_raise))
         monkeypatch.setattr(getpass, "getuser", _raise)
+        monkeypatch.setattr(os, "getuid", lambda: 4242, raising=False)
+        assert user_home() == Path(tempfile.gettempdir()) / "agentao-4242"
+
+    def test_fallback_placeholder_only_without_getuid(self, monkeypatch) -> None:
+        # Windows has no os.getuid; the shared placeholder is the last resort.
+        monkeypatch.setattr(Path, "home", staticmethod(_raise))
+        monkeypatch.setattr(getpass, "getuser", _raise)
+        monkeypatch.delattr(os, "getuid", raising=False)
         assert user_home() == Path(tempfile.gettempdir()) / "agentao-unknown"
 
     def test_resolved_lazily_each_call(self, monkeypatch) -> None:

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -2,21 +2,33 @@
 
 ``Path.home()`` raises ``RuntimeError`` when neither ``$HOME`` (nor
 ``USERPROFILE`` on Windows) nor the password database can yield a home
-dir. ``user_home()`` must degrade to a writable fallback instead of
-letting that crash an import or a turn.
+dir. ``user_home()`` must degrade to a *private, per-user* writable
+fallback instead of letting that crash an import or a turn — and must
+not trust an attacker-pre-created path under the shared temp dir.
 """
 
 from __future__ import annotations
 
 import getpass
 import os
+import stat
 import tempfile
 from pathlib import Path
 
 import pytest
 
 from agentao import paths
-from agentao.paths import USER_DIR_NAME, user_home, user_root
+from agentao.paths import (
+    USER_DIR_NAME,
+    _fallback_user_id,
+    _is_private_to_current_user,
+    user_home,
+    user_root,
+)
+
+_POSIX_ONLY = pytest.mark.skipif(
+    not hasattr(os, "getuid"), reason="POSIX ownership semantics"
+)
 
 
 def _raise(*_a, **_k):
@@ -28,37 +40,23 @@ class TestUserHome:
         monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/wherever/me")))
         assert user_home() == Path("/wherever/me")
 
-    def test_falls_back_to_per_user_tempdir_when_home_unresolvable(self, monkeypatch) -> None:
-        # When Path.home() raises, the home env vars are necessarily unset,
-        # so the fallback is a per-user subdirectory of the temp dir.
-        monkeypatch.setattr(Path, "home", staticmethod(_raise))
-        monkeypatch.setattr(getpass, "getuser", lambda: "alice")
-        assert user_home() == Path(tempfile.gettempdir()) / "agentao-alice"
+    def test_happy_path_does_no_filesystem_io(self, monkeypatch) -> None:
+        # The normal (resolvable home) path must not touch the temp dir.
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/wherever/me")))
+        monkeypatch.setattr(
+            tempfile, "mkdtemp", lambda *a, **k: pytest.fail("should not mkdtemp")
+        )
+        assert user_home() == Path("/wherever/me")
 
-    def test_fallback_namespaced_per_user(self, monkeypatch) -> None:
-        # Two different users must not collide on the same fallback home.
+    def test_fallback_creates_private_per_user_dir(self, monkeypatch, tmp_path) -> None:
         monkeypatch.setattr(Path, "home", staticmethod(_raise))
-        monkeypatch.setattr(getpass, "getuser", lambda: "alice")
-        a = user_home()
-        monkeypatch.setattr(getpass, "getuser", lambda: "bob")
-        b = user_home()
-        assert a != b
-
-    def test_fallback_uses_uid_when_getuser_fails(self, monkeypatch) -> None:
-        # In a fully stripped account getpass.getuser() raises too; fall
-        # through to the numeric uid (stable + unique per POSIX user)
-        # rather than a shared placeholder.
-        monkeypatch.setattr(Path, "home", staticmethod(_raise))
-        monkeypatch.setattr(getpass, "getuser", _raise)
-        monkeypatch.setattr(os, "getuid", lambda: 4242, raising=False)
-        assert user_home() == Path(tempfile.gettempdir()) / "agentao-4242"
-
-    def test_fallback_placeholder_only_without_getuid(self, monkeypatch) -> None:
-        # Windows has no os.getuid; the shared placeholder is the last resort.
-        monkeypatch.setattr(Path, "home", staticmethod(_raise))
-        monkeypatch.setattr(getpass, "getuser", _raise)
-        monkeypatch.delattr(os, "getuid", raising=False)
-        assert user_home() == Path(tempfile.gettempdir()) / "agentao-unknown"
+        monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path))
+        result = user_home()
+        expected = tmp_path / f"agentao-{getpass.getuser()}"
+        assert result == expected
+        assert result.is_dir()
+        if hasattr(os, "getuid"):
+            assert stat.S_IMODE(result.stat().st_mode) == 0o700
 
     def test_resolved_lazily_each_call(self, monkeypatch) -> None:
         # A later monkeypatch of Path.home must be observed (no caching).
@@ -67,17 +65,80 @@ class TestUserHome:
         monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/b")))
         assert user_home() == Path("/b")
 
+    @_POSIX_ONLY
+    def test_rejects_unsafe_preexisting_dir(self, monkeypatch, tmp_path) -> None:
+        # A world/group-accessible pre-existing path (attacker-plantable on a
+        # shared host) must NOT be trusted — user_home falls back to a fresh
+        # private mkdtemp instead.
+        monkeypatch.setattr(Path, "home", staticmethod(_raise))
+        monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path))
+        candidate = tmp_path / f"agentao-{getpass.getuser()}"
+        candidate.mkdir(mode=0o777)
+        os.chmod(candidate, 0o777)  # defeat umask
+        result = user_home()
+        assert result != candidate
+        assert result.is_dir()
+        assert stat.S_IMODE(result.stat().st_mode) == 0o700
+
+
+class TestFallbackUserId:
+    def test_uses_getuser_normally(self, monkeypatch) -> None:
+        monkeypatch.setattr(getpass, "getuser", lambda: "alice")
+        assert _fallback_user_id() == "alice"
+
+    @_POSIX_ONLY
+    def test_uses_uid_when_getuser_fails(self, monkeypatch) -> None:
+        monkeypatch.setattr(getpass, "getuser", _raise)
+        monkeypatch.setattr(os, "getuid", lambda: 4242)
+        assert _fallback_user_id() == "4242"
+
+    def test_placeholder_when_no_getuid(self, monkeypatch) -> None:
+        monkeypatch.setattr(getpass, "getuser", _raise)
+        monkeypatch.delattr(os, "getuid", raising=False)
+        assert _fallback_user_id() == "unknown"
+
+
+@_POSIX_ONLY
+class TestIsPrivateToCurrentUser:
+    def test_private_dir(self, tmp_path) -> None:
+        d = tmp_path / "priv"
+        d.mkdir(mode=0o700)
+        os.chmod(d, 0o700)
+        assert _is_private_to_current_user(d) is True
+
+    def test_group_or_other_access_rejected(self, tmp_path) -> None:
+        d = tmp_path / "open"
+        d.mkdir()
+        os.chmod(d, 0o755)
+        assert _is_private_to_current_user(d) is False
+
+    def test_nonexistent_rejected(self, tmp_path) -> None:
+        assert _is_private_to_current_user(tmp_path / "nope") is False
+
+    def test_symlink_rejected(self, tmp_path) -> None:
+        target = tmp_path / "real"
+        target.mkdir(mode=0o700)
+        link = tmp_path / "link"
+        link.symlink_to(target)
+        assert _is_private_to_current_user(link) is False
+
+    def test_file_rejected(self, tmp_path) -> None:
+        f = tmp_path / "file"
+        f.write_text("x")
+        os.chmod(f, 0o600)
+        assert _is_private_to_current_user(f) is False
+
 
 class TestUserRoot:
     def test_appends_user_dir_name(self, monkeypatch) -> None:
         monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/home/x")))
         assert user_root() == Path("/home/x") / USER_DIR_NAME
 
-    def test_does_not_crash_when_home_unresolvable(self, monkeypatch) -> None:
+    def test_does_not_crash_when_home_unresolvable(self, monkeypatch, tmp_path) -> None:
         monkeypatch.setattr(Path, "home", staticmethod(_raise))
-        monkeypatch.setattr(getpass, "getuser", lambda: "alice")
+        monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path))
         # Must not raise; lands under the per-user temp fallback home.
-        assert user_root() == Path(tempfile.gettempdir()) / "agentao-alice" / USER_DIR_NAME
+        assert user_root() == tmp_path / f"agentao-{getpass.getuser()}" / USER_DIR_NAME
 
     def test_uses_user_home(self, monkeypatch) -> None:
         # user_root must route through user_home (not Path.home directly), so

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,0 +1,71 @@
+"""Tests for agentao.paths — robust home-directory resolution.
+
+``Path.home()`` raises ``RuntimeError`` when neither ``$HOME`` (nor
+``USERPROFILE`` on Windows) nor the password database can yield a home
+dir. ``user_home()`` must degrade to a writable fallback instead of
+letting that crash an import or a turn.
+"""
+
+from __future__ import annotations
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from agentao import paths
+from agentao.paths import USER_DIR_NAME, user_home, user_root
+
+
+def _raise(*_a, **_k):
+    raise RuntimeError("no home directory")
+
+
+class TestUserHome:
+    def test_returns_path_home_when_available(self, monkeypatch) -> None:
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/wherever/me")))
+        assert user_home() == Path("/wherever/me")
+
+    def test_falls_back_to_home_env_when_path_home_raises(self, monkeypatch) -> None:
+        monkeypatch.setattr(Path, "home", staticmethod(_raise))
+        monkeypatch.setenv("HOME", "/from/env")
+        monkeypatch.delenv("USERPROFILE", raising=False)
+        assert user_home() == Path("/from/env")
+
+    def test_falls_back_to_userprofile_when_only_that_is_set(self, monkeypatch) -> None:
+        monkeypatch.setattr(Path, "home", staticmethod(_raise))
+        monkeypatch.delenv("HOME", raising=False)
+        monkeypatch.setenv("USERPROFILE", "/win/profile")
+        assert user_home() == Path("/win/profile")
+
+    def test_falls_back_to_tempdir_when_no_env(self, monkeypatch) -> None:
+        monkeypatch.setattr(Path, "home", staticmethod(_raise))
+        monkeypatch.delenv("HOME", raising=False)
+        monkeypatch.delenv("USERPROFILE", raising=False)
+        assert user_home() == Path(tempfile.gettempdir())
+
+    def test_resolved_lazily_each_call(self, monkeypatch) -> None:
+        # A later monkeypatch of Path.home must be observed (no caching).
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/a")))
+        assert user_home() == Path("/a")
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/b")))
+        assert user_home() == Path("/b")
+
+
+class TestUserRoot:
+    def test_appends_user_dir_name(self, monkeypatch) -> None:
+        monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/home/x")))
+        assert user_root() == Path("/home/x") / USER_DIR_NAME
+
+    def test_does_not_crash_when_home_unresolvable(self, monkeypatch) -> None:
+        monkeypatch.setattr(Path, "home", staticmethod(_raise))
+        monkeypatch.delenv("HOME", raising=False)
+        monkeypatch.delenv("USERPROFILE", raising=False)
+        # Must not raise; lands under the temp dir.
+        assert user_root() == Path(tempfile.gettempdir()) / USER_DIR_NAME
+
+    def test_uses_user_home(self, monkeypatch) -> None:
+        # user_root must route through user_home (not Path.home directly), so
+        # the fallback applies to user_root too.
+        monkeypatch.setattr(paths, "user_home", lambda: Path("/sentinel"))
+        assert user_root() == Path("/sentinel") / USER_DIR_NAME

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -8,6 +8,7 @@ letting that crash an import or a turn.
 
 from __future__ import annotations
 
+import getpass
 import tempfile
 from pathlib import Path
 
@@ -26,23 +27,26 @@ class TestUserHome:
         monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/wherever/me")))
         assert user_home() == Path("/wherever/me")
 
-    def test_falls_back_to_home_env_when_path_home_raises(self, monkeypatch) -> None:
+    def test_falls_back_to_per_user_tempdir_when_home_unresolvable(self, monkeypatch) -> None:
+        # When Path.home() raises, the home env vars are necessarily unset,
+        # so the fallback is a per-user subdirectory of the temp dir.
         monkeypatch.setattr(Path, "home", staticmethod(_raise))
-        monkeypatch.setenv("HOME", "/from/env")
-        monkeypatch.delenv("USERPROFILE", raising=False)
-        assert user_home() == Path("/from/env")
+        monkeypatch.setattr(getpass, "getuser", lambda: "alice")
+        assert user_home() == Path(tempfile.gettempdir()) / "agentao-alice"
 
-    def test_falls_back_to_userprofile_when_only_that_is_set(self, monkeypatch) -> None:
+    def test_fallback_namespaced_per_user(self, monkeypatch) -> None:
+        # Two different users must not collide on the same fallback home.
         monkeypatch.setattr(Path, "home", staticmethod(_raise))
-        monkeypatch.delenv("HOME", raising=False)
-        monkeypatch.setenv("USERPROFILE", "/win/profile")
-        assert user_home() == Path("/win/profile")
+        monkeypatch.setattr(getpass, "getuser", lambda: "alice")
+        a = user_home()
+        monkeypatch.setattr(getpass, "getuser", lambda: "bob")
+        b = user_home()
+        assert a != b
 
-    def test_falls_back_to_tempdir_when_no_env(self, monkeypatch) -> None:
+    def test_fallback_survives_getuser_failure(self, monkeypatch) -> None:
         monkeypatch.setattr(Path, "home", staticmethod(_raise))
-        monkeypatch.delenv("HOME", raising=False)
-        monkeypatch.delenv("USERPROFILE", raising=False)
-        assert user_home() == Path(tempfile.gettempdir())
+        monkeypatch.setattr(getpass, "getuser", _raise)
+        assert user_home() == Path(tempfile.gettempdir()) / "agentao-unknown"
 
     def test_resolved_lazily_each_call(self, monkeypatch) -> None:
         # A later monkeypatch of Path.home must be observed (no caching).
@@ -59,10 +63,9 @@ class TestUserRoot:
 
     def test_does_not_crash_when_home_unresolvable(self, monkeypatch) -> None:
         monkeypatch.setattr(Path, "home", staticmethod(_raise))
-        monkeypatch.delenv("HOME", raising=False)
-        monkeypatch.delenv("USERPROFILE", raising=False)
-        # Must not raise; lands under the temp dir.
-        assert user_root() == Path(tempfile.gettempdir()) / USER_DIR_NAME
+        monkeypatch.setattr(getpass, "getuser", lambda: "alice")
+        # Must not raise; lands under the per-user temp fallback home.
+        assert user_root() == Path(tempfile.gettempdir()) / "agentao-alice" / USER_DIR_NAME
 
     def test_uses_user_home(self, monkeypatch) -> None:
         # user_root must route through user_home (not Path.home directly), so

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -35,6 +35,12 @@ def _raise(*_a, **_k):
     raise RuntimeError("no home directory")
 
 
+@pytest.fixture(autouse=True)
+def _reset_fallback_cache(monkeypatch):
+    # The no-home fallback is cached process-wide; start each test clean.
+    monkeypatch.setattr(paths, "_FALLBACK_HOME", None)
+
+
 class TestUserHome:
     def test_returns_path_home_when_available(self, monkeypatch) -> None:
         monkeypatch.setattr(Path, "home", staticmethod(lambda: Path("/wherever/me")))
@@ -79,6 +85,14 @@ class TestUserHome:
         assert result != candidate
         assert result.is_dir()
         assert stat.S_IMODE(result.stat().st_mode) == 0o700
+        # And it must be stable across calls (cached), so global-scope
+        # helpers don't diverge onto different mkdtemp roots in one process.
+        assert user_home() == result
+
+    def test_fallback_is_process_stable(self, monkeypatch, tmp_path) -> None:
+        monkeypatch.setattr(Path, "home", staticmethod(_raise))
+        monkeypatch.setattr(tempfile, "gettempdir", lambda: str(tmp_path))
+        assert user_home() == user_home()
 
 
 class TestFallbackUserId:


### PR DESCRIPTION
## Summary

PR-3 from `docs/design/deepchat-acp-patch-revision.md` (A3). Makes home-directory resolution robust when `$HOME` is unresolvable.

`Path.home()` (i.e. `Path("~").expanduser()`) raises `RuntimeError` when `$HOME`/`USERPROFILE` is unset **and** there's no password-database entry (stripped service accounts, some container/CI sandboxes, headless ACP launches). Several module-level `~/.agentao` constants resolved `Path.home()` at **import**, so this could crash an import outright.

- Adds `agentao.paths.user_home()` — `Path.home()` with a safe fallback; `user_root()` routes through it.
- Replaces the scattered direct `Path.home()` calls (memory userdict/skills constants, skills registry, plugin discovery, sandbox config, the llm log-handler fallback, the CLI history file) with `user_home()` / `user_root()`.

### Fallback safety

The fallback is a **private, per-user** subdirectory of the system temp dir:
- Namespaced by login name, falling back to the numeric uid (stable + unique per POSIX account) before a shared placeholder.
- Created `0700` and validated to be a non-symlink dir owned by the current user with no group/other access — otherwise abandoned for a fresh `mkdtemp` — so a co-tenant on a shared host can't pre-create the predictable path and have us load their `plugins`/`skills`/`sandbox.json`.
- Cached per-process so global-scope helpers (registry vs. install dir) don't diverge.

The normal (resolvable home) path does **no** filesystem I/O.

## Relationship to Issue 5

Subsystem constructors still take explicit roots (the Issue-5 no-implicit-fallback contract is unchanged); this only hardens the path helpers themselves.

## Testing

- New `tests/test_paths.py` (incl. the security/ownership cases); full suite green (2763 passed).
- Reviewed with `/code-review --fix` + 4 rounds of codex review (final: clean).

🤖 Generated with [Claude Code](https://claude.com/claude-code)