### PR TITLE
feat(acp): advertise initialize extensions under _meta, not top-level (PR-6, B3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,22 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
   — the structured kwargs are forwarded only to callbacks whose signature
   accepts them, dropped otherwise.
 
+### Changed
+
+- **ACP `initialize` advertises extensions through `_meta`, not a top-level
+  `extensions` array.** The ACP-standard `initialize` response carries only
+  `protocolVersion` / `agentCapabilities` / `agentInfo` / `authMethods`;
+  extension data belongs under `_meta`. Agentao now returns its
+  `_agentao.cn/ask_user` advertisement under
+  `_meta["_agentao.cn/extensions"]` (vendor-namespaced so it never collides
+  with another extension's `_meta` payload) instead of the non-standard
+  top-level `extensions: [...]`. `AcpInitializeResponse` drops the
+  `extensions` field for an open `_meta` object (`AcpInitializeMeta`); the
+  schema snapshot (`docs/schema/host.acp.v1.json`) is bumped. Agentao's own
+  `acp_client` never read `extensions`, so no client code changes; a
+  schema-following host that still sends a top-level `extensions` is now
+  rejected (`extra="forbid"`).
+
 ## [0.4.7] — 2026-05-17
 
 ### Added

--- a/agentao/acp/initialize.py
+++ b/agentao/acp/initialize.py
@@ -140,12 +140,19 @@ def handle_initialize(server: "AcpServer", params: Any) -> Dict[str, Any]:
         "agentCapabilities": AGENT_CAPABILITIES,
         "authMethods": AUTH_METHODS,
         "agentInfo": AGENT_INFO,
-        "extensions": [
-            {
-                "method": METHOD_ASK_USER,
-                "description": "Request free-form text input from the user.",
-            },
-        ],
+        # ACP advertises extensions through ``_meta`` rather than a top-level
+        # ``extensions`` array (the standard fields are protocolVersion /
+        # agentCapabilities / agentInfo / authMethods). We namespace the
+        # extension list under the vendor key ``_agentao.cn/extensions`` so it
+        # never collides with another extension's ``_meta`` payload.
+        "_meta": {
+            "_agentao.cn/extensions": [
+                {
+                    "method": METHOD_ASK_USER,
+                    "description": "Request free-form text input from the user.",
+                },
+            ],
+        },
     }
 
 

--- a/agentao/acp/schema.py
+++ b/agentao/acp/schema.py
@@ -99,6 +99,23 @@ class AcpInitializeExtension(BaseModel):
     model_config = ConfigDict(extra="allow")
 
 
+class AcpInitializeMeta(BaseModel):
+    """The ``_meta`` object on the ``initialize`` response.
+
+    ACP advertises extensions through ``_meta`` rather than a top-level
+    ``extensions`` array, so ``handle_initialize`` namespaces its extension
+    list under the vendor key ``_agentao.cn/extensions``. The object is open
+    (extra="allow") so other extensions can attach their own namespaced
+    payloads to the same ``_meta`` without breaking schema-following clients.
+    """
+
+    agentao_extensions: List[AcpInitializeExtension] = Field(
+        default_factory=list, alias="_agentao.cn/extensions"
+    )
+
+    model_config = ConfigDict(extra="allow", populate_by_name=True)
+
+
 class AcpInitializeResponse(BaseModel):
     """``initialize`` response result."""
 
@@ -106,13 +123,14 @@ class AcpInitializeResponse(BaseModel):
     agentCapabilities: AcpAgentCapabilities
     authMethods: List[Dict[str, Any]] = Field(default_factory=list)
     agentInfo: AcpAgentInfo
-    # ``handle_initialize`` returns an ``extensions`` array advertising
-    # ``_agentao.cn/ask_user`` (and any future runtime extensions).
-    # Without this field, schema-following hosts would reject every
-    # successful initialize response that includes the extension list.
-    extensions: List[AcpInitializeExtension] = Field(default_factory=list)
+    # ``handle_initialize`` advertises ``_agentao.cn/ask_user`` (and any future
+    # runtime extensions) through ``_meta._agentao.cn/extensions`` — ACP's
+    # standard channel for extension data — rather than a non-standard
+    # top-level ``extensions`` array. Without this field, schema-following
+    # hosts would reject every successful initialize response.
+    meta: Optional[AcpInitializeMeta] = Field(default=None, alias="_meta")
 
-    model_config = ConfigDict(extra="forbid")
+    model_config = ConfigDict(extra="forbid", populate_by_name=True)
 
 
 # ---------------------------------------------------------------------------
@@ -750,6 +768,7 @@ __all__ = [
     "AcpConfigOptionChoice",
     "AcpError",
     "AcpInitializeExtension",
+    "AcpInitializeMeta",
     "AcpInitializeRequest",
     "AcpInitializeResponse",
     "AcpMcpEnvVar",

--- a/agentao/acp/schema.py
+++ b/agentao/acp/schema.py
@@ -113,7 +113,10 @@ class AcpInitializeMeta(BaseModel):
         default_factory=list, alias="_agentao.cn/extensions"
     )
 
-    model_config = ConfigDict(extra="allow", populate_by_name=True)
+    # Alias-only: the wire key is ``_agentao.cn/extensions``; the Python field
+    # name is never an accepted input key (no ``populate_by_name``), so the
+    # validation surface stays identical to the published JSON Schema.
+    model_config = ConfigDict(extra="allow")
 
 
 class AcpInitializeResponse(BaseModel):
@@ -130,7 +133,10 @@ class AcpInitializeResponse(BaseModel):
     # hosts would reject every successful initialize response.
     meta: Optional[AcpInitializeMeta] = Field(default=None, alias="_meta")
 
-    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    # Alias-only (no ``populate_by_name``): only the wire key ``_meta`` is an
+    # accepted input key, so ``extra="forbid"`` is not weakened by also
+    # accepting the bare field name ``meta`` — the handler never emits it.
+    model_config = ConfigDict(extra="forbid")
 
 
 # ---------------------------------------------------------------------------

--- a/docs/features/acp-client.md
+++ b/docs/features/acp-client.md
@@ -173,7 +173,7 @@ ACP interactions: 1 pending
 
 ## ACP Extension: `_agentao.cn/ask_user`
 
-Agentao supports a private ACP extension method `_agentao.cn/ask_user` for requesting free-form text input from the user. This is advertised in the `initialize` response's `extensions` array.
+Agentao supports a private ACP extension method `_agentao.cn/ask_user` for requesting free-form text input from the user. This is advertised in the `initialize` response under `_meta["_agentao.cn/extensions"]` (ACP's standard channel for extension data).
 
 ### Request
 

--- a/docs/schema/host.acp.v1.json
+++ b/docs/schema/host.acp.v1.json
@@ -469,6 +469,21 @@
       "title": "AcpInitializeExtension",
       "type": "object"
     },
+    "AcpInitializeMeta": {
+      "additionalProperties": true,
+      "description": "The ``_meta`` object on the ``initialize`` response.\n\nACP advertises extensions through ``_meta`` rather than a top-level\n``extensions`` array, so ``handle_initialize`` namespaces its extension\nlist under the vendor key ``_agentao.cn/extensions``. The object is open\n(extra=\"allow\") so other extensions can attach their own namespaced\npayloads to the same ``_meta`` without breaking schema-following clients.",
+      "properties": {
+        "_agentao.cn/extensions": {
+          "items": {
+            "$ref": "#/$defs/AcpInitializeExtension"
+          },
+          "title": "Agentao.Cn/Extensions",
+          "type": "array"
+        }
+      },
+      "title": "AcpInitializeMeta",
+      "type": "object"
+    },
     "AcpInitializeRequest": {
       "additionalProperties": false,
       "description": "``initialize`` request params (one handshake per stdio connection).",
@@ -503,6 +518,17 @@
       "additionalProperties": false,
       "description": "``initialize`` response result.",
       "properties": {
+        "_meta": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/AcpInitializeMeta"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        },
         "agentCapabilities": {
           "$ref": "#/$defs/AcpAgentCapabilities"
         },
@@ -515,13 +541,6 @@
             "type": "object"
           },
           "title": "Authmethods",
-          "type": "array"
-        },
-        "extensions": {
-          "items": {
-            "$ref": "#/$defs/AcpInitializeExtension"
-          },
-          "title": "Extensions",
           "type": "array"
         },
         "protocolVersion": {

--- a/tests/test_acp_ask_user.py
+++ b/tests/test_acp_ask_user.py
@@ -151,6 +151,8 @@ class TestCapabilityAdvertisement:
             "clientCapabilities": {},
         })
 
