### PR TITLE
docs(acp): sync ACP docs for PR-4/PR-6 wire changes

### DIFF
--- a/developer-guide/en/appendix/c-acp-messages.md
+++ b/developer-guide/en/appendix/c-acp-messages.md
@@ -27,7 +27,7 @@ Handshake. MUST be first call.
 | `agentCapabilities` | `object` | See below |
 | `authMethods` | `[]` | Empty in v1 — Agentao does no ACP-level auth |
 | `agentInfo` | `object` | `{name: "agentao", title: "Agentao", version}` |
-| `extensions` | `[{method, description}]` | Vendor methods; includes `_agentao.cn/ask_user` |
+| `_meta["_agentao.cn/extensions"]` | `[{method, description}]` | Vendor methods advertised under `_meta` (ACP's standard extension channel); includes `_agentao.cn/ask_user` |
 
 ### `agentCapabilities` block (v0.2.x)
 
@@ -68,6 +68,7 @@ Create a fresh session.
 | Field | Type | Notes |
 |-------|------|-------|
 | `sessionId` | `string` | UUID. Keep it — needed for every subsequent call |
+| `configOptions` | `[object]` | Model/provider selection options (`configId: "model"`); drive a switch via `session/set_config_option`. Empty list if the agent can't enumerate a catalog |
 
 ### Common failures
 
@@ -182,7 +183,7 @@ Resume a session by id. Only usable when the agent advertises `loadSession: true
 
 ### ← Response
 
-Empty object. The agent replays prior turns as `session/update` notifications (reconstructed from persisted history) before it's ready for the next `session/prompt`.
+`{configOptions: [...]}` — the same model/provider selection options as `session/new` (empty list if no catalog). The agent also replays prior turns as `session/update` notifications (reconstructed from persisted history) before it's ready for the next `session/prompt`.
 
 ### Fingerprint rule
 

--- a/developer-guide/en/part-3/1-acp-tour.md
+++ b/developer-guide/en/part-3/1-acp-tour.md
@@ -166,7 +166,7 @@ sequenceDiagram
 
 ## Extension: `_agentao.cn/ask_user`
 
-The base spec only lets the server **request permission** — it does not let the server ask the user a free-form question. Agentao advertises a private extension method `_agentao.cn/ask_user` in the `extensions` field to do exactly that. Client options:
+The base spec only lets the server **request permission** — it does not let the server ask the user a free-form question. Agentao advertises a private extension method `_agentao.cn/ask_user` under `_meta["_agentao.cn/extensions"]` (ACP's standard extension channel) to do exactly that. Client options:
 
 - Implement it: prompt the user, return the answer string
 - Don't implement: the agent falls back to `"[ask_user: not available in non-interactive mode]"`

--- a/developer-guide/en/part-3/2-agentao-as-server.md
+++ b/developer-guide/en/part-3/2-agentao-as-server.md
@@ -82,12 +82,14 @@ agentao --acp --stdio
       "title": "Agentao",
       "version": "0.2.14"
     },
-    "extensions": [
-      {
-        "method": "_agentao.cn/ask_user",
-        "description": "Request free-form text input from the user."
-      }
-    ]
+    "_meta": {
+      "_agentao.cn/extensions": [
+        {
+          "method": "_agentao.cn/ask_user",
+          "description": "Request free-form text input from the user."
+        }
+      ]
+    }
   }
 }
 ```

--- a/developer-guide/zh/appendix/c-acp-messages.md
+++ b/developer-guide/zh/appendix/c-acp-messages.md
@@ -27,7 +27,7 @@ Agentao 的 ACP 服务器/客户端发出的每种消息的字段级速查。端
 | `agentCapabilities` | `object` | 见下 |
 | `authMethods` | `[]` | v1 为空——Agentao 不做 ACP 级认证 |
 | `agentInfo` | `object` | `{name: "agentao", title: "Agentao", version}` |
-| `extensions` | `[{method, description}]` | 扩展方法；含 `_agentao.cn/ask_user` |
+| `_meta["_agentao.cn/extensions"]` | `[{method, description}]` | 扩展方法，放在 `_meta` 下（ACP 标准的扩展通道）；含 `_agentao.cn/ask_user` |
 
 ### `agentCapabilities` 字段（v0.2.x）
 
@@ -68,6 +68,7 @@ Agentao 的 ACP 服务器/客户端发出的每种消息的字段级速查。端
 | 字段 | 类型 | 说明 |
 |------|------|------|
 | `sessionId` | `string` | UUID。收好——后续每个调用都要用 |
+| `configOptions` | `[object]` | 模型/提供方选择项（`configId: "model"`）；通过 `session/set_config_option` 触发切换。无法枚举目录时为空数组 |
 
 ### 常见失败
 
@@ -182,7 +183,7 @@ Agentao 的 ACP 服务器/客户端发出的每种消息的字段级速查。端
 
 ### ← 响应
 
-空对象。Agent 会通过 `session/update` 通知回放历史轮次（从持久化历史重建），之后才进入可接受下一轮 `session/prompt` 的状态。
+`{configOptions: [...]}`——与 `session/new` 相同的模型/提供方选择项（无目录时为空数组）。Agent 还会通过 `session/update` 通知回放历史轮次（从持久化历史重建），之后才进入可接受下一轮 `session/prompt` 的状态。
 
 ### 指纹规则
 

--- a/developer-guide/zh/part-3/1-acp-tour.md
+++ b/developer-guide/zh/part-3/1-acp-tour.md
@@ -165,7 +165,7 @@ sequenceDiagram
 
 ## 扩展：`_agentao.cn/ask_user`
 
-协议标准里 Server 只能**请求权限**而不能**向用户追问文本**。Agentao 通过 `extensions` 机制宣告了一个私有扩展方法 `_agentao.cn/ask_user`，用来从 Server 向 Client 反问任意问题。Client 可以：
+协议标准里 Server 只能**请求权限**而不能**向用户追问文本**。Agentao 通过 `_meta["_agentao.cn/extensions"]`（ACP 标准的扩展通道）宣告了一个私有扩展方法 `_agentao.cn/ask_user`，用来从 Server 向 Client 反问任意问题。Client 可以：
 
 - 实现它：把问题弹给用户、拿到答复后返回字符串
 - 不实现：Agent 会 fallback 到 `"[ask_user: not available in non-interactive mode]"`

--- a/developer-guide/zh/part-3/2-agentao-as-server.md
+++ b/developer-guide/zh/part-3/2-agentao-as-server.md
@@ -82,12 +82,14 @@ agentao --acp --stdio
       "title": "Agentao",
       "version": "0.2.14"
     },
