### PR TITLE
feat(acp): session/set_mode uses standard modeId, accepts unknown values (PR-5, B2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,23 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Changed
+
+- **ACP `session/set_mode` uses the standard `modeId` field and accepts
+  unknown values.** The ACP-standard field is `modeId` (not the pre-existing
+  non-standard `mode`), and a `modeId` is a UI/behavioural selector that need
+  not be an Agentao permission preset. The handler now reads `modeId`, applies
+  a `PermissionEngine` preset **only** on an exact match (`read-only` /
+  `workspace-write` / `full-access` / `plan`), and **persists + echoes** any
+  other value without changing permission posture — so a client mode like
+  DeepChat's `code` / `ask` round-trips instead of being rejected with
+  `-32602`. A non-preset `modeId` needs no permission engine; a recognized
+  preset still does. `AcpSessionSetModeRequest.modeId` /
+  `AcpSessionSetModeResponse.modeId` are now open strings (snapshot
+  `docs/schema/host.acp.v1.json` bumped). The permission-axis split and
+  `availableModes` / `currentModeId` + `current_mode_update` remain deferred
+  to their own design.
+
 ### Fixed
 
 - **Silence jieba's `SyntaxWarning` noise on first Chinese-text recall.**

--- a/agentao/acp/models.py
+++ b/agentao/acp/models.py
@@ -207,6 +207,11 @@ class AcpSessionState:
     #: provider" (``LLM_PROVIDER`` env). A ``provider/model`` switch sets it;
     #: model-only switches leave it untouched (the provider is preserved).
     provider_id: Optional[str] = None
+    #: The ACP ``modeId`` the client last set (``session/set_mode``). Persisted
+    #: even when it does not map to an Agentao permission preset, so a client
+    #: UI mode that has no permission meaning (e.g. DeepChat's ``code`` /
+    #: ``ask``) round-trips instead of being rejected. ``None`` until first set.
+    mode_id: Optional[str] = None
     closed: bool = False
 
     def close(self) -> None:

--- a/agentao/acp/schema.py
+++ b/agentao/acp/schema.py
@@ -426,24 +426,25 @@ class AcpAgentaoSetModelResponse(BaseModel):
 class AcpSessionSetModeRequest(BaseModel):
     """``session/set_mode`` request params.
 
-    ``mode`` is constrained to the PermissionMode values the runtime
-    actually accepts; ``handle_session_set_mode`` parses any other
-    string into a ``-32602`` error, so the schema must reflect the
-    closed set or schema-following clients would generate requests
-    that fail at runtime. New presets require both a runtime change
-    and a snapshot bump (a load-bearing pairing).
+    The field is the ACP-standard ``modeId`` (not ``mode``), and it is an
+    **open string**, not a closed enum: a ``modeId`` is a UI/behavioural
+    selector that need not map to an Agentao permission preset. The handler
+    applies a permission preset only on an exact match
+    (``read-only`` / ``workspace-write`` / ``full-access`` / ``plan``) and
+    otherwise persists the value unchanged — so a client mode like ``code`` /
+    ``ask`` round-trips instead of being rejected.
     """
 
     sessionId: str
-    mode: Literal["read-only", "workspace-write", "full-access", "plan"]
+    modeId: str = Field(min_length=1)
 
     model_config = ConfigDict(extra="forbid")
 
 
 class AcpSessionSetModeResponse(BaseModel):
-    """The active mode after the update — confirms which preset is live."""
+    """The active ``modeId`` after the update (echoes the persisted value)."""
 
-    mode: Literal["read-only", "workspace-write", "full-access", "plan"]
+    modeId: str
 
     model_config = ConfigDict(extra="forbid")
 

--- a/agentao/acp/session_set_mode.py
+++ b/agentao/acp/session_set_mode.py
@@ -1,15 +1,31 @@
 """ACP ``session/set_mode`` handler.
 
-Updates a session's permission preset by calling
-``agent.permission_engine.set_mode(...)``. Per-session — each session owns
-its own ``PermissionEngine``, so a mode change on session A never affects
-session B.
+The ACP-standard field is ``modeId`` (not ``mode``), and a ``modeId`` is a
+free-form UI/behavioural selector — not necessarily an Agentao permission
+preset. This handler therefore:
+
+  - reads ``modeId`` (the standard field name);
+  - **accepts unknown values** — a ``modeId`` that does not match an Agentao
+    :class:`~agentao.permissions.PermissionMode` (e.g. DeepChat's ``code`` /
+    ``ask``) is persisted on the session and echoed back, *without* changing
+    permission posture, rather than being rejected;
+  - maps to a permission preset **only on an exact match**, calling
+    ``permission_engine.set_mode(...)``.
+
+Deferred (their own design — see the patch-revision doc): splitting the
+permission axis from the UI mode axis, and advertising ``availableModes`` /
+``currentModeId`` + the ``current_mode_update`` notification. This PR is the
+minimal field rename + accept-unknown so a DeepChat-style client is not
+rejected.
+
+Per-session: each session owns its own ``PermissionEngine``, so a preset
+change on session A never affects session B.
 """
 
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Any, Dict, Optional
 
 from agentao.permissions import PermissionMode
 
@@ -23,31 +39,51 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-def _parse_mode(value: Any) -> PermissionMode:
+def _parse_mode_id(value: Any) -> str:
     if not isinstance(value, str) or not value:
-        raise TypeError("session/set_mode.mode must be a non-empty string")
+        raise TypeError("session/set_mode.modeId must be a non-empty string")
+    return value
+
+
+def _as_permission_mode(mode_id: str) -> Optional[PermissionMode]:
+    """Return the matching preset, or ``None`` for a non-preset modeId."""
     try:
-        return PermissionMode(value)
+        return PermissionMode(mode_id)
     except ValueError:
-        valid = ", ".join(sorted(m.value for m in PermissionMode))
-        raise TypeError(f"session/set_mode.mode must be one of: {valid}")
+        return None
 
 
 def handle_session_set_mode(server: "AcpServer", params: Any) -> Dict[str, Any]:
     session = require_active_session(server, params, METHOD_SESSION_SET_MODE)
-    mode = _parse_mode(params.get("mode"))
+    mode_id = _parse_mode_id(params.get("modeId"))
 
-    if session.agent.permission_engine is None:
-        raise JsonRpcHandlerError(
-            code=INVALID_REQUEST,
-            message=f"session {session.session_id} has no permission engine to update",
-        )
+    preset = _as_permission_mode(mode_id)
 
     # Hold turn_lock so an in-flight tool call cannot consult the engine
     # mid-decision while we swap the active preset.
     with hold_idle_turn_lock(session, METHOD_SESSION_SET_MODE):
-        session.agent.permission_engine.set_mode(mode)
-        return {"mode": session.agent.permission_engine.active_mode.value}
+        if preset is not None:
+            # A recognized preset actually changes permission posture, so an
+            # engine is required for it. Unknown modeIds need no engine — they
+            # are pure UI state we persist and echo.
+            if session.agent.permission_engine is None:
+                raise JsonRpcHandlerError(
+                    code=INVALID_REQUEST,
+                    message=(
+                        f"session {session.session_id} has no permission engine "
+                        f"to apply modeId {mode_id!r}"
+                    ),
+                )
+            session.agent.permission_engine.set_mode(preset)
+        else:
+            logger.info(
+                "acp: session %s set non-preset modeId %r (permission posture "
+                "unchanged)",
+                session.session_id,
+                mode_id,
+            )
+        session.mode_id = mode_id
+        return {"modeId": session.mode_id}
 
 
 def register(server: "AcpServer") -> None:

--- a/docs/schema/host.acp.v1.json
+++ b/docs/schema/host.acp.v1.json
@@ -1139,16 +1139,11 @@
     },
     "AcpSessionSetModeRequest": {
       "additionalProperties": false,
-      "description": "``session/set_mode`` request params.\n\n``mode`` is constrained to the PermissionMode values the runtime\nactually accepts; ``handle_session_set_mode`` parses any other\nstring into a ``-32602`` error, so the schema must reflect the\nclosed set or schema-following clients would generate requests\nthat fail at runtime. New presets require both a runtime change\nand a snapshot bump (a load-bearing pairing).",
+      "description": "``session/set_mode`` request params.\n\nThe field is the ACP-standard ``modeId`` (not ``mode``), and it is an\n**open string**, not a closed enum: a ``modeId`` is a UI/behavioural\nselector that need not map to an Agentao permission preset. The handler\napplies a permission preset only on an exact match\n(``read-only`` / ``workspace-write`` / ``full-access`` / ``plan``) and\notherwise persists the value unchanged \u2014 so a client mode like ``code`` /\n``ask`` round-trips instead of being rejected.",
       "properties": {
-        "mode": {
-          "enum": [
-            "read-only",
-            "workspace-write",
-            "full-access",
-            "plan"
-          ],
-          "title": "Mode",
+        "modeId": {
+          "minLength": 1,
+          "title": "Modeid",
           "type": "string"
         },
         "sessionId": {
@@ -1158,28 +1153,22 @@
       },
       "required": [
         "sessionId",
-        "mode"
+        "modeId"
       ],
       "title": "AcpSessionSetModeRequest",
       "type": "object"
     },
     "AcpSessionSetModeResponse": {
       "additionalProperties": false,
-      "description": "The active mode after the update \u2014 confirms which preset is live.",
+      "description": "The active ``modeId`` after the update (echoes the persisted value).",
       "properties": {
-        "mode": {
-          "enum": [
-            "read-only",
-            "workspace-write",
-            "full-access",
-            "plan"
-          ],
-          "title": "Mode",
+        "modeId": {
+          "title": "Modeid",
           "type": "string"
         }
       },
       "required": [
-        "mode"
+        "modeId"
       ],
       "title": "AcpSessionSetModeResponse",
       "type": "object"

--- a/tests/test_acp_schema.py
+++ b/tests/test_acp_schema.py
@@ -345,27 +345,33 @@ def test_session_set_model_rejects_payloads_runtime_rejects():
 
 def test_session_set_mode_round_trip():
     req = AcpSessionSetModeRequest.model_validate({
-        "sessionId": "s-1", "mode": "read-only",
+        "sessionId": "s-1", "modeId": "read-only",
     })
-    assert req.mode == "read-only"
-    resp = AcpSessionSetModeResponse.model_validate({"mode": "read-only"})
-    assert resp.mode == "read-only"
+    assert req.modeId == "read-only"
+    resp = AcpSessionSetModeResponse.model_validate({"modeId": "read-only"})
+    assert resp.modeId == "read-only"
 
 
-def test_session_set_mode_rejects_unsupported_values():
-    """Mode is constrained to the runtime's ``PermissionMode`` set;
-    arbitrary strings (including legacy/aspirational names like
-    ``acceptEdits``) must fail validation rather than silently
-    advertise a setting the runtime would reject with ``-32602``."""
-    for valid in ("read-only", "workspace-write", "full-access", "plan"):
-        AcpSessionSetModeRequest.model_validate({
-            "sessionId": "s-1", "mode": valid,
+def test_session_set_mode_accepts_open_mode_ids():
+    """``modeId`` is the ACP-standard field and an OPEN string — a UI mode
+    that has no Agentao permission meaning (DeepChat's ``code`` / ``ask``)
+    must validate, not be rejected. Permission presets are still valid
+    values; the handler applies a preset only on an exact match."""
+    for value in (
+        "read-only", "workspace-write", "full-access", "plan",  # presets
+        "code", "ask", "acceptEdits",                            # UI-only modes
+    ):
+        req = AcpSessionSetModeRequest.model_validate({
+            "sessionId": "s-1", "modeId": value,
         })
-    for invalid in ("acceptEdits", "bypassPermissions", "", "WORKSPACE_WRITE"):
-        with pytest.raises(ValidationError):
-            AcpSessionSetModeRequest.model_validate({
-                "sessionId": "s-1", "mode": invalid,
-            })
+        assert req.modeId == value
+    # Still rejects an empty modeId and the legacy ``mode`` field name.
+    with pytest.raises(ValidationError):
+        AcpSessionSetModeRequest.model_validate({"sessionId": "s-1", "modeId": ""})
+    with pytest.raises(ValidationError):
+        AcpSessionSetModeRequest.model_validate({
+            "sessionId": "s-1", "mode": "read-only",
+        })
 
 
 def test_session_list_models_round_trip_with_warning():

--- a/tests/test_acp_session_set_model.py
+++ b/tests/test_acp_session_set_model.py
@@ -238,24 +238,48 @@ class TestSetMode:
         server = make_server()
         with pytest.raises(JsonRpcHandlerError) as exc:
             acp_set_mode.handle_session_set_mode(
-                server, {"sessionId": "s", "mode": "read-only"}
+                server, {"sessionId": "s", "modeId": "read-only"}
             )
         assert exc.value.code == SERVER_NOT_INITIALIZED
 
-    def test_unknown_mode_rejected(self, make_engine):
+    def test_empty_mode_id_rejected(self, make_engine):
         server = make_initialized_server()
         agent = _FakeAgent(permission_engine=make_engine())
         _register_session(server, "s", agent)
         with pytest.raises(TypeError):
             acp_set_mode.handle_session_set_mode(
-                server, {"sessionId": "s", "mode": "yolo"}
+                server, {"sessionId": "s", "modeId": ""}
             )
+
+    def test_unknown_mode_id_accepted_without_changing_posture(self, make_engine):
+        # DeepChat-style UI modes (code/ask) are NOT permission presets — they
+        # must be accepted and echoed, not rejected, and must leave the
+        # permission posture untouched.
+        server = make_initialized_server()
+        engine = make_engine()
+        agent = _FakeAgent(permission_engine=engine)
+        _register_session(server, "s", agent)
+
+        result = acp_set_mode.handle_session_set_mode(
+            server, {"sessionId": "s", "modeId": "code"}
+        )
+        assert result == {"modeId": "code"}
+        assert engine.active_mode == PermissionMode.WORKSPACE_WRITE  # unchanged
+
+    def test_unknown_mode_id_accepted_without_engine(self):
+        # A non-preset modeId needs no permission engine — it is pure UI state.
+        server = make_initialized_server()
+        _register_session(server, "s", _FakeAgent(permission_engine=None))
+        result = acp_set_mode.handle_session_set_mode(
+            server, {"sessionId": "s", "modeId": "ask"}
+        )
+        assert result == {"modeId": "ask"}
 
     def test_unknown_session(self):
         server = make_initialized_server()
         with pytest.raises(JsonRpcHandlerError) as exc:
             acp_set_mode.handle_session_set_mode(
-                server, {"sessionId": "nope", "mode": "read-only"}
+                server, {"sessionId": "nope", "modeId": "read-only"}
             )
         assert exc.value.code == INVALID_REQUEST
 
@@ -266,10 +290,20 @@ class TestSetMode:
         _register_session(server, "s", agent)
 
         result = acp_set_mode.handle_session_set_mode(
-            server, {"sessionId": "s", "mode": "read-only"}
+            server, {"sessionId": "s", "modeId": "read-only"}
         )
-        assert result == {"mode": "read-only"}
+        assert result == {"modeId": "read-only"}
         assert engine.active_mode == PermissionMode.READ_ONLY
+
+    def test_preset_mode_requires_engine(self):
+        # A recognized preset DOES change posture, so it needs an engine.
+        server = make_initialized_server()
+        _register_session(server, "s", _FakeAgent(permission_engine=None))
+        with pytest.raises(JsonRpcHandlerError) as exc:
+            acp_set_mode.handle_session_set_mode(
+                server, {"sessionId": "s", "modeId": "read-only"}
+            )
+        assert exc.value.code == INVALID_REQUEST
 
     def test_does_not_affect_other_session(self, make_engine):
         """Critical isolation guarantee: each session owns its own
@@ -281,7 +315,7 @@ class TestSetMode:
         _register_session(server, "b", _FakeAgent(permission_engine=engine_b))
 
         acp_set_mode.handle_session_set_mode(
-            server, {"sessionId": "a", "mode": "read-only"}
+            server, {"sessionId": "a", "modeId": "read-only"}
         )
         assert engine_a.active_mode == PermissionMode.READ_ONLY
         assert engine_b.active_mode == PermissionMode.WORKSPACE_WRITE
@@ -455,7 +489,7 @@ class TestActiveTurnGuard:
         try:
             with pytest.raises(JsonRpcHandlerError) as exc:
                 acp_set_mode.handle_session_set_mode(
-                    server, {"sessionId": "s", "mode": "read-only"}
+                    server, {"sessionId": "s", "modeId": "read-only"}
                 )
             assert exc.value.code == INVALID_REQUEST
             assert "active turn" in exc.value.message

--- a/tests/test_acp_session_set_model.py
+++ b/tests/test_acp_session_set_model.py
@@ -258,12 +258,13 @@ class TestSetMode:
         server = make_initialized_server()
         engine = make_engine()
         agent = _FakeAgent(permission_engine=engine)
-        _register_session(server, "s", agent)
+        state = _register_session(server, "s", agent)
 
         result = acp_set_mode.handle_session_set_mode(
             server, {"sessionId": "s", "modeId": "code"}
         )
         assert result == {"modeId": "code"}
+        assert state.mode_id == "code"  # persisted on the session
         assert engine.active_mode == PermissionMode.WORKSPACE_WRITE  # unchanged
 
     def test_unknown_mode_id_accepted_without_engine(self):
@@ -287,12 +288,13 @@ class TestSetMode:
         server = make_initialized_server()
         engine = make_engine()
         agent = _FakeAgent(permission_engine=engine)
-        _register_session(server, "s", agent)
+        state = _register_session(server, "s", agent)
 
         result = acp_set_mode.handle_session_set_mode(
             server, {"sessionId": "s", "modeId": "read-only"}
         )
         assert result == {"modeId": "read-only"}
+        assert state.mode_id == "read-only"  # persisted on the session
         assert engine.active_mode == PermissionMode.READ_ONLY
 
     def test_preset_mode_requires_engine(self):


### PR DESCRIPTION
## Summary

PR-5 (B2) of the DeepChat ACP patch revision (`docs/design/deepchat-acp-patch-revision.md`). Minimal field rename + accept-unknown so a DeepChat-style client is not rejected.

- `session/set_mode` reads the **ACP-standard `modeId`** field (was non-standard `mode`).
- **Accepts unknown `modeId` values** — a `modeId` that doesn't match an Agentao `PermissionMode` (e.g. DeepChat's `code` / `ask`) is persisted on the session and echoed back **without** changing permission posture, rather than being rejected.
- Maps to a permission preset **only on an exact match** (preset requires the session's `PermissionEngine`); non-preset modeIds need no engine.
- Schema: `AcpSessionSetModeRequest.modeId` / response `modeId` are open strings (was a `Literal` pinned to presets).

Deferred (separate design): splitting the permission axis from the UI mode axis, and advertising `availableModes` / `currentModeId`.

## Test plan

- `tests/test_acp_session_set_model.py` + `tests/test_acp_schema.py` updated: `mode`→`modeId`, accept-unknown tests, preset-requires-engine, asserts `state.mode_id` persisted.
- Full suite green.
- code-review `--fix` (test-strengthening) + codex review clean (round 1, no issues).

> Note: shares `docs/schema/host.acp.v1.json` with PR-4 and PR-6 — sequential merges will need a snapshot regen + re-test of the merged tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)