### PR TITLE
feat(host): add extra_tools / disable_tools tool injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ _Targeting 0.4.9. Add entries under the relevant heading as work lands._
 
 ### Added
 
+- **Host tool injection: `Agentao(extra_tools=..., disable_tools=...)`.** Two
+  first-class, construction-time kwargs on the embedded-host contract for
+  adding, replacing, and hiding tools — replacing post-construction pokes at
+  the runtime `agent.tools.register(...)`.
+  - `extra_tools` — pre-built `Tool` / `AsyncToolBase` instances, registered as
+    the true final pass (after built-in, MCP, and agent tools) so a same-named
+    entry overrides a built-in or agent tool. Injected tools inherit the same
+    working-directory / filesystem / shell capability binding as built-ins.
+    Names using the reserved `mcp_` prefix raise (MCP replacement stays on
+    `mcp_manager=` / `extra_mcp_servers=`); duplicates raise.
+  - `disable_tools` — a set of built-in tool names to skip registering. A typo
+    or unknown name raises at construction (validated against the static
+    `BUILTIN_TOOL_NAMES` set) rather than silently no-op'ing. It only skips
+    built-in registration — not a global denylist, not a security boundary
+    (that stays with the permission engine).
+  - `WebSearchTool(backend=..., api_key=...)` — explicit constructor args now
+    take precedence over the `BOCHA_API_KEY` env var, so two in-process
+    Agentao instances can use different search backends. Pass a configured
+    instance via `extra_tools=[...]`.
+  - `Tool`, `AsyncToolBase`, `RegistrableTool` are now re-exported from
+    `agentao.host` as a stable import path for host tool authors.
+  - Design: `docs/design/host-tool-injection.md` / `.zh.md`.
+
 ### Changed
 
 - **Split six oversized modules into focused, cohesive units (internal,

--- a/agentao/agent.py
+++ b/agentao/agent.py
@@ -4,7 +4,7 @@ import asyncio
 import logging
 import warnings
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional, Union, TYPE_CHECKING
+from typing import Any, Callable, Dict, Iterable, List, Optional, Sequence, Union, TYPE_CHECKING
 
 from .llm import LLMClient
 from .llm.client import KEEP_BASE_URL as _KEEP_BASE_URL
@@ -13,7 +13,13 @@ from .runtime import ChatLoopRunner, ToolRunner, run_llm_call, run_turn
 from .runtime import model as _runtime_model
 from .runtime.tool_executor import ASYNC_CANCEL_REASON
 from .tools import ToolRegistry, SaveMemoryTool, TodoWriteTool
-from .tooling import init_mcp, register_agent_tools, register_builtin_tools, register_mcp_tools
+from .tooling import (
+    init_mcp,
+    register_agent_tools,
+    register_builtin_tools,
+    register_extra_tools,
+    register_mcp_tools,
+)
 from .agents import AgentManager
 from .cancellation import CancellationToken
 from .plan import PlanSession
@@ -33,6 +39,7 @@ if TYPE_CHECKING:
     from .mcp import McpClientManager  # type-only; MCP SDK is heavy
     from .memory import MemoryManager  # noqa: F401
     from .replay import ReplayConfig, ReplayManager  # type-only — replay no longer in core surface
+    from .tools.base import RegistrableTool  # noqa: F401
 
 
 class Agentao:
@@ -61,6 +68,9 @@ class Agentao:
         *,
         working_directory: Path,
         extra_mcp_servers: Optional[Dict[str, Dict[str, Any]]] = None,
+        # ── Host tool injection ───────────────────────────────────────────
+        extra_tools: Optional[Sequence["RegistrableTool"]] = None,
+        disable_tools: Optional[Iterable[str]] = None,
         # Embedded-harness explicit-injection kwargs.
         llm_client: Optional[LLMClient] = None,
         logger: Optional[logging.Logger] = None,
@@ -111,6 +121,20 @@ class Agentao:
                 file-loaded entry with the same name. ``None`` means "no
                 extras", which is the CLI default and produces the legacy
                 file-only behavior.
+            extra_tools: Pre-built ``Tool`` / ``AsyncToolBase`` instances to
+                register on top of the built-ins. Registered as the final
+                pass (after built-in, MCP, and agent tools), so a same-named
+                entry overrides a built-in or agent tool. Names using the
+                reserved ``mcp_`` prefix, or duplicate names, raise at
+                construction. Injected tools inherit the same
+                working-directory / filesystem / shell binding as built-ins.
+                See ``docs/design/host-tool-injection.md``.
+            disable_tools: Built-in tool names to skip registering (e.g.
+                ``{"run_shell_command"}`` for a read-only deployment). Each
+                name must be a known built-in or construction raises (typo
+                guard). Only skips built-in registration — not a global
+                denylist and not a security boundary (that stays with the
+                permission engine).
 
         Deprecated args (still accepted for backward compatibility,
         scheduled for removal in 0.5.0):
@@ -146,6 +170,14 @@ class Agentao:
         self._working_directory: Path = (
             Path(working_directory).expanduser().resolve()
         )
+
+        # Host tool injection (registered during ``_wire_tooling``).
+        # ``extra_tools`` are pre-built instances; ``disable_tools`` skips
+        # built-ins by name. Both are validated up-front so a typo or a
+        # reserved-namespace collision fails at construction, not silently.
+        self._extra_tools: List["RegistrableTool"] = list(extra_tools or ())
+        self._disable_tools: frozenset = frozenset(disable_tools or ())
+        self._validate_tool_injection()
 
         # When ``None``, file/search/shell tools fall back to
         # ``LocalFileSystem`` / ``LocalShellExecutor`` at first use.
@@ -245,6 +277,53 @@ class Agentao:
             raise ValueError(
                 "Agentao(): pass either mcp_manager= (pre-built) or "
                 "mcp_registry= (config source), not both."
+            )
+
+    def _validate_tool_injection(self) -> None:
+        """Validate ``extra_tools`` / ``disable_tools`` at construction.
+
+        Fails loudly rather than silently mis-registering:
+
+        * ``extra_tools`` names must be unique and must not use the ``mcp_``
+          prefix — that namespace is reserved for MCP-discovered tools, so
+          extras can never collide with (or shadow) them. MCP replacement
+          goes through ``mcp_manager=`` / ``extra_mcp_servers=`` instead.
+        * ``disable_tools`` names must each be a known built-in
+          (:data:`BUILTIN_TOOL_NAMES`) — a typo (``{"web_serach"}``) raises
+          instead of becoming a no-op. The check is against *static
+          registration eligibility*, not live availability, so disabling
+          ``web_search`` is legal even when ``[web]`` isn't installed
+          (it's just a no-op then).
+        """
+        from .tooling.registry import BUILTIN_TOOL_NAMES
+
+        seen: set = set()
+        for tool in self._extra_tools:
+            name = tool.name
+            if not isinstance(name, str) or not name:
+                raise ValueError(
+                    f"Agentao(extra_tools=): {type(tool).__name__}.name must "
+                    f"be a non-empty string, got {name!r}."
+                )
+            if name.startswith("mcp_"):
+                raise ValueError(
+                    f"Agentao(extra_tools=): tool name '{name}' uses the "
+                    "reserved 'mcp_' prefix. Replace MCP tools via "
+                    "mcp_manager= / extra_mcp_servers= instead."
+                )
+            if name in seen:
+                raise ValueError(
+                    f"Agentao(extra_tools=): duplicate tool name '{name}'."
+                )
+            seen.add(name)
+
+        unknown = sorted(self._disable_tools - BUILTIN_TOOL_NAMES)
+        if unknown:
+            raise ValueError(
+                f"Agentao(disable_tools=): unknown built-in tool name(s) "
+                f"{unknown}. Only built-ins can be disabled (agent-path tools "
+                f"like codebase_investigator and plan tools are not disableable). "
+                f"Valid names: {sorted(BUILTIN_TOOL_NAMES)}."
             )
 
     def _init_mcp_sources(
@@ -379,6 +458,12 @@ class Agentao:
             include_builtin_agents=enable_builtin_agents,
         )
         self._register_agent_tools()
+
+        # Host ``extra_tools`` register last — after built-in, MCP, and
+        # agent tools — so a same-named entry overrides built-in / agent
+        # tools (the ``mcp_`` prefix is banned, so never MCP). See
+        # ``register_extra_tools``.
+        register_extra_tools(self)
 
         if self.bg_store is not None:
             self.bg_store.recover()

--- a/agentao/host/__init__.py
+++ b/agentao/host/__init__.py
@@ -43,19 +43,45 @@ from .models import (
     SubagentLifecycleEvent,
     ToolLifecycleEvent,
 )
+from typing import Any, TYPE_CHECKING
+
 from .schema import (
     export_host_acp_json_schema,
     export_host_event_json_schema,
 )
 
+# Tool base types for host ``extra_tools`` injection are re-exported
+# *lazily* (PEP 562 ``__getattr__``). Importing them eagerly would pull the
+# entire ``agentao.tools`` package — ~35 modules (mcp, sandbox, capabilities
+# …) — onto every ``import agentao.host``, defeating the lightweight
+# stability-boundary intent (a host importing only ``HostEvent`` /
+# ``ActivePermissions`` typing should not drag in the tool runtime). The
+# canonical definitions stay in ``agentao.tools.base``; this is a stable
+# import path, NOT a new host-tool abstraction layer.
+_LAZY_TOOL_EXPORTS = frozenset({"AsyncToolBase", "RegistrableTool", "Tool"})
+
+if TYPE_CHECKING:  # static type-checkers resolve the names directly
+    from ..tools.base import AsyncToolBase, RegistrableTool, Tool
+
+
+def __getattr__(name: str) -> Any:
+    if name in _LAZY_TOOL_EXPORTS:
+        from ..tools import base as _base  # pulls the tools package once, on demand
+        return getattr(_base, name)
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+
+
 __all__ = [
     "ActivePermissions",
+    "AsyncToolBase",
     "EventStream",
     "HostEvent",
     "PermissionDecisionEvent",
     "RFC3339UTCString",
+    "RegistrableTool",
     "StreamSubscribeError",
     "SubagentLifecycleEvent",
+    "Tool",
     "ToolLifecycleEvent",
     "export_host_acp_json_schema",
     "export_host_event_json_schema",

--- a/agentao/tooling/__init__.py
+++ b/agentao/tooling/__init__.py
@@ -14,10 +14,16 @@ Split by concern so each file is small and independently testable:
 
 from .agent_tools import register_agent_tools
 from .mcp_tools import init_mcp, register_mcp_tools
-from .registry import register_builtin_tools
+from .registry import (
+    BUILTIN_TOOL_NAMES,
+    register_builtin_tools,
+    register_extra_tools,
+)
 
 __all__ = [
+    "BUILTIN_TOOL_NAMES",
     "register_builtin_tools",
+    "register_extra_tools",
     "register_agent_tools",
     "init_mcp",
     "register_mcp_tools",

--- a/agentao/tooling/registry.py
+++ b/agentao/tooling/registry.py
@@ -29,8 +29,55 @@ from ..tools import (
 
 if TYPE_CHECKING:
     from ..agent import Agentao
+    from ..tools.base import RegistrableTool
 
 _logger = logging.getLogger(__name__)
+
+# Every name a built-in tool *could* register under, independent of which
+# optional deps (``[web]``) or opt-in subsystems (``bg_store``) are live.
+# Used to validate ``disable_tools`` at construction so a typo
+# (``{"web_serach"}``) fails loudly instead of silently no-op'ing. This is
+# a flat constant by design — NOT a tool-metadata registry. The test
+# ``test_builtin_tool_names_constant_in_sync`` pins it to the names
+# actually produced by ``register_builtin_tools`` so it can't drift.
+#
+# Scope is *static registration eligibility*, not live availability:
+# ``web_search`` is listed even when ``[web]`` is absent (disabling it is
+# then a harmless no-op). Agent-path tools (codebase_investigator /
+# cli_help) register elsewhere and are intentionally out of scope.
+BUILTIN_TOOL_NAMES: frozenset = frozenset({
+    "read_file",
+    "write_file",
+    "replace",
+    "list_directory",
+    "glob",
+    "search_file_content",
+    "run_shell_command",
+    "web_fetch",
+    "web_search",
+    "save_memory",
+    "activate_skill",
+    "ask_user",
+    "todo_write",
+    "check_background_agent",
+    "cancel_background_agent",
+})
+
+
+def _bind_and_register(
+    agent: "Agentao", tool: "RegistrableTool", *, replace: bool = False
+) -> None:
+    """Bind session capabilities onto ``tool`` and register it.
+
+    Shared by built-in and ``extra_tools`` registration so injected tools
+    inherit the exact same working-directory / filesystem / shell binding
+    as built-ins (ACP session cwd isolation, host FS/shell redirection) —
+    they never become "bare" tools.
+    """
+    tool.working_directory = agent._working_directory
+    tool.filesystem = agent.filesystem
+    tool.shell = agent.shell
+    agent.tools.register(tool, replace=replace)
 
 
 def register_builtin_tools(agent: "Agentao") -> None:
@@ -75,9 +122,42 @@ def register_builtin_tools(agent: "Agentao") -> None:
         tools_to_register.append(CheckBackgroundAgentTool(bg_store=agent.bg_store))
         tools_to_register.append(CancelBackgroundAgentTool(bg_store=agent.bg_store))
 
-    wd = agent._working_directory
+    # ``disable_tools`` only skips built-in registration; it is not a global
+    # denylist (``extra_tools`` and MCP are untouched) and not a security
+    # boundary (that stays with the permission engine). Its value is a
+    # smaller schema so the model doesn't attempt inapplicable built-ins.
+    # ``extra_tools`` is NOT registered here — see ``register_extra_tools``,
+    # which runs after MCP and agent tools so it can override them.
+    disabled = agent._disable_tools
+    tools_to_register = [t for t in tools_to_register if t.name not in disabled]
+
     for tool in tools_to_register:
-        tool.working_directory = wd
-        tool.filesystem = agent.filesystem
-        tool.shell = agent.shell
-        agent.tools.register(tool)
+        _bind_and_register(agent, tool)
+
+
+def register_extra_tools(agent: "Agentao") -> None:
+    """Register host-supplied ``extra_tools`` — the true final pass.
+
+    Called from ``agent.py`` *after* built-in, MCP, and agent tools are all
+    registered, so an entry whose name matches a built-in or agent tool
+    overrides it (explicit replacement, silent). Extra-tool names are
+    forbidden the ``mcp_`` prefix at construction (see
+    ``Agentao._validate_tool_injection``), so they never collide with — and
+    cannot override — MCP tools; MCP replacement goes through the existing
+    ``mcp_manager=`` / ``extra_mcp_servers=`` injection points instead.
+    """
+    for tool in agent._extra_tools:
+        # Decide override against the live registry, which at this point
+        # holds built-in + MCP + agent tools. The ``mcp_`` prefix ban means
+        # a collision can only be with a built-in / agent tool.
+        replace = tool.name in agent.tools.tools
+        if replace:
+            # ``register(replace=True)`` is silent (intentional override), but
+            # an accidental name clash would otherwise vanish without a trace.
+            # Log at INFO so the override is auditable in agentao.log.
+            _logger.info(
+                "extra_tools: '%s' (%s) overrides an already-registered tool",
+                tool.name,
+                type(tool).__name__,
+            )
+        _bind_and_register(agent, tool, replace=replace)

--- a/agentao/tools/base.py
+++ b/agentao/tools/base.py
@@ -206,13 +206,17 @@ class ToolRegistry:
     def __init__(self):
         self.tools = {}
 
-    def register(self, tool: RegistrableTool) -> None:
+    def register(self, tool: RegistrableTool, *, replace: bool = False) -> None:
         """Register a tool.
 
-        Logs a warning if a tool with the same name is already registered, so
-        accidental MCP / built-in name collisions are visible in agentao.log.
+        When ``replace`` is ``False`` (default) and a tool with the same
+        name is already registered, logs a warning so accidental MCP /
+        built-in name collisions stay visible in agentao.log. When
+        ``replace`` is ``True`` the overwrite is intentional (a host
+        ``extra_tools`` entry deliberately replacing a built-in / agent
+        tool) and is performed silently. Either way the last write wins.
         """
-        if tool.name in self.tools:
+        if tool.name in self.tools and not replace:
             _logger.warning(
                 "Tool '%s' is already registered; overwriting with %s",
                 tool.name,

--- a/agentao/tools/web.py
+++ b/agentao/tools/web.py
@@ -3,7 +3,7 @@
 import asyncio
 import logging
 import os
-from typing import TYPE_CHECKING, Any, Dict
+from typing import TYPE_CHECKING, Any, Dict, Optional
 from urllib.parse import quote_plus
 
 # `httpx`, `bs4`, and `crawl4ai` are deferred (P0.5): the web tools may
@@ -275,9 +275,45 @@ class WebFetchTool(Tool):
 
 
 class WebSearchTool(Tool):
-    def __init__(self) -> None:
-        self._bocha_api_key = os.getenv("BOCHA_API_KEY")
-        self._provider = "bocha" if self._bocha_api_key else "duckduckgo"
+    def __init__(
+        self, *, backend: Optional[str] = None, api_key: Optional[str] = None
+    ) -> None:
+        """Web-search tool.
+
+        Args:
+            backend: Search provider override (``"bocha"`` / ``"duckduckgo"``).
+                When ``None``, derived from key availability.
+            api_key: Bocha API key. When ``None``, falls back to the
+                ``BOCHA_API_KEY`` process env var.
+
+        Explicit args take precedence over the env var so two Agentao
+        instances in the same process can use different search backends —
+        the env read is only a fallback, not a process-global override.
+        Pass a configured instance via ``Agentao(extra_tools=[...])``.
+
+        Raises:
+            ValueError: if ``backend`` is not a known provider, or if
+                ``backend="bocha"`` is requested without a resolvable key.
+                Fails loudly at construction rather than emitting a
+                ``Bearer None`` request (401) on the first query.
+        """
+        # ``is not None`` (not ``or``) so an explicit api_key="" — a host
+        # deliberately forcing "no key" — is honored and does NOT silently
+        # fall back to the process-global env var.
+        self._bocha_api_key = (
+            api_key if api_key is not None else os.getenv("BOCHA_API_KEY")
+        )
+        if backend is not None and backend not in ("bocha", "duckduckgo"):
+            raise ValueError(
+                f"WebSearchTool(backend=): unknown backend {backend!r}; "
+                "expected 'bocha' or 'duckduckgo'."
+            )
+        self._provider = backend or ("bocha" if self._bocha_api_key else "duckduckgo")
+        if self._provider == "bocha" and not self._bocha_api_key:
+            raise ValueError(
+                "WebSearchTool: backend 'bocha' requires an API key — pass "
+                "api_key= or set BOCHA_API_KEY."
+            )
 
     @property
     def is_read_only(self) -> bool:

--- a/docs/api/host.md
+++ b/docs/api/host.md
@@ -49,6 +49,8 @@ intentionally not part of this surface.
 | `RFC3339UTCString` | Constrained timestamp type used by all public events. |
 | `export_host_event_json_schema()` | Canonical JSON schema for the events + permissions surface. |
 | `export_host_acp_json_schema()` | Canonical JSON schema for the host-facing ACP payload surface. |
+| `Tool`, `AsyncToolBase` | Base classes for host-supplied tools passed via `Agentao(extra_tools=[...])`. Re-export of the canonical types in `agentao.tools.base` — a stable import path, not a new abstraction layer. |
+| `RegistrableTool` | `Union[Tool, AsyncToolBase]` — the type the registry / `extra_tools=` accepts. |
 | `agentao.host.replay_projection` | Submodule bridging `EventStream` ⇄ replay JSONL — see [Replay projection](#replay-projection-agentaohostreplay_projection) below. |
 
 ## Capability protocols (`agentao.host.protocols`)

--- a/docs/design/host-tool-injection.md
+++ b/docs/design/host-tool-injection.md
@@ -1,0 +1,262 @@
+# Host tool injection: `extra_tools` / `disable_tools` (v1)
+
+**Status:** **v1 landed** (`extra_tools` + `disable_tools` + `WebSearchTool(backend/api_key)`, see §11; tests in `tests/test_host_tool_injection.py`). `tool_options` / settings.json still deferred, see §10.
+**Audience:** agentao maintainers building a declarative host tool-injection surface; reviewers of the follow-up PR.
+**Companions:**
+- `docs/design/host-tool-injection.zh.md` — Chinese version
+- `docs/design/pi-mono-tools-review.md` / `.zh.md` — where the idea was surfaced (pi-mono tool-design comparison)
+- `docs/design/embedded-host-contract.md` — the host-contract stability boundary (where this design belongs)
+- `agentao/tooling/registry.py` — `register_builtin_tools`, the main change site
+- `agentao/tools/base.py` — `Tool` / `AsyncToolBase` / `ToolRegistry.register`
+
+---
+
+## 1. Problem: agentao has no host tool-injection surface
+
+agentao ships ~19 built-in tools, but **whether a given tool exists** is controlled by **five unrelated mechanisms**:
+
+- `[web]` extra detection (`registry.py:57`; no `bs4` → web tools not registered)
+- `bg_store` opt-in (`registry.py:74`; no store → bg-agent tools not registered)
+- plan mode (`base.py:242`; `plan_*` enter the schema only in plan mode)
+- agent registration path (`_register_agent_tools`; `codebase_investigator` / `cli_help`)
+- MCP runtime discovery (`mcp_{server}_{tool}`)
+
+**None of them is a host injection surface.** A host has no first-class way to do the three most basic things:
+
+1. **Add** a custom tool
+2. **Replace** a built-in's implementation (e.g. swap `web_search` for an in-house retriever)
+3. **Remove** a built-in (e.g. drop `run_shell_command` in a read-only deployment)
+
+Today the only option is to poke the runtime registry after construction via `agent.tools.register(...)` — it works, but it mutates runtime internals directly and is **not part of the stability-guaranteed `agentao.host` contract**.
+
+There is a fourth, related gap: **configuring a built-in tool's behavior**. `WebSearchTool.__init__` (`web.py:279`) reads `os.getenv("BOCHA_API_KEY")` at construction — process-global — so two same-process `Agentao` instances cannot use different search backends. This contradicts the invariant stated in `agent.py`'s docstring / CLAUDE.md that "two same-process instances with different `working_directory` can coexist." The v1 fix is in §7: give built-in tools constructor args and pass pre-configured instances via `extra_tools`, **without introducing an extra config layer**.
+
+## 2. Scope decision: v1 does exactly two things
+
+**The need comes from agentao's own embedded-host posture**: a host needs a stable API to **add/replace tools** and **hide inapplicable built-ins**, while injected tools automatically get capability binding (`working_directory` / `filesystem` / `shell`) — rather than reaching into `agent.tools.register(...)` after construction (runtime internals, off-contract). This is the agentao gap described in §1, independent of any external framework.
+
+> Background: pi-mono's `createTool` / preset / bare-`AgentTool`-override trio (see `pi-mono-tools-review`) is where the idea was surfaced, but it is background only. v1 scope is decided by the agentao gap in §1, **not by parity with pi-mono**.
+
+**v1 ships only `extra_tools` + `disable_tools`:**
+
+| Host need | v1 mechanism | Form |
+|---|---|---|
+| Add / replace a tool | `extra_tools` (same name → replaces) | Code (instance) |
+| Hide an inapplicable built-in | `disable_tools={...}` | Pure data (names) |
+| Configure a built-in's behavior | **no dedicated mechanism** → `extra_tools=[WebSearchTool(api_key=...)]` | Code (instance) |
+
+**Why `tool_options` is not in v1 (see §10):**
+- Configuring a built-in is satisfied in v1 by passing a **pre-constructed, configured instance** via `extra_tools` — provided built-in classes accept constructor args (§7), which they should anyway.
+- `tool_options` + settings.json + env placeholders + unset rules introduce a semi-public kwargs contract, settings fields, and loader behavior differences — too broad for v1 host injection. Build it when a real "CLI user wants to configure a built-in" need appears, and start from one concrete tool (gap≠need).
+
+**v1 also explicitly does not:**
+- Copy pi-mono's per-tool `operations?` capability DI — agentao already has a single `FileSystem` / `ShellExecutor` Protocol (`capabilities/`); one object to redirect all IO uniformly is the better answer.
+- Load `extra_tools` from JSON — tools are implementations and cannot be serialized.
+
+## 3. Constructor signature
+
+Slot into `agent.py`'s existing embedded-injection kwargs block (near `extra_mcp_servers`):
+
+```python
+def __init__(
+    self,
+    ...,
+    *,
+    working_directory: Path,
+    extra_mcp_servers: Optional[Dict[str, Dict[str, Any]]] = None,
+    # ── Host tool injection (NEW) ─────────────────────────────────
+    extra_tools: Optional[Sequence["RegistrableTool"]] = None,
+    disable_tools: Optional[Iterable[str]] = None,
+    ...,
+):
+    ...
+    self._extra_tools = list(extra_tools or ())
+    self._disable_tools = frozenset(disable_tools or ())
+    self._validate_tool_injection()   # extra: unique names, no `mcp_`; disable: must be in static built-in name set
+```
+
+- **`extra_tools`** — a list of already-constructed `Tool` / `AsyncToolBase` instances. Construction-time validation rejects duplicate names and the `mcp_` prefix (MCP namespace is reserved; MCP replacement goes through `mcp_manager=` etc., see §4).
+- **`disable_tools`** — a set of built-in tool names to skip during registration. Construction-time validation: **every name must belong to the static built-in name set, else `ValueError`** — pure typo protection (`{"web_serach"}` fails immediately instead of silently no-op'ing). Validation is against **static registration eligibility** (all possible built-in names), **not** live availability — so `disable_tools={"web_search"}` is valid (a no-op) even without `[web]` installed, the same "eligibility ≠ dependency availability" principle as §10 risk 3. Agent tools are out of `disable_tools` scope (separate registration path).
+
+## 4. Semantics and precedence
+
+Two rules, no ambiguity:
+
+1. **`disable_tools` only skips built-in registration** — it is **not** a global denylist, does not affect `extra_tools`, does not affect MCP. It is also **not a security boundary**: security/authorization stays with the permission engine; the value of `disable_tools` is reducing the schema and keeping the model from attempting inapplicable built-in capabilities.
+2. **`extra_tools` registers after built-ins and agent tools** — a separate pass (see §5b), so it can override same-named tools among **built-ins and agent tools**. It **does not enter the `mcp_` namespace**: extra tool names are forbidden the `mcp_` prefix (§3 validation), so by construction they cannot and will not override MCP tools. **Replacing MCP tools goes through the existing host injection surfaces** (`extra_mcp_servers=` / `mcp_manager=` / `mcp_registry=`), not `extra_tools` — keeping the boundary clean.
+
+The combinations follow with **no warn-then-continue conflict arbitration needed**:
+
+| Host passes | Result |
+|---|---|
+| `extra_tools` name doesn't collide with a registered built-in/agent tool | Added |
+| `extra_tools` name == a built-in / agent tool | That tool registers first; extra overrides it in the final pass (explicit replace) |
+| `extra_tools` name carries an `mcp_` prefix | §3 validation **rejects** it (`ValueError`) — MCP namespace reserved |
+| `disable_tools={"web_search"}` | Skip built-in `web_search` |
+| `disable_tools={"web_search"}` + `extra_tools=[a tool named web_search]` | Built-in skipped, extra registered — **net effect is the host's web_search is active**. A legitimate, meaningful combination (drop the built-in, supply your own); no error |
+| `disable_tools={"web_serach"}` (typo / unknown name) | Construction-time **`ValueError`** (see §3 validation) — typo protection, not silent |
+
+## 5. `register_builtin_tools` change: filter built-ins only
+
+`disable_tools` filters the built-in list. **`extra_tools` is not registered here** (see §5b). No `tool_options` injection, no options-eligible / dependency-wired classification:
+
+```python
+def register_builtin_tools(agent: "Agentao") -> None:
+    disabled = agent._disable_tools
+
+    tools = [ReadFileTool(), WriteFileTool(), EditTool(), ReadFolderTool(),
+             FindFilesTool(), SearchTextTool(), ShellTool()]
+    if importlib.util.find_spec("bs4") is not None:
+        tools += [WebFetchTool(), WebSearchTool()]
+    tools += [agent.memory_tool, ActivateSkillTool(agent.skill_manager),
+              AskUserTool(...), agent.todo_tool]
+    if agent.bg_store is not None:
+        tools += [CheckBackgroundAgentTool(bg_store=agent.bg_store),
+                  CancelBackgroundAgentTool(bg_store=agent.bg_store)]
+
+    # disable_tools: skip built-in registration only
+    tools = [t for t in tools if t.name not in disabled]
+
+    for tool in tools:
+        _bind_and_register(agent, tool)   # shared binding helper, see §5b
+```
+
+## 5b. `register_extra_tools`: the genuinely-last pass
+
+`extra_tools` must register after **all** built-in, MCP, and agent tools, otherwise it isn't "last wins." The current registration order (`agent.py`) is:
+
+```
+355  self.tools = ToolRegistry()
+356  self._register_tools()        # register_builtin_tools  →  built-ins
+366  self.mcp_manager = ...        # init_mcp / register_mcp_tools  →  mcp_{server}_{tool}
+381  self._register_agent_tools()  # codebase_investigator / cli_help / bg-agent
+387  self.tool_runner = ToolRunner(tools=self.tools, ...)
+```
+
+Insert the extra-tools registration **after 381, before 387** — add `register_extra_tools(agent)` and call it from `agent.py`:
+
+```python
+# agent.py, after _register_agent_tools(), before constructing ToolRunner:
+self._register_agent_tools()
+register_extra_tools(self)        # NEW — host extras register genuinely last
+self.tool_runner = ToolRunner(tools=self.tools, ...)
+```
+
+```python
+# tooling/registry.py
+def _bind_and_register(agent, tool, *, replace=False):
+    """Shared by built-ins and extras: bind capabilities, then register."""
+    tool.working_directory = agent._working_directory
+    tool.filesystem = agent.filesystem    # same capability binding as built-ins
+    tool.shell = agent.shell              # (was registry.py:78-83)
+    agent.tools.register(tool, replace=replace)
+
+def register_extra_tools(agent: "Agentao") -> None:
+    for tool in agent._extra_tools:
+        # Decide override against the live registry. It now holds built-in +
+        # MCP + agent tools, but extra names are forbidden the `mcp_` prefix
+        # (§3), so in practice they only collide with built-in/agent tools.
+        replace = tool.name in agent.tools.tools
+        _bind_and_register(agent, tool, replace=replace)
+```
+
+Two key points:
+
+1. **Extras go through exactly the same capability binding** (`working_directory` / `filesystem` / `shell`) — injected tools automatically inherit the ACP session's cwd isolation and the host's FS/shell redirection, and never become "bare" tools.
+2. **Placing the pass after `_register_agent_tools()` is specifically to override agent tools** (codebase_investigator / cli_help / bg-agent). `replace=` checks the live registry, so the implementation needs no per-source special-casing; but because the `mcp_` prefix is forbidden, what can actually be overridden is built-in and agent tools only, **not MCP** (MCP replacement goes through `mcp_manager=` etc.).
+
+## 6. Add an explicit override to `ToolRegistry.register`
+
+To support §5's `replace=`, add a parameter to `register` (`tools/base.py:209`). Semantics: **an explicit override (host deliberately replacing) is silent; a non-explicit collision (MCP / plugin accidental same-name) still warns** — keeping the existing last-write-wins behavior, only giving deliberate replacement a warn-free path:
+
+```python
+def register(self, tool: RegistrableTool, *, replace: bool = False) -> None:
+    if tool.name in self.tools and not replace:
+        # Non-explicit collision: keep historical behavior — overwrite and warn
+        # (visible when MCP/plugins accidentally collide).
+        _logger.warning(
+            "Tool '%s' already registered; overwriting with %s",
+            tool.name, type(tool).__name__)
+    self.tools[tool.name] = tool
+```
+
+Do not turn "non-explicit collision" into an outright `raise`: that would affect the MCP / plugin collision path, where the risk outweighs the benefit.
+
+## 7. Give built-in tools constructor args (the v1 path to configuring built-ins)
+
+For `extra_tools=[WebSearchTool(api_key=...)]` to configure a built-in, the built-in class must accept constructor args while **keeping a zero-arg default** (backward compatible). This also fixes the §1 multi-instance crack — explicit arg > env, with env as fallback:
+
+```python
+class WebSearchTool(Tool):
+    def __init__(self, *, backend: str | None = None, api_key: str | None = None):
+        self._bocha_api_key = api_key or os.getenv("BOCHA_API_KEY")
+        self._provider = backend or ("bocha" if self._bocha_api_key else "duckduckgo")
+```
+
+**v1 commits to constructor args for `WebSearchTool` only:**
+
+| Tool | v1 kwargs | Env replaced | Why required in v1 |
+|---|---|---|---|
+| `web_search` | `backend`, `api_key` | `BOCHA_API_KEY` | The §1 multi-instance env leak — a **demonstrated** defect, not "might be useful" |
+
+**`web_fetch`'s `fallback`: same-class multi-instance crack** (`WebFetchTool.__init__` likewise reads the process-global `AGENTAO_WEB_FETCH_FALLBACK`, `web.py:139/30`), **but its env is a non-secret, deployment-level mode switch (none/jina/crawl4ai) with low per-instance-variance priority, so it is deferred in v1.** Detailed rationale left to a follow-up issue/ADR.
+
+**The genuinely "might be useful" tier**: `read/write`'s `max_bytes/max_lines`, shell's `timeout/prefix` — no evidence agentao needs them now; add them one tool at a time when a concrete need appears.
+
+**Contract-burden note (and why it is *not* an argument against `tool_options`)**: configuring a built-in **necessarily** makes the depended-upon kwarg names a **semi-public contract** subject to deprecation on rename — **whether via `extra_tools` reusing the built-in class or, later, via `tool_options`**. This burden is not a new cost introduced by `tool_options`; it is the cost of "letting a host configure built-ins" at all:
+- v1 bears it via `extra_tools`, at the cost of being **wide-open** — the whole constructor signature is exposed and the class must be importable;
+- later, `tool_options` is the mechanism that **narrows the same contract into an explicit option schema** (agentao keeps construction control, exposes only the option keys it commits to), see §10.
+
+v1 commits only to `WebSearchTool`'s `api_key`/`backend` precisely to keep this wide-open contract minimal — avoiding a PR that silently expands the public contract surface.
+
+## 8. End-to-end usage
+
+```python
+from agentao import Agentao
+
+# Configure a built-in (the secret is held by host code, never in any config file)
+agent = Agentao(
+    working_directory=wd,
+    extra_tools=[WebSearchTool(backend="bocha", api_key=key)],  # same name → replaces built-in
+)
+
+# Remove the built-in search/fetch and add a separate in-house retriever
+# (different name — this is an addition, NOT a replacement of web_search semantics)
+agent = Agentao(
+    working_directory=wd,
+    disable_tools={"web_search", "web_fetch"},
+    extra_tools=[MyRetrievalTool()],
+)
+```
+
+## 9. Implementation prerequisites and out-of-scope notes
+
+- **`RegistrableTool` entering the contract = re-export only, no abstraction layer**: export the existing `Tool` / `AsyncToolBase` / `RegistrableTool` from `agentao.host`. Do **not** create a new host-tool protocol / adapter / wrapper — that is a separate design task, unrelated to this one. Implementation: a direct export from `agentao.host.__init__`; do not touch `host/protocols.py` or add a protocol.
+- **Concentrated change surface**: `Agentao.__init__` (accept `extra_tools` / `disable_tools` + construction-time validation), `register_builtin_tools` (add `disable_tools` filtering), new `register_extra_tools` called after `agent.py`'s `_register_agent_tools()`, `ToolRegistry.register(replace=...)`, plus `WebSearchTool` constructor args. Simple route.
+- **Static built-in name set = a constant/small function in registry.py**: the "all possible built-in names" needed for `disable_tools` validation should be a simple constant in `registry.py` (or a small function derived from the factory list) — **do not introduce a tool-metadata registry**.
+- **Registration paths left untouched**: plan-only (`plan_*`) and agent-tool (`codebase_investigator` / `cli_help`) registration paths are orthogonal to this design and unchanged in v1.
+
+## 10. Future need (not in v1): `tool_options` + settings.json
+
+`tool_options: Dict[str, Dict[str, Any]]` (`name → kwargs`) has exactly one irreplaceable value: **it can live in JSON** (letting non-programmatic CLI users tune built-ins via settings.json). Its other increments are already covered by `extra_tools`. Not in v1.
+
+**Trigger gates (either one → reopen for evaluation via a dedicated ADR):**
+- **A (JSON-driven)**: a real "non-programmatic / CLI host wants to configure built-ins via settings.json" need — then `tool_options` ships **with JSON together**.
+- **B (scale-driven)**: configurable built-ins reach ~3+, where a uniform map beats N constructor calls.
+
+> Evaluated and rejected: "`tool_options` but without JSON." It cuts the one irreplaceable increment (JSON) while keeping the medium cost — ≈ a stringly-typed `extra_tools`. If JSON's secret/versioning risk is the worry, the right answer is to not ship `tool_options` at all (the status quo), not a stripped version.
+
+**Three risk classes the ADR must cover (details left to the ADR):** settings-schema contract surface, env-secret expansion, unknown-vs-missing-dependency validation. The one easy-to-trip, non-obvious point worth recording now: **when an env placeholder doesn't resolve, warn + drop the key — do not adopt MCP's silent `""`** (otherwise an unset `$BOCHA_API_KEY` would silently fall web_search back to duckduckgo).
+
+## 11. Quick reference (v1)
+
+| Dimension | `extra_tools` | `disable_tools` |
+|---|---|---|
+| Form | Code (instance) | Pure data (name set) |
+| v1 source | in-process `Agentao(...)` API | in-process `Agentao(...)` API |
+| settings.json | No (implementations can't serialize) | **No in v1** — pure data is serialization-friendly, but v1 has no settings loader and doesn't read settings.json; CLI/JSON needs come later |
+| Can do | add / replace impl / configure built-in (pass a configured instance) | skip built-in registration only (not a security boundary — security is the permission engine's) |
+| Registers | after built-in + agent tools (separate pass, §5b) | filters the built-in list |
+| On name collision | registers last, overrides same-named **built-in and agent tools** (`replace=True` silent); **does not enter the `mcp_` namespace** — MCP replacement goes through `mcp_manager=` etc. | does not participate in collision arbitration — only decides whether a built-in exists |
+
+(`tool_options` is the §10 future need; not delivered in v1.)

--- a/docs/design/host-tool-injection.zh.md
+++ b/docs/design/host-tool-injection.zh.md
@@ -1,0 +1,259 @@
+# Host 工具注入：`extra_tools` / `disable_tools`（首版）
+
+**状态：** **首版已落地**(`extra_tools` + `disable_tools` + `WebSearchTool(backend/api_key)`,见 §11;测试 `tests/test_host_tool_injection.py`)。`tool_options` / settings.json 仍推迟,见 §10。
+**读者：** 要给 host 一个声明式工具注入口的 agentao 维护者；以及后续 PR 的评审者。
+**配套：**
+- `docs/design/host-tool-injection.md` — 英文版
+- `docs/design/pi-mono-tools-review.md` / `.zh.md` — pi-mono 工具设计对比的来源
+- `docs/design/embedded-host-contract.md` — host 契约稳定边界（本设计的归属处）
+- `agentao/tooling/registry.py` — `register_builtin_tools`，改造主战场
+- `agentao/tools/base.py` — `Tool` / `AsyncToolBase` / `ToolRegistry.register`
+
+---
+
+## 1. 问题：agentao 没有 host 工具注入口
+
+agentao 内置约 19 个工具，但「一个工具在不在」被**五种互不统一的机制**各自控制：
+
+- `[web]` extra 检测（`registry.py:57`，无 `bs4` 则不注册 web 工具）
+- `bg_store` opt-in（`registry.py:74`，无 store 则不注册 bg-agent 工具）
+- plan 模式（`base.py:242`，`plan_*` 仅 plan 模式进 schema）
+- agent 注册路径（`_register_agent_tools`，`codebase_investigator` / `cli_help`）
+- MCP 运行时发现（`mcp_{server}_{tool}`）
+
+**但没有一个是 host 注入口。** host 想做三件最基本的事都没有一等公民接口：
+
+1. **新增**一个自定义工具
+2. **替换**某个内置工具的实现（例：把 `web_search` 换成自研检索）
+3. **移除**某个内置工具（例：只读部署里去掉 `run_shell_command`）
+
+现状只能在构造后捅运行时注册表 `agent.tools.register(...)`——能用，但它直接操作运行时内部，**不在 `agentao.host` 那套有稳定性保证的契约面里**。
+
+还有第四个相关缺口:**配置内置工具的行为**。`WebSearchTool.__init__`（`web.py:279`）在构造时 `os.getenv("BOCHA_API_KEY")` 是**进程全局**的——于是同进程两个 Agentao 实例无法用不同搜索后端，撞上了 `agent.py` docstring / CLAUDE.md 声明的「同进程内两个 `working_directory` 不同的实例可共存」不变量。本版的修法见 §7：给内置工具加构造参数 + 用 `extra_tools` 传配置好的实例，**不引入额外的配置层**。
+
+## 2. 范围决策：首版只做两件事
+
+**必要性来自 agentao 自身的 embedded-host 定位**:host 需要一个稳定 API 来**新增/替换工具**、**隐藏不适用的内置**,同时让注入的工具自动获得 capability 绑定(`working_directory` / `filesystem` / `shell`)——而不是构造后手改 `agent.tools.register(...)`(那直接操作运行时内部,不在契约面里)。这是 §1 描述的 agentao 自身缺口,与任何外部框架无关。
+
+> 背景:pi-mono 的 `createTool` / preset / 裸 `AgentTool` 覆盖三件套(见 `pi-mono-tools-review`)是这个想法的来源参照,但仅作背景。首版范围由 §1 的 agentao 缺口决定,**不以 pi-mono 对齐为论据**。
+
+**首版只交付 `extra_tools` + `disable_tools`**：
+
+| host 需求 | 首版机制 | 形态 |
+|---|---|---|
+| 新增 / 替换工具 | `extra_tools`（同名即替换） | 代码（实例） |
+| 隐藏不适用的内置 | `disable_tools={...}` | 纯数据（名字） |
+| 配置内置行为 | **无专门机制** → 用 `extra_tools=[WebSearchTool(api_key=...)]` | 代码（实例） |
+
+**为什么不在首版做 `tool_options`（见 §10）：**
+- 配置内置工具的需求,首版用 `extra_tools` 传**已构造好、带配置的实例**即可满足——前提是内置类接受构造参数（§7），这本就该做。
+- `tool_options` + settings.json + env 占位 + unset 规则会引入半公开 kwargs 契约、settings 字段、loader 行为差异——对首版 host 注入过宽。等真出现「CLI 用户要配置内置工具」的需求再做,且只从一个具体工具起步（gap≠need）。
+
+**首版也明确不做：**
+- 不照搬 pi-mono 的 per-tool `operations?` 能力 DI——agentao 已有单一 `FileSystem` / `ShellExecutor` Protocol（`capabilities/`），统一重定向用一个对象就够，是更优解。
+- `extra_tools` 不从 JSON 加载——工具是实现，无法序列化。
+
+## 3. 构造器签名
+
+接在 `agent.py` 现有 embedded-injection kwargs 区（`extra_mcp_servers` 附近）:
+
+```python
+def __init__(
+    self,
+    ...,
+    *,
+    working_directory: Path,
+    extra_mcp_servers: Optional[Dict[str, Dict[str, Any]]] = None,
+    # ── Host tool injection (NEW) ─────────────────────────────────
+    extra_tools: Optional[Sequence["RegistrableTool"]] = None,
+    disable_tools: Optional[Iterable[str]] = None,
+    ...,
+):
+    ...
+    self._extra_tools = list(extra_tools or ())
+    self._disable_tools = frozenset(disable_tools or ())
+    self._validate_tool_injection()   # extra:名字唯一、禁 `mcp_`;disable:须属静态内置名集
+```
+
+- **`extra_tools`** — 已构造好的 `Tool` / `AsyncToolBase` 实例列表。构造期校验拒绝重名和 `mcp_` 前缀(MCP 命名空间保留;MCP 替换走 `mcp_manager=` 等,见 §4)。
+- **`disable_tools`** — 要从内置里跳过注册的工具名集合。构造期校验:**每个名字必须属于静态内置工具名集,否则 `ValueError`**——纯防 typo(`{"web_serach"}` 当场报错,不静默无效)。校验对**静态注册资格**(全部可能的内置名),**不**对实时可用性——没装 `[web]` 时 `disable_tools={"web_search"}` 仍合法(no-op),与 §10 风险 3 的「注册资格≠依赖可用性」同一原则。agent 工具不在 disable 范围(走另一注册路径)。
+
+## 4. 语义与优先级
+
+两条规则,无歧义:
+
+1. **`disable_tools` 只跳过内置工具的注册**——它**不是**全局 denylist,不影响 `extra_tools`、不影响 MCP。它也**不是安全边界**:安全/越权仍由 permission engine 负责;`disable_tools` 的价值是减少 schema、避免模型尝试不适用的内置能力。
+2. **`extra_tools` 在内置和 agent 工具之后注册**——独立 pass(见 §5b),所以能覆盖**内置和 agent 工具**里的同名工具。**不进入 `mcp_` 命名空间**:extra 工具名禁止 `mcp_` 前缀(§3 校验),因此构造上就不会、也不能覆盖 MCP 工具。**MCP 工具的替换走已有的 host 注入口**(`extra_mcp_servers=` / `mcp_manager=` / `mcp_registry=`),不归 `extra_tools` 管——边界更清楚。
+
+由此推出各组合的行为,**无需任何 warn-then-continue 的冲突仲裁**:
+
+| host 传入 | 结果 |
+|---|---|
+| `extra_tools` 名字不撞已注册的内置/agent 工具 | 新增 |
+| `extra_tools` 名字 == 某内置 / agent 工具 | 该工具先注册、extra 在最后 pass 覆盖之（显式替换） |
+| `extra_tools` 名字含 `mcp_` 前缀 | §3 校验**拒绝**(`ValueError`)——MCP 命名空间保留 |
+| `disable_tools={"web_search"}` | 跳过内置 `web_search` |
+| `disable_tools={"web_search"}` + `extra_tools=[名为 web_search 的工具]` | 内置被跳过,extra 注册——**净效果就是 host 的 web_search 生效**。这是合法且有意义的组合(去掉内置、换上自己的),不报错 |
+| `disable_tools={"web_serach"}`（拼错 / 未知名） | 构造期 **`ValueError`**(见 §3 校验)——防 typo,不静默 |
+
+## 5. `register_builtin_tools` 改造：仅过滤内置
+
+`disable_tools` 过滤内置列表。**`extra_tools` 不在这里注册**(见 §5b)。无 `tool_options` 注入,无 options-eligible / dependency-wired 分类:
+
+```python
+def register_builtin_tools(agent: "Agentao") -> None:
+    disabled = agent._disable_tools
+
+    tools = [ReadFileTool(), WriteFileTool(), EditTool(), ReadFolderTool(),
+             FindFilesTool(), SearchTextTool(), ShellTool()]
+    if importlib.util.find_spec("bs4") is not None:
+        tools += [WebFetchTool(), WebSearchTool()]
+    tools += [agent.memory_tool, ActivateSkillTool(agent.skill_manager),
+              AskUserTool(...), agent.todo_tool]
+    if agent.bg_store is not None:
+        tools += [CheckBackgroundAgentTool(bg_store=agent.bg_store),
+                  CancelBackgroundAgentTool(bg_store=agent.bg_store)]
+
+    # disable_tools:仅跳过内置注册
+    tools = [t for t in tools if t.name not in disabled]
+
+    for tool in tools:
+        _bind_and_register(agent, tool)   # 见 §5b 的共享绑定 helper
+```
+
+## 5b. `register_extra_tools`：真正的最后一个 pass
+
+`extra_tools` 必须在**全部**内置、MCP、agent 工具注册完之后才注册,否则不是"最后生效"。当前注册时序(`agent.py`)是:
+
+```
+355  self.tools = ToolRegistry()
+356  self._register_tools()        # register_builtin_tools  →  内置
+366  self.mcp_manager = ...        # init_mcp / register_mcp_tools  →  mcp_{server}_{tool}
+381  self._register_agent_tools()  # codebase_investigator / cli_help / bg-agent
+387  self.tool_runner = ToolRunner(tools=self.tools, ...)
+```
+
+把 extra 注册插在 **381 之后、387 之前**,新增 `register_extra_tools(agent)` 并在 `agent.py` 调用:
+
+```python
+# agent.py,_register_agent_tools() 之后、ToolRunner 构造之前:
+self._register_agent_tools()
+register_extra_tools(self)        # NEW —— host extras 真正最后注册
+self.tool_runner = ToolRunner(tools=self.tools, ...)
+```
+
+```python
+# tooling/registry.py
+def _bind_and_register(agent, tool, *, replace=False):
+    """内置与 extra 共用:绑定 capability 后注册。"""
+    tool.working_directory = agent._working_directory
+    tool.filesystem = agent.filesystem    # 与内置同一套 capability 绑定
+    tool.shell = agent.shell              # （原 registry.py:78-83）
+    agent.tools.register(tool, replace=replace)
+
+def register_extra_tools(agent: "Agentao") -> None:
+    for tool in agent._extra_tools:
+        # 对活注册表判断是否覆盖。此刻表里有内置 + MCP + agent 工具,
+        # 但 extra 名禁含 `mcp_` 前缀(§3),所以实际只会撞上内置/agent 工具。
+        replace = tool.name in agent.tools.tools
+        _bind_and_register(agent, tool, replace=replace)
+```
+
+两个关键点:
+
+1. **extras 走与内置完全相同的 capability 绑定**（`working_directory` / `filesystem` / `shell`）——注入的工具自动继承 ACP 会话 cwd 隔离和 host 的 FS/shell 重定向，不会变成「裸」工具。
+2. **放在 `_register_agent_tools()` 之后的真实目的是覆盖 agent 工具**(codebase_investigator / cli_help / bg-agent)。`replace=` 对活注册表判断,实现上无需特判来源;但因 `mcp_` 前缀被禁,可覆盖的实际只有内置和 agent 工具,**不含 MCP**(MCP 替换走 `mcp_manager=` 等已有注入口)。
+
+## 6. `ToolRegistry.register` 加显式 override
+
+为支持 §5 的 `replace=`,给 `register` 加一个参数（`tools/base.py:209`）。语义:**显式覆盖（host 故意替换）可静默；非显式撞名（MCP / 插件意外同名）仍 warning**——保留现有 last-write-wins 行为,只是给有意替换一条免 warn 的路:
+
+```python
+def register(self, tool: RegistrableTool, *, replace: bool = False) -> None:
+    if tool.name in self.tools and not replace:
+        # 非显式撞名:沿用历史行为——覆盖并 warn(MCP/插件意外同名时可见)
+        _logger.warning(
+            "Tool '%s' already registered; overwriting with %s",
+            tool.name, type(tool).__name__)
+    self.tools[tool.name] = tool
+```
+
+不把"非显式撞名"改成直接 `raise`:那会波及 MCP / 插件的撞名路径,风险大于收益。
+
+## 7. 内置工具补构造参数（配置内置的首版途径）
+
+要让 `extra_tools=[WebSearchTool(api_key=...)]` 能配置内置工具,内置类需接受构造参数,且**保持零参默认**（向后兼容）。这也顺手修了 §1 的多实例裂缝——显式参数 > env,env 退为 fallback:
+
+```python
+class WebSearchTool(Tool):
+    def __init__(self, *, backend: str | None = None, api_key: str | None = None):
+        self._bocha_api_key = api_key or os.getenv("BOCHA_API_KEY")
+        self._provider = backend or ("bocha" if self._bocha_api_key else "duckduckgo")
+```
+
+**首版只承诺 `WebSearchTool` 一个工具的构造参数**:
+
+| 工具 | 首版 kwargs | 取代的 env | 为何首版必需 |
+|---|---|---|---|
+| `web_search` | `backend`、`api_key` | `BOCHA_API_KEY` | §1 的多实例 env 泄漏——这是被问题陈述**证明**的真实缺陷,不是"可能有用" |
+
+**`web_fetch` 的 `fallback`:同类多实例裂缝(`WebFetchTool.__init__` 同样读进程全局 `AGENTAO_WEB_FETCH_FALLBACK`,`web.py:139/30`),但其 env 是非密钥、偏部署级的模式开关(none/jina/crawl4ai),每实例变化优先级低,首版暂缓。** 详细论证留后续 issue/ADR。
+
+**真正的"可能有用"档**:`read/write` 的 `max_bytes/max_lines`、shell 的 `timeout/prefix` ——无 agentao 当前必须的证据,出现具体需求再逐个补,**一次一个工具**。
+
+**契约负担提醒(并澄清它不是反对 `tool_options` 的理由)**:配置内置**必然**让被依赖的 kwarg 名成为**半公开契约**,改名要走 deprecation——**无论经 `extra_tools` 复用内置类、还是将来经 `tool_options`**。这份负担不是 `tool_options` 引入的新成本,而是"允许 host 配置内置"本身的成本:
+- 首版用 `extra_tools` 承担它,代价是**敞口**——暴露整个构造签名 + 要求该类可 import;
+- 将来 `tool_options` 是把同一份契约**收口成显式 option schema** 的机制(agentao 持构造权,只公开承诺的 option key),见 §10。
+
+首版只承诺 `WebSearchTool` 的 `api_key`/`backend` 两个名,正是为把这份敞口契约压到最小——避免一个 PR 悄悄扩大公共契约面。
+
+## 8. 全景用法
+
+```python
+from agentao import Agentao
+
+# 配置内置（密钥由 host 代码持有,不落任何配置文件）
+agent = Agentao(
+    working_directory=wd,
+    extra_tools=[WebSearchTool(backend="bocha", api_key=key)],  # 同名替换内置
+)
+
+# 移除内置搜索/抓取,另新增一个自研检索工具(不同名 —— 是新增,不是替换原 web_search 语义)
+agent = Agentao(
+    working_directory=wd,
+    disable_tools={"web_search", "web_fetch"},
+    extra_tools=[MyRetrievalTool()],
+)
+```
+
+## 9. 落地前置依赖与遗留项
+
+- **`RegistrableTool` 入契约面 = 仅 re-export,不建抽象层**:从 `agentao.host` 导出已有的 `Tool` / `AsyncToolBase` / `RegistrableTool` 即可。**不**新建 host-tool protocol / adapter / wrapper——那是另一项设计任务,与本设计无关。
+- **改动面集中**:`Agentao.__init__`(收 `extra_tools` / `disable_tools` + 构造期校验)、`register_builtin_tools`(加 `disable_tools` 过滤)、新增 `register_extra_tools` 并在 `agent.py` 的 `_register_agent_tools()` 之后调用、`ToolRegistry.register(replace=...)`，外加给 `WebSearchTool` 补构造参数。路线简明。
+- **静态内置名集 = registry.py 一个常量/小函数**:disable_tools 校验所需的"全部可能内置名"落成 `registry.py` 里一个简单常量(或从工厂表派生的小函数)即可,**不引入工具元数据注册中心**。
+- **不碰的注册路径**:plan-only（`plan_*`）、agent-tool（`codebase_investigator` / `cli_help`）的注册路径与本设计正交,本版不动。
+
+## 10. 未来需求（不进首版）：`tool_options` + settings.json
+
+`tool_options: Dict[str, Dict[str, Any]]`（`name → kwargs`）的唯一不可替代价值是**可进 JSON**(让非编程 CLI 用户经 settings.json 调内置);其余增量 `extra_tools` 已覆盖。首版不做。
+
+**触发闸门(任一满足即另起 ADR 重新评估):**
+- **A(JSON 驱动)**:出现「非编程 / CLI host 要经 settings.json 配内置」需求——届时带 JSON 一起上。
+- **B(规模驱动)**:可配置内置达 ~3+ 个,统一 map 优于 N 次构造。
+
+> 已评估否决「上 tool_options 但不上 JSON」:砍掉唯一不可替代的 JSON,却留中等成本,≈ 弱类型版 `extra_tools`。担忧 JSON 风险的正解是整段不上(现状),非阉割版。
+
+**届时 ADR 要覆盖的三类风险(细节留给 ADR):** settings schema 契约面、env secret 展开、unknown-vs-依赖缺失校验。其中唯一容易踩、值得现在就记下的非显然点:**env 占位未解析时须 warn + 丢键,不能沿用 mcp 的静默 `""`**(否则 `$BOCHA_API_KEY` 未设会让 web_search 静默退回 duckduckgo)。
+
+## 11. 速查表（首版）
+
+| 维度 | `extra_tools` | `disable_tools` |
+|---|---|---|
+| 形态 | 代码（实例） | 纯数据（名字集合） |
+| 首版来源 | in-process `Agentao(...)` API | in-process `Agentao(...)` API |
+| settings.json | 否（实现无法序列化） | **首版否**——纯数据虽序列化友好,但首版无 settings loader,不接 settings.json;CLI/JSON 需求以后再说 |
+| 能做 | 增 / 替换实现 / 配置内置（传配好的实例） | 仅跳过内置注册（不是安全边界——安全归 permission engine） |
+| 注册时机 | 内置 + agent 工具之后（独立 pass，§5b） | 过滤内置列表 |
+| 撞名时 | 最后注册,覆盖**内置和 agent 工具**的同名项（`replace=True` 静默）；**不进 `mcp_` 命名空间**,MCP 替换走 `mcp_manager=` 等 | 不参与撞名仲裁——只决定内置在不在 |
+
+（`tool_options` 见 §10 阶段二，首版不交付。）

--- a/tests/test_host_tool_injection.py
+++ b/tests/test_host_tool_injection.py
@@ -1,0 +1,297 @@
+"""Host tool injection: ``extra_tools`` / ``disable_tools``.
+
+Covers the four behavioral contracts from
+``docs/design/host-tool-injection.md``:
+
+1. ``extra_tools`` register last and override built-in / agent tools.
+2. ``extra_tools`` names using the reserved ``mcp_`` prefix raise.
+3. Unknown ``disable_tools`` names raise (typo guard).
+4. ``WebSearchTool`` explicit constructor args take precedence over env.
+
+Plus the supporting invariants: capability binding on injected tools,
+``disable_tools`` only skipping built-ins, and the ``BUILTIN_TOOL_NAMES``
+constant staying in sync with what ``register_builtin_tools`` produces.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from agentao import Agentao
+from agentao.host import AsyncToolBase, RegistrableTool, Tool
+from agentao.tooling import BUILTIN_TOOL_NAMES
+from agentao.tools.web import WebSearchTool
+
+
+def _make_agent(tmp_path, **kwargs) -> Agentao:
+    """Construct an Agentao with a dummy LLM config (no network at init)."""
+    return Agentao(
+        working_directory=tmp_path,
+        api_key="x",
+        base_url="http://localhost:0",
+        model="dummy",
+        **kwargs,
+    )
+
+
+class _NamedTool(Tool):
+    """Minimal concrete Tool with a configurable name + marker description."""
+
+    def __init__(self, name: str, description: str = "marker") -> None:
+        self._name = name
+        self._description = description
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    @property
+    def description(self) -> str:
+        return self._description
+
+    @property
+    def parameters(self):
+        return {"type": "object", "properties": {}}
+
+    def execute(self, **kwargs) -> str:
+        return "ran"
+
+
+# ── Contract 1: extra_tools register last & override ──────────────────────
+
+
+def test_extra_tools_add_new_tool(tmp_path):
+    agent = _make_agent(tmp_path, extra_tools=[_NamedTool("my_retrieval")])
+    try:
+        assert "my_retrieval" in agent.tools.tools
+    finally:
+        agent.close()
+
+
+def test_extra_tools_override_builtin(tmp_path):
+    """A same-named extra replaces the built-in (last-write-wins, silent).
+
+    Targets ``read_file`` — an *unconditional* built-in — so this exercises
+    the genuine override path even on a bare (no-``[web]``) install. Using a
+    conditional tool like ``web_search`` would silently degrade to an "add"
+    when ``bs4`` is absent.
+    """
+    custom = _NamedTool("read_file", description="custom-override")
+    agent = _make_agent(tmp_path, extra_tools=[custom])
+    try:
+        assert agent.tools.tools["read_file"] is custom
+        assert agent.tools.tools["read_file"].description == "custom-override"
+    finally:
+        agent.close()
+
+
+def test_extra_tools_inherit_capability_binding(tmp_path):
+    """Injected tools get the same wd/filesystem/shell binding as built-ins."""
+    tool = _NamedTool("my_retrieval")
+    agent = _make_agent(tmp_path, extra_tools=[tool])
+    try:
+        registered = agent.tools.tools["my_retrieval"]
+        assert registered.working_directory == agent._working_directory
+        # Bound to the agent's *own* capability objects (identity), not just
+        # "some attribute exists" — a regression that bound the wrong object
+        # would still leave the attrs present.
+        assert registered.filesystem is agent.filesystem
+        assert registered.shell is agent.shell
+    finally:
+        agent.close()
+
+
+# ── Contract 2: mcp_ prefix is rejected ───────────────────────────────────
+
+
+def test_extra_tools_mcp_prefix_rejected(tmp_path):
+    with pytest.raises(ValueError, match="reserved 'mcp_' prefix"):
+        _make_agent(tmp_path, extra_tools=[_NamedTool("mcp_alpha_ping")])
+
+
+def test_extra_tools_duplicate_name_rejected(tmp_path):
+    with pytest.raises(ValueError, match="duplicate tool name"):
+        _make_agent(
+            tmp_path,
+            extra_tools=[_NamedTool("dup"), _NamedTool("dup")],
+        )
+
+
+# ── Contract 3: disable_tools typo guard ──────────────────────────────────
+
+
+def test_disable_unknown_tool_raises(tmp_path):
+    with pytest.raises(ValueError, match="unknown built-in tool name"):
+        _make_agent(tmp_path, disable_tools={"web_serach"})
+
+
+def test_disable_known_tool_skips_registration(tmp_path):
+    agent = _make_agent(tmp_path, disable_tools={"read_file"})
+    try:
+        assert "read_file" not in agent.tools.tools
+        # Other built-ins remain.
+        assert "write_file" in agent.tools.tools
+    finally:
+        agent.close()
+
+
+def test_disable_tool_without_extra_dep_is_noop_not_error(tmp_path):
+    """Disabling a name is legal even if its optional dep is absent.
+
+    ``disable_tools`` validates against static registration eligibility,
+    not live availability — so ``web_search`` is always a valid name even
+    when ``[web]`` isn't installed; disabling it is simply a no-op then.
+    """
+    agent = _make_agent(tmp_path, disable_tools={"web_search", "web_fetch"})
+    try:
+        assert "web_search" not in agent.tools.tools
+        assert "web_fetch" not in agent.tools.tools
+    finally:
+        agent.close()
+
+
+def test_disable_plus_extra_replacement(tmp_path):
+    """disable built-in + add own same-named tool = host's tool wins.
+
+    Uses ``read_file`` (unconditional) so the disable+replace path is
+    exercised on any install, not only when ``[web]`` is present.
+    """
+    custom = _NamedTool("read_file", description="host-owned")
+    agent = _make_agent(
+        tmp_path, disable_tools={"read_file"}, extra_tools=[custom]
+    )
+    try:
+        assert agent.tools.tools["read_file"] is custom
+    finally:
+        agent.close()
+
+
+# ── Contract 4: WebSearchTool explicit args > env ─────────────────────────
+
+
+def test_web_search_explicit_args_beat_env(monkeypatch):
+    monkeypatch.setenv("BOCHA_API_KEY", "from-env")
+    tool = WebSearchTool(backend="bocha", api_key="explicit")
+    assert tool._bocha_api_key == "explicit"
+    assert tool._provider == "bocha"
+
+
+def test_web_search_env_is_fallback(monkeypatch):
+    monkeypatch.setenv("BOCHA_API_KEY", "from-env")
+    tool = WebSearchTool()
+    assert tool._bocha_api_key == "from-env"
+    assert tool._provider == "bocha"
+
+
+def test_web_search_no_key_defaults_duckduckgo(monkeypatch):
+    monkeypatch.delenv("BOCHA_API_KEY", raising=False)
+    tool = WebSearchTool()
+    assert tool._provider == "duckduckgo"
+
+
+def test_web_search_empty_api_key_overrides_env(monkeypatch):
+    """Explicit api_key='' (force-unset) must beat the env var, not fall back."""
+    monkeypatch.setenv("BOCHA_API_KEY", "from-env")
+    tool = WebSearchTool(api_key="")
+    assert tool._bocha_api_key == ""
+    assert tool._provider == "duckduckgo"
+
+
+def test_web_search_unknown_backend_raises(monkeypatch):
+    monkeypatch.setenv("BOCHA_API_KEY", "k")
+    with pytest.raises(ValueError, match="unknown backend"):
+        WebSearchTool(backend="brave")
+
+
+def test_web_search_bocha_backend_without_key_raises(monkeypatch):
+    """Forcing backend='bocha' with no key fails loudly, not as a 'Bearer None' 401."""
+    monkeypatch.delenv("BOCHA_API_KEY", raising=False)
+    with pytest.raises(ValueError, match="requires an API key"):
+        WebSearchTool(backend="bocha")
+
+
+# ── Validation edge cases ─────────────────────────────────────────────────
+
+
+def test_extra_tools_empty_name_rejected(tmp_path):
+    with pytest.raises(ValueError, match="non-empty string"):
+        _make_agent(tmp_path, extra_tools=[_NamedTool("")])
+
+
+def test_extra_tools_override_is_logged_and_unwarned(tmp_path, caplog):
+    """An override emits an auditable INFO line but NOT the collision WARNING.
+
+    ``register(replace=True)`` is silent by contract; the visibility instead
+    comes from ``register_extra_tools`` logging at INFO. Pins both halves so
+    a regression (spurious warning, or a silent clobber with no trace) fails.
+    """
+    import logging
+
+    # ``read_file`` is unconditional — without it (e.g. overriding the
+    # bs4-gated web_search on a bare install) replace would be False and the
+    # asserted INFO line would never fire.
+    custom = _NamedTool("read_file", description="host-owned")
+    with caplog.at_level(logging.INFO):
+        agent = _make_agent(tmp_path, extra_tools=[custom])
+    try:
+        infos = [r for r in caplog.records if r.levelno == logging.INFO
+                 and "overrides an already-registered tool" in r.getMessage()]
+        assert infos, "expected an INFO audit line for the override"
+        warns = [r for r in caplog.records if r.levelno == logging.WARNING
+                 and "already registered" in r.getMessage()]
+        assert not warns, "override must not emit the accidental-collision warning"
+    finally:
+        agent.close()
+
+
+# ── Supporting invariant: BUILTIN_TOOL_NAMES stays in sync ────────────────
+
+
+def test_builtin_tool_names_constant_in_sync(tmp_path):
+    """The static name set must equal what registration actually produces.
+
+    Pins the hand-maintained constant to reality so a tool rename can't
+    silently desync the ``disable_tools`` validator. bg_store is forced
+    live so the conditional bg-agent tools register.
+
+    The web tools are conditional on the ``[web]`` extra, so instead of
+    *skipping* without ``bs4`` (which would leave the constant un-guarded on
+    a no-[web] CI lane and let a rename slip through), we subtract the web
+    names from the expected set when ``bs4`` is absent — the invariant is
+    still enforced in both environments.
+    """
+    import importlib.util
+    from unittest.mock import Mock
+    from agentao.tooling.registry import register_builtin_tools
+
+    # Minimal stand-in agent exposing only what register_builtin_tools reads.
+    fake = Mock()
+    fake._working_directory = tmp_path
+    fake.filesystem = None
+    fake.shell = None
+    fake._disable_tools = frozenset()
+    fake.bg_store = Mock()  # truthy → bg tools register
+    fake.skill_manager = Mock()
+    fake.todo_tool = _NamedTool("todo_write")
+    fake.memory_tool = _NamedTool("save_memory")
+    fake.transport = Mock()
+
+    from agentao.tools.base import ToolRegistry
+
+    fake.tools = ToolRegistry()
+    register_builtin_tools(fake)
+
+    expected = set(BUILTIN_TOOL_NAMES)
+    if importlib.util.find_spec("bs4") is None:
+        expected -= {"web_fetch", "web_search"}  # not registered without [web]
+
+    assert set(fake.tools.tools) == expected
+
+
+def test_registrable_tool_reexport_identity():
+    """host re-export must BE the canonical types, not copies."""
+    from agentao.tools import base
+
+    assert Tool is base.Tool
+    assert AsyncToolBase is base.AsyncToolBase
+    assert RegistrableTool is base.RegistrableTool

--- a/tests/test_host_typing.py
+++ b/tests/test_host_typing.py
@@ -192,12 +192,15 @@ def test_host_all_matches_documented_set() -> None:
 
     documented = {
         "ActivePermissions",
+        "AsyncToolBase",
         "EventStream",
         "HostEvent",
         "PermissionDecisionEvent",
         "RFC3339UTCString",
+        "RegistrableTool",
         "StreamSubscribeError",
         "SubagentLifecycleEvent",
+        "Tool",
         "ToolLifecycleEvent",
         "export_host_acp_json_schema",
         "export_host_event_json_schema",


### PR DESCRIPTION
## What

First-class, construction-time host API to **add / replace / hide** tools, replacing post-construction pokes at `agent.tools.register(...)`.

| Need | Mechanism | Form |
|---|---|---|
| Add / replace a tool | `extra_tools=[...]` (same name → replace) | code (instances) |
| Hide an inapplicable built-in | `disable_tools={...}` | data (names) |
| Configure a built-in | `extra_tools=[WebSearchTool(api_key=...)]` | code (instances) |

### Semantics
- **`extra_tools`** register as the *true final pass* — after built-in, MCP, and agent tools — so a same-named entry overrides a built-in or agent tool. Injected tools inherit the same `working_directory` / `filesystem` / `shell` capability binding as built-ins. The `mcp_` prefix and duplicate names raise at construction (MCP replacement stays on `mcp_manager=` / `extra_mcp_servers=`). An override is logged at INFO for auditability; accidental collisions on the normal path still warn.
- **`disable_tools`** only skips built-in registration — not a global denylist, not a security boundary (that stays with the permission engine). Unknown names raise (validated against the static `BUILTIN_TOOL_NAMES`, pinned to reality by a sync test) instead of silently no-op'ing.
- **`WebSearchTool(backend=, api_key=)`** — explicit args beat the `BOCHA_API_KEY` env var (so two in-process instances can use different backends); `api_key=""` is honored. Unknown backend / `backend="bocha"` without a key fail loudly at construction rather than a `Bearer None` 401 at query time.
- **`Tool` / `AsyncToolBase` / `RegistrableTool`** re-exported from `agentao.host` via a **lazy PEP 562 `__getattr__`** so `import agentao.host` stays lightweight (verified: 5 modules, not 39).

### Deferred (see design §10)
`tool_options` / settings.json — gated on a real JSON-config demand or ~3+ configurable built-ins.

## Design
`docs/design/host-tool-injection.md` / `.zh.md` (status: v1 landed).

## Tests
`tests/test_host_tool_injection.py` — 19 cases covering the four contracts (final-pass override, `mcp_` rejection, unknown-disable rejection, explicit-args>env), capability-binding identity, override audit log, loud web-search failures, and a drift guard pinning `BUILTIN_TOOL_NAMES` to actual registration (enforced with and without the `[web]` extra).

Full suite: **2859 passed, 2 skipped**. Reviewed via internal multi-angle review + an independent Codex pass (converged to CLEAN).

🤖 Generated with [Claude Code](https://claude.com/claude-code)