-    "extensions": [
-      {
-        "method": "_agentao.cn/ask_user",
-        "description": "Request free-form text input from the user."
-      }
-    ]
+    "_meta": {
+      "_agentao.cn/extensions": [
+        {
+          "method": "_agentao.cn/ask_user",
+          "description": "Request free-form text input from the user."
+        }
+      ]
+    }
   }
 }
 ```

--- a/docs/ACP.md
+++ b/docs/ACP.md
@@ -69,10 +69,10 @@ The same shape works for any client that launches an ACP agent over stdio: pass 
 | Method | Status | Notes |
 |---|---|---|
 | `initialize` | ✅ | Echoes the client's `protocolVersion` if supported (currently `1`); falls back to ours otherwise. Records `clientCapabilities` per connection. |
-| `session/new` | ✅ | Creates a fresh session bound to a per-session `cwd` and (optionally) per-session MCP servers. Returns `{"sessionId": "sess_…"}`. |
+| `session/new` | ✅ | Creates a fresh session bound to a per-session `cwd` and (optionally) per-session MCP servers. Returns `{"sessionId": "sess_…", "configOptions": [...]}` (model/provider selection options — see `session/set_config_option`). |
 | `session/prompt` | ✅ | Runs one Agentao turn against the named session; returns `{"stopReason": "end_turn" \| "cancelled"}`. |
 | `session/cancel` | ✅ | Fires the session's active `CancellationToken`. Idempotent; no-op on closed sessions or sessions with no active turn. Accepted both as a notification (no `id`) and as a request. |
-| `session/load` | ✅ | Reuses `agentao/session.py`'s persistence layer, hydrates the runtime's message history, and replays each persisted message as a `session/update` notification before responding. |
+| `session/load` | ✅ | Reuses `agentao/session.py`'s persistence layer, hydrates the runtime's message history, and replays each persisted message as a `session/update` notification before responding. Response includes `configOptions` (same as `session/new`). |
 
 ### Server → client (sent by Agentao)
 
@@ -289,7 +289,7 @@ Below is a complete client→server→client conversation. Each line on the wire
     "mcpServers":[]
   }}
 
-← {"jsonrpc":"2.0","id":2,"result":{"sessionId":"sess_3a8f1b2c..."}}
+← {"jsonrpc":"2.0","id":2,"result":{"sessionId":"sess_3a8f1b2c...","configOptions":[{"id":"model","name":"Model","category":"model","type":"select","currentValue":"openai/gpt-4o","options":[...]}]}}
 
 // 3. Send a prompt. Agentao runs one chat() turn, streaming events as
 //    session/update notifications, then returns a final stopReason.


### PR DESCRIPTION
## Summary

Audited README, `docs/`, and `developer-guide/` for content made stale by the merged ACP rework (PR-4/PR-5/PR-6) + image-fallback, and fixed the concrete factual errors.

### Findings
- **README.md / README.zh.md** — ✅ no change needed. They expose no ACP wire details (model switching is shown only via the embedded `agent.set_model()` API, which is unchanged).
- **`docs/` design/release/implementation records** — left as-is (intentionally point-in-time).
- **Living ACP docs** — had concrete factual errors, fixed here.

### PR-6 — `initialize` extensions moved under `_meta`
Docs literally claimed a **top-level `extensions` array**, now false:
- `developer-guide/{en,zh}/part-3/2-agentao-as-server.md` — initialize response JSON example → `_meta["_agentao.cn/extensions"]`
- `developer-guide/{en,zh}/part-3/1-acp-tour.md` — prose
- `developer-guide/{en,zh}/appendix/c-acp-messages.md` — response field table row

### PR-4 — `configOptions` on `session/new` + `session/load`
- `developer-guide/{en,zh}/appendix/c-acp-messages.md` — `session/new` response gains a `configOptions` row; `session/load` corrected from "**empty object**" (now wrong) to `{configOptions: [...]}`
- `docs/ACP.md` — `session/new` / `session/load` method-table cells + NDJSON transcript now include `configOptions`

### Not covered (flagged, not done)
The ACP wire references don't yet **document the new methods** `session/set_config_option`, `_agentao.cn/set_model`, or `session/set_mode` (modeId) at all — that's additive new content, not a stale-fix, so it's out of scope for this sync PR. Happy to add it in a follow-up if wanted.

Docs-only; no code/schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)