### PR TITLE
docs(acp): document new ACP model/mode-switching methods

### DIFF
--- a/developer-guide/en/appendix/c-acp-messages.md
+++ b/developer-guide/en/appendix/c-acp-messages.md
@@ -189,7 +189,85 @@ Resume a session by id. Only usable when the agent advertises `loadSession: true
 
 `mcpServers` is hashed during `session/new`. If `session/load` passes a different set (added / removed / reordered), Agentao may either reject the call or silently re-init — depends on implementation phase. When in doubt, use the **same** list you originally passed.
 
-## C.8 `_agentao.cn/ask_user` ⇠ notification (extension)
+## C.8 `session/set_config_option`
+
+Switch the model (and optionally the provider) via the ACP-standard config-option mechanism. **Credentials never travel on the wire** — the agent resolves them server-side from a host-injected `provider_resolver` (default: environment).
+
+### → Request
+
+| Field | Type | Req | Notes |
+|-------|------|-----|-------|
+| `sessionId` | `string` | yes | Active session |
+| `configId` | `string` | yes | Must be `"model"`; any other value → `-32600` Invalid Request |
+| `value` | `string` | yes | `provider/model` (e.g. `openai/gpt-4o`) or a bare `model` (keeps the current provider). Split on the **first** `/`; provider is lower-cased, model kept as-is |
+
+`apiKey`, `baseUrl`, `_meta`, and any other field are **rejected** (`-32602`; `extra="forbid"` + handler whitelist) — *"credentials resolve server-side and never travel on the wire"*.
+
+### ← Response
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `configOptions` | `[object]` | Refreshed selection options (same shape as `session/new`), reflecting the new `currentValue` |
+
+### Resolution & errors
+
+- **`provider/model`**: the agent calls `provider_resolver(provider_id)` → `{api_key, base_url?}`, then swaps provider + model. The **default** resolver accepts only the configured `LLM_PROVIDER` (case-insensitive) and reads `{PREFIX}_API_KEY` / `{PREFIX}_BASE_URL`; any other provider → `-32600` `cannot resolve provider '<id>'`. Inject a richer resolver to support more providers.
+- **bare `model`**: model-only switch (provider unchanged) via the same path as `_agentao.cn/set_model`.
+- On resolver failure the server logs only the provider id + exception **type**, never the message (it could embed a key).
+
+### `ConfigOption` shape (entries in `configOptions`)
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `id` | `string` | `"model"` |
+| `name` | `string` | `"Model"` |
+| `category` | `"mode" \| "model" \| "thought_level"` | `"model"` |
+| `type` | `"select"` | only `select` in v1 |
+| `currentValue` | `string?` | `provider/model` of the live model |
+| `options` | `[{value, name?, description?}]` | Catalog choices; `value` is `provider/model`. Default catalog = the single current env model; richer catalog host-injected |
+
+## C.9 `_agentao.cn/set_model` (extension)
+
+Agentao-specific free-form model switch — the vendor sibling of `session/set_config_option`'s bare-value path. Secret-free; shares the same core code path.
+
+### → Request
+
+| Field | Type | Req | Notes |
+|-------|------|-----|-------|
+| `sessionId` | `string` | yes | Active session |
+| `model` | `string` | yes | Any model id the current provider accepts (stripped). Free-form — not validated against a catalog |
+
+`apiKey`, `baseUrl`, `_meta` are **rejected** (`-32602`).
+
+### ← Response
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `model` | `string` | The active model id after the switch (`agent.llm.model`) |
+
+## C.10 `session/set_mode`
+
+Set the session's ACP `modeId`. The field is the ACP-standard **`modeId`** (not `mode`) and is an **open string** — a UI/behavioural selector that need not map to an Agentao permission preset.
+
+### → Request
+
+| Field | Type | Req | Notes |
+|-------|------|-----|-------|
+| `sessionId` | `string` | yes | Active session |
+| `modeId` | `string` | yes | Non-empty. On an exact match to a permission preset (`read-only` / `workspace-write` / `full-access` / `plan`) the agent applies it; any other value (e.g. `code`, `ask`) is persisted and echoed **without** changing permission posture |
+
+### ← Response
+
+| Field | Type | Notes |
+|-------|------|-------|
+| `modeId` | `string` | Echoes the persisted value |
+
+### Notes
+
+- A recognized preset **requires** the session to have a `PermissionEngine`, else `-32600` Invalid Request. Unknown modeIds need no engine — they are pure UI state.
+- Per-session: each session owns its own engine, so a preset change on session A never affects session B.
+
+## C.11 `_agentao.cn/ask_user` ⇠ notification (extension)
 
 Agentao-specific. Server asks the user a free-form question.
 
@@ -208,7 +286,7 @@ Agentao-specific. Server asks the user a free-form question.
 
 If the user is unavailable, clients may return the sentinel `"(user unavailable)"` (constant `ASK_USER_UNAVAILABLE_SENTINEL`).
 
-## C.9 JSON-RPC error codes (quick reference)
+## C.12 JSON-RPC error codes (quick reference)
 
 | Code | Name | Meaning |
 |------|------|---------|

--- a/developer-guide/zh/appendix/c-acp-messages.md
+++ b/developer-guide/zh/appendix/c-acp-messages.md
@@ -189,7 +189,85 @@ Agentao 的 ACP 服务器/客户端发出的每种消息的字段级速查。端
 
 `session/new` 时 `mcpServers` 会被哈希。如果 `session/load` 传了不同的集合（增/删/重排），Agentao 可能拒绝或静默重建——取决于实现阶段。拿不准就**传原样列表**。
 
-## C.8 `_agentao.cn/ask_user` ⇠ 通知（扩展）
+## C.8 `session/set_config_option`
+
+用 ACP 标准的 config-option 机制切换模型（以及可选地切换提供方）。**凭证绝不上线**——Agentao 在服务端用宿主注入的 `provider_resolver` 解析凭证（默认走环境变量）。
+
+### → 请求
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `sessionId` | `string` | 是 | 活跃会话 |
+| `configId` | `string` | 是 | 必须是 `"model"`；其它值 → `-32600` Invalid Request |
+| `value` | `string` | 是 | `provider/model`（如 `openai/gpt-4o`）或裸 `model`（保持当前提供方）。按**第一个** `/` 切分；provider 转小写，model 原样保留 |
+
+`apiKey`、`baseUrl`、`_meta` 以及任何其它字段都会被**拒绝**（`-32602`；`extra="forbid"` + handler 白名单）——*"凭证在服务端解析，绝不上线"*。
+
+### ← 响应
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `configOptions` | `[object]` | 刷新后的选择项（与 `session/new` 同形），反映新的 `currentValue` |
+
+### 解析与错误
+
+- **`provider/model`**：Agentao 调 `provider_resolver(provider_id)` → `{api_key, base_url?}`，然后整套切换 provider + model。**默认** resolver 只接受配置的 `LLM_PROVIDER`（大小写不敏感），读 `{PREFIX}_API_KEY` / `{PREFIX}_BASE_URL`；其它 provider → `-32600` `cannot resolve provider '<id>'`。要支持更多提供方，注入更丰富的 resolver。
+- **裸 `model`**：只换模型（provider 不变），与 `_agentao.cn/set_model` 走同一条核心路径。
+- resolver 失败时，服务端只记录 provider id + 异常**类型**，绝不记录消息（可能夹带密钥）。
+
+### `ConfigOption` 结构（`configOptions` 里的条目）
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `id` | `string` | `"model"` |
+| `name` | `string` | `"Model"` |
+| `category` | `"mode" \| "model" \| "thought_level"` | `"model"` |
+| `type` | `"select"` | v1 只有 `select` |
+| `currentValue` | `string?` | 当前模型的 `provider/model` |
+| `options` | `[{value, name?, description?}]` | 候选项；`value` 是 `provider/model`。默认目录 = 当前环境的单一模型；更丰富的目录由宿主注入 |
+
+## C.9 `_agentao.cn/set_model`（扩展）
+
+Agentao 独有的自由文本换模型——`session/set_config_option` 裸值路径的厂商版兄弟。无密钥；与其共享同一条核心路径。
+
+### → 请求
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `sessionId` | `string` | 是 | 活跃会话 |
+| `model` | `string` | 是 | 当前提供方接受的任意模型 id（会 strip）。自由文本——不按目录校验 |
+
+`apiKey`、`baseUrl`、`_meta` 会被**拒绝**（`-32602`）。
+
+### ← 响应
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `model` | `string` | 切换后的活跃模型 id（`agent.llm.model`） |
+
+## C.10 `session/set_mode`
+
+设置会话的 ACP `modeId`。字段是 ACP 标准的 **`modeId`**（不是 `mode`），且是**开放字符串**——一个 UI/行为选择器，不一定映射到 Agentao 权限预设。
+
+### → 请求
+
+| 字段 | 类型 | 必填 | 说明 |
+|------|------|------|------|
+| `sessionId` | `string` | 是 | 活跃会话 |
+| `modeId` | `string` | 是 | 非空。精确命中权限预设（`read-only` / `workspace-write` / `full-access` / `plan`）时 Agentao 应用之；其它值（如 `code`、`ask`）会被持久化并回显，但**不改变**权限姿态 |
+
+### ← 响应
+
+| 字段 | 类型 | 说明 |
+|------|------|------|
+| `modeId` | `string` | 回显持久化的值 |
+
+### 说明
+
+- 命中预设**要求**会话有 `PermissionEngine`，否则 `-32600` Invalid Request。未知 modeId 不需要引擎——纯 UI 状态。
+- 按会话隔离：每个会话拥有自己的引擎，会话 A 的预设变更绝不影响会话 B。
+
+## C.11 `_agentao.cn/ask_user` ⇠ 通知（扩展）
 
 Agentao 独有，服务器向用户问一个自由文本问题。
 
@@ -208,7 +286,7 @@ Agentao 独有，服务器向用户问一个自由文本问题。
 
 用户不可达时，客户端可回返哨兵 `"(user unavailable)"`（常量 `ASK_USER_UNAVAILABLE_SENTINEL`）。
 
-## C.9 JSON-RPC 错误码速查
+## C.12 JSON-RPC 错误码速查
 
 | 代码 | 名 | 含义 |
 |------|-----|------|

--- a/docs/ACP.md
+++ b/docs/ACP.md
@@ -73,6 +73,10 @@ The same shape works for any client that launches an ACP agent over stdio: pass 
 | `session/prompt` | ✅ | Runs one Agentao turn against the named session; returns `{"stopReason": "end_turn" \| "cancelled"}`. |
 | `session/cancel` | ✅ | Fires the session's active `CancellationToken`. Idempotent; no-op on closed sessions or sessions with no active turn. Accepted both as a notification (no `id`) and as a request. |
 | `session/load` | ✅ | Reuses `agentao/session.py`'s persistence layer, hydrates the runtime's message history, and replays each persisted message as a `session/update` notification before responding. Response includes `configOptions` (same as `session/new`). |
+| `session/set_config_option` | ✅ | ACP-standard model/provider switch (`configId="model"`, `value="provider/model"` or bare `model`). Credentials resolve **server-side** via an injectable `provider_resolver` — `apiKey`/`baseUrl`/`_meta` are rejected. Returns refreshed `configOptions`. |
+| `_agentao.cn/set_model` | ✅ | Vendor free-form model switch (`{sessionId, model}`); secret-free, shares the `set_config_option` core path. Returns `{"model": …}`. |
+| `session/set_mode` | ✅ | Sets the session's ACP `modeId` (open string). Exact match to a preset (`read-only`/`workspace-write`/`full-access`/`plan`) changes permission posture; any other value persists + echoes without changing it. Returns `{"modeId": …}`. |
+| `session/set_model`, `session/list_models` | ✅ (compat) | Pre-standard model methods, kept as one-release compatibility aliases. Prefer `session/set_config_option`. |
 
 ### Server → client (sent by Agentao)
 


### PR DESCRIPTION
## Summary

Follow-up to #61. The ACP wire references documented every method **except** the model/mode-switching surface added in PR-4/PR-5. This adds full reference docs for the three new methods, with contracts verified against the actual handlers.

### Appendix C (`developer-guide/{en,zh}/appendix/c-acp-messages.md`)
Three new sections (ask_user renumbered → C.11, error codes → C.12):
- **C.8 `session/set_config_option`** — `configId="model"`, `provider/model` vs bare `model` parsing, server-side `provider_resolver` (default reads `LLM_PROVIDER`/`{PREFIX}_API_KEY`), `configOptions`/`ConfigOption` shape, rejected `apiKey`/`baseUrl`/`_meta`, error codes.
- **C.9 `_agentao.cn/set_model`** — vendor free-form secret-free model switch.
- **C.10 `session/set_mode`** — open `modeId`, preset-vs-unknown behaviour, engine requirement, per-session isolation.

### `docs/ACP.md`
"Supported Methods" table gains rows for `session/set_config_option`, `_agentao.cn/set_model`, `session/set_mode`, and the `set_model`/`list_models` compat aliases.

### Verification
- Contracts cross-checked against `session_set_config_option.py`, `agentao_set_model.py`, `session_set_mode.py`, and `schema.py` (field types, `extra="forbid"` rejections, error codes).
- `npm run docs:build` (VitePress) passes; appendix C numbering is clean C.1–C.12 in both languages.

Docs-only; no code/schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)