### PR TITLE
feat(llm): fall back to text image references when a model rejects image input

### DIFF
--- a/agentao/cli/commands/image.py
+++ b/agentao/cli/commands/image.py
@@ -147,6 +147,7 @@ def handle_image_command(cli: "AgentaoCLI", args: str) -> None:
         "data": data,
         "mimeType": mime_type,
         "_label": path.name,
+        "_source": str(path),
     })
     console.print(
         f"\n[green]✓ Staged image: {path.name}[/green] "

--- a/agentao/cli/input_loop.py
+++ b/agentao/cli/input_loop.py
@@ -411,7 +411,11 @@ def run_loop(cli: "AgentaoCLI") -> None:
             images = None
             if cli._staged_images:
                 images = [
-                    {"data": img["data"], "mimeType": img["mimeType"]}
+                    {
+                        "data": img["data"],
+                        "mimeType": img["mimeType"],
+                        "_source": img.get("_source") or img.get("_label", "image"),
+                    }
                     for img in cli._staged_images
                 ]
 

--- a/agentao/llm/_retry.py
+++ b/agentao/llm/_retry.py
@@ -137,6 +137,35 @@ def _is_temperature_unsupported(err_str: str) -> bool:
     )
 
 
+def _is_image_unsupported(err_str: str) -> bool:
+    """True when an error says the model rejects image / vision input."""
+    s = err_str.lower()
+    provider_multimodal_rejections = (
+        "unexpected item type in content" in s
+        or ("unknown variant image_url" in s and "expected text" in s)
+    )
+    if provider_multimodal_rejections:
+        return True
+    image_mentioned = (
+        "image_url" in s
+        or "image input" in s
+        or "image inputs" in s
+        or "images" in s
+        or "vision" in s
+        or "multimodal" in s
+    )
+    if not image_mentioned:
+        return False
+    return (
+        "does not support" in s
+        or "do not support" in s
+        or "not supported" in s
+        or "unsupported" in s
+        or "only supported" in s
+        or "invalid content type" in s
+    )
+
+
 def _compute_backoff_delay(attempt: int, retry_after_header: Optional[str] = None) -> float:
     """Compute the next sleep duration. Honors ``Retry-After`` when present."""
     parsed = _parse_retry_after(retry_after_header)

--- a/agentao/runtime/chat_loop/_runner.py
+++ b/agentao/runtime/chat_loop/_runner.py
@@ -21,6 +21,7 @@ from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
 from ...cancellation import AgentCancelledError, CancellationToken
 from ...context_manager import is_context_too_long_error
+from ...llm._retry import _is_image_unsupported
 from ...transport import AgentEvent, EventType
 from ..sanitize import canonicalize_tool_arguments, sanitize_assistant_message
 from ._compaction import _CompactionMixin
@@ -146,6 +147,8 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
             return hook_outcome.early_return
         user_message = hook_outcome.user_message
 
+        image_fallback_text: Optional[str] = None
+        image_fallback_index: Optional[int] = None
         if images:
             # Multimodal turn: emit OpenAI-style content parts (text +
             # image_url). The base64 data rides on the wire here; the LLM
@@ -178,6 +181,12 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
                     "type": "image_url",
                     "image_url": {"url": data_url},
                 })
+            image_fallback_text = (
+                system_reminder
+                + user_message
+                + self._render_image_reference_fallback(images)
+            )
+            image_fallback_index = len(agent.messages)
             agent.add_message("user", content)
         else:
             agent.add_message("user", system_reminder + user_message)
@@ -240,7 +249,12 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
             agent.transport.emit(AgentEvent(EventType.TURN_START, {}))
 
             llm_outcome = self._call_llm_with_overflow_recovery(
-                messages_with_system, system_prompt, tools, token,
+                messages_with_system,
+                system_prompt,
+                tools,
+                token,
+                image_fallback_text=image_fallback_text if iteration == 1 else None,
+                image_fallback_index=image_fallback_index if iteration == 1 else None,
             )
             if llm_outcome.error_return is not None:
                 return llm_outcome.error_return
@@ -683,6 +697,8 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
         system_prompt: str,
         tools: list,
         token: CancellationToken,
+        image_fallback_text: Optional[str] = None,
+        image_fallback_index: Optional[int] = None,
     ) -> "ChatLoopRunner._LlmOutcome":
         agent = self._agent
         try:
@@ -693,6 +709,26 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
                 system_prompt=system_prompt,
             )
         except Exception as e:
+            if image_fallback_text and _is_image_unsupported(str(e)):
+                agent.llm.logger.info(
+                    "Model rejected image input; retrying with image references as text"
+                )
+                self._replace_image_message_for_fallback(
+                    image_fallback_text,
+                    image_fallback_index,
+                )
+                messages_with_system = [
+                    {"role": "system", "content": system_prompt}
+                ] + agent.messages
+                try:
+                    response = agent._llm_call(messages_with_system, tools, token)
+                    return ChatLoopRunner._LlmOutcome(
+                        response=response,
+                        messages_with_system=messages_with_system,
+                        system_prompt=system_prompt,
+                    )
+                except Exception as fallback_e:
+                    e = fallback_e
             if not is_context_too_long_error(e):
                 err_msg = f"[LLM API error: {e}]"
                 agent.llm.logger.error(f"LLM call failed: {e}")