-        assert "extensions" in result
-        ext = result["extensions"]
+        # Extensions are advertised through ``_meta`` (ACP's standard channel),
+        # namespaced under the vendor key — not a top-level ``extensions`` array.
+        assert "extensions" not in result
+        ext = result["_meta"]["_agentao.cn/extensions"]
         assert any(e["method"] == METHOD_ASK_USER for e in ext)

--- a/tests/test_acp_schema.py
+++ b/tests/test_acp_schema.py
@@ -99,10 +99,11 @@ def test_initialize_request_round_trip():
 
 
 def test_initialize_response_round_trip():
-    """The runtime returns ``extensions`` (advertising
-    ``_agentao.cn/ask_user``) on the initialize response. The schema
-    must accept it — pre-fix, ``extra="forbid"`` rejected the field
-    and any host validating the response saw every successful
+    """The runtime advertises ``_agentao.cn/ask_user`` through
+    ``_meta._agentao.cn/extensions`` — ACP's standard channel for
+    extension data — not a non-standard top-level ``extensions`` array.
+    The schema must accept the ``_meta`` object; pre-fix ``extra="forbid"``
+    rejected it and any host validating the response saw every successful
     handshake as malformed."""
     resp = AcpInitializeResponse.model_validate({
         "protocolVersion": 1,
@@ -113,16 +114,42 @@ def test_initialize_response_round_trip():
         },
         "authMethods": [],
         "agentInfo": {"name": "agentao", "version": "0.3.1.dev0"},
-        "extensions": [
-            {
-                "method": "_agentao.cn/ask_user",
-                "description": "Request free-form text input from the user.",
-            },
-        ],
+        "_meta": {
+            "_agentao.cn/extensions": [
+                {
+                    "method": "_agentao.cn/ask_user",
+                    "description": "Request free-form text input from the user.",
+                },
+            ],
+        },
     })
     assert resp.agentInfo.name == "agentao"
-    assert len(resp.extensions) == 1
-    assert resp.extensions[0].method == "_agentao.cn/ask_user"
+    assert resp.meta is not None
+    assert len(resp.meta.agentao_extensions) == 1
+    assert resp.meta.agentao_extensions[0].method == "_agentao.cn/ask_user"
+
+
+def test_initialize_response_rejects_top_level_extensions():
+    """The non-standard top-level ``extensions`` array is gone: with
+    ``extra="forbid"`` a payload that still carries it is rejected, so a
+    client cannot keep relying on the old shape."""
+    import pytest
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        AcpInitializeResponse.model_validate({
+            "protocolVersion": 1,
+            "agentCapabilities": {
+                "loadSession": True,
+                "promptCapabilities": {"image": True, "audio": False, "embeddedContext": False},
+                "mcpCapabilities": {"http": False, "sse": True},
+            },
+            "authMethods": [],
+            "agentInfo": {"name": "agentao", "version": "0.3.1.dev0"},
+            "extensions": [
+                {"method": "_agentao.cn/ask_user"},
+            ],
+        })
 
 
 def test_session_new_validates_mcp_server_discriminator():

--- a/tests/test_acp_schema.py
+++ b/tests/test_acp_schema.py
@@ -152,6 +152,34 @@ def test_initialize_response_rejects_top_level_extensions():
         })
 
 
+def test_initialize_response_meta_is_alias_only():
+    """``_meta`` is the only accepted input key — the bare Python field name
+    ``meta`` is rejected (no ``populate_by_name``), so the validation surface
+    matches the published JSON Schema exactly and ``extra="forbid"`` is not
+    weakened by silently accepting an off-spec ``meta`` key."""
+    import pytest
+    from pydantic import ValidationError
+
+    base = {
+        "protocolVersion": 1,
+        "agentCapabilities": {
+            "loadSession": True,
+            "promptCapabilities": {"image": True, "audio": False, "embeddedContext": False},
+            "mcpCapabilities": {"http": False, "sse": True},
+        },
+        "authMethods": [],
+        "agentInfo": {"name": "agentao", "version": "0.3.1.dev0"},
+    }
+    # The wire alias is accepted.
+    ok = AcpInitializeResponse.model_validate(
+        {**base, "_meta": {"_agentao.cn/extensions": []}}
+    )
+    assert ok.meta is not None
+    # The bare field name is not — it is off-spec and the handler never emits it.
+    with pytest.raises(ValidationError):
+        AcpInitializeResponse.model_validate({**base, "meta": {}})
+
+
 def test_session_new_validates_mcp_server_discriminator():
     req = AcpSessionNewRequest.model_validate({
         "cwd": "/tmp/proj",


### PR DESCRIPTION
## Summary

PR-6 (B3) of the DeepChat ACP patch revision (`docs/design/deepchat-acp-patch-revision.md`). Spec-clean: move the `initialize` extension advertisement off a non-standard top-level array and into ACP's standard `_meta` channel.

- The ACP-standard `initialize` response carries only `protocolVersion` / `agentCapabilities` / `agentInfo` / `authMethods`; extension data belongs under `_meta`.
- `_agentao.cn/ask_user` is now advertised under `_meta["_agentao.cn/extensions"]` (vendor-namespaced so it never collides with another extension's `_meta` payload) instead of the non-standard top-level `extensions: [...]`.
- Schema: new alias-only `AcpInitializeMeta` (`extra="allow"`); `AcpInitializeResponse` drops `extensions` for `meta` (alias `_meta`), still `extra="forbid"`. Validation is alias-only (no `populate_by_name`) so the surface matches the published JSON Schema exactly.
- agentao's own `acp_client` never read `extensions` (0 refs), so no client code changes; a host that still sends top-level `extensions` is now rejected.

## Test plan

- `tests/test_acp_schema.py` + `tests/test_acp_ask_user.py` updated: assert the `_meta` shape, top-level `extensions` rejected, `_meta` is alias-only.
- Full suite green (2795 passed, 2 skipped); schema snapshot `docs/schema/host.acp.v1.json` regenerated.
- code-review `--fix` (alias-only tightening + stale doc fix) + codex review clean (round 1, no issues).

> Note: shares `docs/schema/host.acp.v1.json` with PR-4 and PR-5 — sequential merges will need a snapshot regen + re-test of the merged tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)