@@ -765,6 +801,63 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
                     agent.llm.logger.error(f"LLM call failed after compression: {e2}")
                     agent.messages.append({"role": "assistant", "content": err_msg})
                     return ChatLoopRunner._LlmOutcome(error_return=err_msg)
+
+    # ------------------------------------------------------------------
+    # Image fallback helpers
+    # ------------------------------------------------------------------
+
+    def _render_image_reference_fallback(self, images: List[Dict[str, str]]) -> str:
+        refs = []
+        for i, img in enumerate(images, 1):
+            source = (
+                img.get("_source")
+                or img.get("url")
+                or img.get("path")
+                or img.get("_label")
+                or f"inline image {i}"
+            )
+            mime_type = img.get("mimeType")
+            refs.append(f"- {source}" + (f" ({mime_type})" if mime_type else ""))
+        return (
+            "\n\n[Image attachments could not be sent because the selected "
+            "model does not support image input. The available image "
+            "references are:]\n"
+            + "\n".join(refs)
+        )
+
+    def _replace_image_message_for_fallback(
+        self,
+        fallback_text: str,
+        preferred_index: Optional[int],
+    ) -> None:
+        agent = self._agent
+        if (
+            preferred_index is not None
+            and 0 <= preferred_index < len(agent.messages)
+            and self._message_has_image_content(agent.messages[preferred_index])
+        ):
+            agent.messages[preferred_index] = {
+                "role": "user",
+                "content": fallback_text,
+            }
+            return
+
+        for i in range(len(agent.messages) - 1, -1, -1):
+            if self._message_has_image_content(agent.messages[i]):
+                agent.messages[i] = {"role": "user", "content": fallback_text}
+                return
+
+    @staticmethod
+    def _message_has_image_content(message: Dict[str, Any]) -> bool:
+        if message.get("role") != "user":
+            return False
+        content = message.get("content")
+        if not isinstance(content, list):
+            return False
+        return any(
+            isinstance(part, dict) and part.get("type") == "image_url"
+            for part in content
+        )
 
     # ------------------------------------------------------------------
     # Skill / memory diff replay events

--- a/tests/support/stop_precompact.py
+++ b/tests/support/stop_precompact.py
@@ -136,7 +136,9 @@ def make_runner_with_stub_llm(
     )
     monkeypatch.setattr(
         runner, "_call_llm_with_overflow_recovery",
-        lambda m, s, t, k: fake_outcome,
+        # Accept **kw so the stub tolerates optional kwargs the real method
+        # takes (e.g. image_fallback_text / image_fallback_index).
+        lambda m, s, t, k, **kw: fake_outcome,
     )
     monkeypatch.setattr(agent, "_build_system_prompt", lambda: "")
     agent.skill_manager = MagicMock()

--- a/tests/test_chat_images.py
+++ b/tests/test_chat_images.py
@@ -6,6 +6,7 @@ with an inline ``data:`` URL), and that a plain text turn is unchanged.
 """
 
 from pathlib import Path
+from types import SimpleNamespace
 from unittest.mock import MagicMock, Mock, patch
 
 
@@ -25,6 +26,7 @@ def _stub_llm(agent):
     fake_response.choices[0].message.content = "ok"
     fake_response.choices[0].message.reasoning_content = None
     agent._llm_call = Mock(return_value=fake_response)
+    return fake_response
 
 
 def test_images_become_multimodal_content():
@@ -86,6 +88,66 @@ def test_empty_image_data_raises_clear_error():
     # Empty data would build a malformed `data:...;base64,` URL — reject it.
     with pytest.raises(ValueError, match="non-empty"):
         agent.chat("hi", images=[{"mimeType": "image/png", "data": ""}])
+
+
+def test_image_unsupported_falls_back_to_text_reference():
+    agent = _make_agent()
+    fake_response = _stub_llm(agent)
+    agent._llm_call = Mock(side_effect=[
+        ValueError("Invalid content type. image_url is only supported by vision models"),
+        fake_response,
+    ])
+
+    response = agent.chat(
+        "describe this",
+        images=[{
+            "mimeType": "image/png",
+            "data": "QUJD",
+            "_source": "/tmp/shot.png",
+        }],
+    )
+
+    assert response == "ok"
+    assert agent._llm_call.call_count == 2
+    user_msgs = [m for m in agent.messages if m["role"] == "user"]
+    assert user_msgs
+    content = user_msgs[0]["content"]
+    assert isinstance(content, str)
+    assert "describe this" in content
+    assert "/tmp/shot.png (image/png)" in content
+    assert "data:image/png;base64" not in content
+
+
+def test_image_fallback_replaces_image_message_before_background_note():
+    agent = _make_agent()
+    fake_response = _stub_llm(agent)
+    agent.bg_store = SimpleNamespace(
+        drain_notifications=Mock(return_value=["background finished"])
+    )
+    agent._llm_call = Mock(side_effect=[
+        ValueError("Unexpected item type in content."),
+        fake_response,
+    ])
+
+    response = agent.chat(
+        "describe this",
+        images=[{
+            "mimeType": "image/png",
+            "data": "QUJD",
+            "_source": "/tmp/shot.png",
+        }],
+    )
+
+    assert response == "ok"
+    assert agent._llm_call.call_count == 2
+
+    retry_messages = agent._llm_call.call_args_list[1].args[0]
+    retry_user_contents = [
+        msg["content"] for msg in retry_messages if msg.get("role") == "user"
+    ]
+    assert not any(isinstance(content, list) for content in retry_user_contents)
+    assert any("/tmp/shot.png (image/png)" in content for content in retry_user_contents)
+    assert any("background finished" in content for content in retry_user_contents)
 
 
 def test_arun_forwards_images():

--- a/tests/test_hooks_stop_doom_loop_no_double_dispatch.py
+++ b/tests/test_hooks_stop_doom_loop_no_double_dispatch.py
@@ -72,7 +72,9 @@ def test_doom_loop_dispatches_stop_exactly_once(tmp_path, monkeypatch):
     monkeypatch.setattr(
         runner,
         "_call_llm_with_overflow_recovery",
-        lambda m, s, t, k: fake_outcome,
+        # Accept **kw so the stub tolerates optional kwargs the real method
+        # takes (e.g. image_fallback_text / image_fallback_index).
+        lambda m, s, t, k, **kw: fake_outcome,
     )
 
     agent.tool_runner = MagicMock()

--- a/tests/test_llm_client_retry.py
+++ b/tests/test_llm_client_retry.py
@@ -18,7 +18,7 @@ import openai
 import pytest
 
 from agentao.llm import client as client_mod
-from agentao.llm._retry import _is_temperature_unsupported
+from agentao.llm._retry import _is_image_unsupported, _is_temperature_unsupported
 from agentao.llm.client import (
     LLMClient,
     MAX_RETRY_ATTEMPTS,
@@ -112,6 +112,26 @@ class TestIsTemperatureUnsupported:
     ])
     def test_non_rejection_messages_do_not_match(self, msg):
         assert _is_temperature_unsupported(msg) is False
+
+
+class TestIsImageUnsupported:
+    @pytest.mark.parametrize("msg", [
+        "Invalid content type. image_url is only supported by vision models",
+        "InternalError.Algo.InvalidParameter: The provided messages input is invalid. "
+        "The error info is [Unexpected item type in content.].",
+        "Failed to deserialize the JSON body into the target type: messages[1]: "
+        "unknown variant image_url, expected text at line 1 column 34878",
+    ])
+    def test_rejection_messages_match(self, msg):
+        assert _is_image_unsupported(msg) is True
+
+    @pytest.mark.parametrize("msg", [
+        "rate limit exceeded",
+        "invalid text content",
+        "unknown variant tool_call, expected text",
+    ])
+    def test_non_rejection_messages_do_not_match(self, msg):
+        assert _is_image_unsupported(msg) is False
 
 
 class TestClassifyRetry:


### PR DESCRIPTION
## Summary

When a multimodal turn is sent to a model that doesn't support image input, the LLM call fails outright and the user's whole turn is lost. This adds an automatic, transparent fallback: on a vision-rejection error, the turn is retried once with the images rendered as text references instead of inline `image_url` parts.

- `agentao/llm/_retry.py`: new `_is_image_unsupported(err_str)` — detects provider vision-rejection errors (e.g. "unexpected item type in content", "does not support image input", "unknown variant image_url", "vision not supported", …).
- `agentao/runtime/chat_loop/_runner.py`: on the first iteration, when the multimodal LLM call raises and the error matches `_is_image_unsupported`, the image-bearing user message is replaced in-place with a text-only version (`_replace_image_message_for_fallback`) whose body lists the image references (`_render_image_reference_fallback` — uses `_source` / `url` / `path` / `_label` / index, plus mimeType when present), then the call is retried once. Other errors fall through to the existing overflow/context-length recovery path unchanged.
- `agentao/cli/commands/image.py` + `agentao/cli/input_loop.py`: carry an image source/label so the fallback text can name each attachment.

Text-only turns and models that *do* accept images are completely unaffected — the fallback only triggers on a genuine image-rejection error.

## Test plan

- `tests/test_chat_images.py`: fallback path (image-rejection → text retry succeeds), source/label rendering, no-fallback when the model accepts images.
- `tests/test_llm_client_retry.py`: `_is_image_unsupported` matcher (positive provider strings + negative non-image errors).
- 63 tests pass on a clean `main` base.

> History note: this commit was originally authored on top of the PR-4 branch by accident; it has been cherry-picked clean onto `origin/main` here so it stands alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)