### PR TITLE
docs(design): runtime tool injection (add_tool / remove_tool) — deferred

### DIFF
--- a/docs/design/host-tool-injection.zh.md
+++ b/docs/design/host-tool-injection.zh.md
@@ -4,6 +4,7 @@
 **读者：** 要给 host 一个声明式工具注入口的 agentao 维护者；以及后续 PR 的评审者。
 **配套：**
 - `docs/design/host-tool-injection.md` — 英文版
+- `docs/design/runtime-tool-injection.zh.md` — 运行时(构造后)对偶 `add_tool` / `remove_tool`(推迟,issue #65)
 - `docs/design/pi-mono-tools-review.md` / `.zh.md` — pi-mono 工具设计对比的来源
 - `docs/design/embedded-host-contract.md` — host 契约稳定边界（本设计的归属处）
 - `agentao/tooling/registry.py` — `register_builtin_tools`，改造主战场

--- a/docs/design/runtime-tool-injection.md
+++ b/docs/design/runtime-tool-injection.md
@@ -1,0 +1,164 @@
+# Runtime tool injection: `add_tool` / `remove_tool` (deferred design)
+
+**Status:** Design draft. **Implementation deferred** until a demand-gate (§8) is met. Tracked in [issue #65](https://github.com/jin-bo/agentao/issues/65).
+**Audience:** agentao maintainers considering, on top of construction-time tool injection (PR #64), a runtime (post-construction) entry point for hosts to add / remove tools.
+**Companions:**
+- `docs/design/runtime-tool-injection.zh.md` — Chinese version
+- `docs/design/host-tool-injection.md` — construction-time injection (`extra_tools` / `disable_tools`), the predecessor to this design
+- `docs/design/embedded-host-contract.md` — the host-contract stability boundary (where this design belongs)
+- `agentao/tools/base.py` — `ToolRegistry` (main change site: add `unregister`)
+- `agentao/tooling/registry.py` — `_bind_and_register` (reused by runtime injection)
+
+---
+
+## 1. Problem: we have construction-time injection, not runtime
+
+PR #64 landed **construction-time** tool injection — `Agentao(extra_tools=..., disable_tools=...)` (see `host-tool-injection.md`). Those two kwargs are consumed once in `_wire_tooling` and **never re-read**.
+
+This design tracks the **runtime** counterpart: a host wanting to add / replace / remove a tool *after* construction, *between* `chat()` calls. Real scenarios:
+
+- An ACP session attaching a connector mid-conversation (the dual of `extra_mcp_servers=` session-scoped injection in `session/new`, Issue 11).
+- A host toggling a capability based on runtime state (e.g. exposing a tool only after login).
+- A long-lived embedded session trimming the tool surface in response to user actions.
+
+## 2. Current state (grep-verified on `main`)
+
+| Fact | Anchor | Implication |
+|---|---|---|
+| **Schema is rebuilt once per `chat()` / `arun()` call** | `runtime/chat_loop/_runner.py:201` (`to_openai_format()` snapshots once, *before* the inner LLM iteration loop) | A registry change made *between* `chat()`/`arun()` calls takes effect on the next call; *within* a single call (across later LLM iterations, stop-hook re-entry) the tool list is frozen |
+| **Dynamic add / replace technically works** | `tools/base.py:209` `ToolRegistry.register(tool, replace=)` | …but that pokes runtime internals; it is not on the `agentao.host` contract surface |
+| **…and it bypasses two safeguards** | `tooling/registry.py:67` `_bind_and_register` | (a) capability binding (`working_directory`/`filesystem`/`shell`) is lost → the tool goes "bare" (ACP cwd isolation + host FS/shell redirection break); (b) the construction-time validation (`mcp_` prefix ban, empty/non-str name guard, override audit log) does not run |
+| **Dynamic removal has no API at all** | `tools/base.py:198-263` (only `register`/`get`/`list_tools`/`to_openai_format`) | No `unregister`/`remove`; `disable_tools` filters at construction only |
+
+In one line: **runtime add/replace is possible but unsafe (bare tools + no validation), and runtime removal has no entry point at all.** Neither is on the contract surface. (Visibility of a change = the next `chat()`/`arun()` call, see §5.)
+
+## 3. Scope: `add_tool` + `remove_tool`, demand-gated
+
+**Only once §8 is triggered**, add two methods to the `agentao.host` contract, **reusing existing infrastructure rather than special-casing**:
+
+```python
+agent.add_tool(tool, *, replace=False)   # reuse _bind_and_register + the extra_tools validation
+agent.remove_tool(name) -> bool          # reuse the new ToolRegistry.unregister(name)
+```
+
+Placed in the `Agentao` public-method cluster alongside `events()` (`agent.py:681`), `active_permissions()` (`agent.py:699`), and `add_host_event_observer()` (`agent.py:658`) — already contract-surface methods.
+
+**Explicitly out of scope:**
+- No mid-turn (within a single `chat()`) visibility — the snapshot already constrains this, see §5.
+- No cross-task concurrent registry mutation — v1 only supports calls *between* `chat()`/`arun()` calls, see §7.
+- No add/remove/replace of plan tools (`_PLAN_ONLY_TOOLS`) — they are reserved names; `add_tool` / `remove_tool` both `ValueError`, see §5.
+- No `tool_options` / settings.json (deferred in `host-tool-injection` §10).
+- No add/remove of MCP tools — those belong to the MCP lifecycle (`mcp_manager=` / `extra_mcp_servers=`), see §5.
+
+## 4. API
+
+### 4.1 `Agentao.add_tool`
+
+```python
+def add_tool(self, tool: "RegistrableTool", *, replace: bool = False) -> None:
+    """Register a tool post-construction. Visible to the model on the next
+    ``chat()`` / ``arun()`` call (see §5).
+
+    Goes through the SAME validation + capability-binding path as
+    ``extra_tools=``:
+    - reject **reserved names** — the ``mcp_`` prefix (MCP namespace) and
+      ``_PLAN_ONLY_TOOLS`` (``plan_save`` / ``plan_finalize``, bound to the
+      plan state machine) — plus empty / non-string names;
+    - bind ``working_directory`` / ``filesystem`` / ``shell``;
+    - ``replace=False`` with a name clash → ``ValueError`` (require an
+      explicit ``replace=True`` — stricter than ``register``'s
+      warn-and-overwrite, fitting a deliberate host call);
+    - ``replace=True`` overrides a built-in / agent / other extra tool,
+      silently, with an INFO audit line.
+    """
+```
+
+### 4.2 `Agentao.remove_tool`
+
+```python
+def remove_tool(self, name: str) -> bool:
+    """Unregister a tool post-construction. Returns whether it was actually
+    removed (absent → False, not an exception).
+
+    - ``mcp_`` prefix / plan tools (``plan_save`` / ``plan_finalize``, i.e.
+      ``_PLAN_ONLY_TOOLS``) → ``ValueError``: the former belongs to the MCP
+      lifecycle, the latter to the plan state machine; neither is removed here.
+    - built-in / extra / agent tools may be removed.
+    - Gone from the model's view on the next ``chat()`` / ``arun()`` call.
+    """
+```
+
+### 4.3 `ToolRegistry.unregister` (new substrate)
+
+```python
+def unregister(self, name: str) -> bool:
+    """Remove ``name`` from the registry. Returns whether it existed. Pure
+    dict op, no side effects."""
+    return self.tools.pop(name, None) is not None
+```
+
+## 5. Semantics & precedence
+
+1. **Visibility = "the next `chat()` / `arun()` call"**. `to_openai_format()` snapshots only *before* each `chat()` enters the inner LLM iteration loop (`_runner.py:201`), so a post-construction add/remove takes effect on the **next prompt/chat call**: *within the same `chat()`* (later LLM iterations, stop-hook re-entry) the tool surface does not change. This is a contract, not a defect — it makes "a consistent tool surface within a single call" an invariant (same source as plan-mode's `plan_*` filtering).
+2. **`add_tool` validates and binds exactly like `extra_tools`**. Extract the **per-tool** validation from PR #64's `_validate_tool_injection` (`agent.py`) into a reusable function (e.g. `_validate_one_extra_tool(tool)`), shared by `add_tool` and the construction-time loop — so runtime injection cannot produce a bare tool, nor use a reserved name (`mcp_` prefix ∪ `_PLAN_ONLY_TOOLS`) to replace an MCP / plan tool. Note: once the reserved-name set includes `_PLAN_ONLY_TOOLS`, construction-time `extra_tools` benefits too — it incidentally closes the old gray zone where an extra named `plan_save` would be overwritten by the CLI's later registration. A consistent tightening.
+3. **Coverage: built-in + agent + extra, not MCP**. The `mcp_` prefix is rejected in both `add_tool`/`remove_tool` — MCP tool names always start with `mcp_` (`mcp/tool.py:19-21` `make_mcp_tool_name`), so runtime injection structurally cannot touch MCP. Runtime MCP add/remove goes through `mcp_manager=` / `extra_mcp_servers=`; clean boundary.
+4. **Plan tools cannot be added / removed / replaced (reserved names)**. `plan_save`/`plan_finalize` are registered by the CLI post-construction (`cli/app.py:91-92`), enter the schema only in plan mode (`_PLAN_ONLY_TOOLS`), and are bound to the plan state machine. `add_tool` (including `replace=True`) **and** `remove_tool` both `ValueError` on `_PLAN_ONLY_TOOLS` names — banning only removal would leave the `add_tool(name="plan_save", replace=True)` loophole, so both ends are banned, leaving no public-API gray zone.
+
+## 6. Implementation sketch (change surface)
+
+| Change | Location |
+|---|---|
+| `ToolRegistry.unregister(name) -> bool` | `tools/base.py`, next to `register` (:209) |
+| Extract per-tool validation `_validate_one_extra_tool(tool)` | `agent.py`, from the existing `_validate_tool_injection`; shared by the construction-time loop and `add_tool`. **Reserved-name set = `mcp_` prefix ∪ `_PLAN_ONLY_TOOLS`**, plus the empty/non-string name guard |
+| `Agentao.add_tool` / `remove_tool` | `agent.py`, in the `events()`/`active_permissions()` cluster (near :681/:699). Both validate against the reserved-name set first (`add_tool` via `_validate_one_extra_tool`; `remove_tool` likewise rejects `mcp_` + `_PLAN_ONLY_TOOLS`), then bind / `unregister` |
+| `add_tool` reuses `_bind_and_register` | already at `tooling/registry.py:67`, no change |
+| Docs + contract surface | add two rows to the public-method table in `docs/api/host.md`; `host/__init__.py` needs no change (these are `Agentao` methods, not package-level symbols) |
+
+A simple route, same shape as PR #64: **grep-verify → design (this doc) → patch + tests**.
+
+## 7. Call timing & concurrency (kept narrow)
+
+v1 **only supports calling `add_tool` / `remove_tool` between `chat()` / `arun()` calls**. It does **not** promise: cross-task concurrent registry mutation, or mutating the registry while a `chat()` is in progress (from another task or from a tool's own `execute()`).
+
+Why: `to_openai_format()` iterates `self.tools` via `sorted(self.tools.values(), ...)` to snapshot, which combined with concurrent `dict` add/remove is **not** safe (can hit "dict changed size during iteration"). Once the semantics are narrowed to "between calls", that combination cannot arise — so v1 **needs no lock**, and **needs no** appeal to single-op GIL atomicity.
+
+If a real "must mutate the tool surface mid-session, concurrently" scenario appears, *then* evaluate adding a lock to `ToolRegistry`, or versioning the snapshot — that's a separate design, not a promise of this doc.
+
+## 8. Implementation trigger (demand gate)
+
+Start implementation only when **one** of these holds (gap ≠ need):
+
+1. A real embedding scenario needs to add/remove tools **mid-session**, where construction-time `extra_tools`/`disable_tools` + rebuilding `Agentao` won't do (e.g. a long ACP session that can't be rebuilt).
+2. An ACP `session/update`-style need appears, requiring a session-scoped dynamic tool surface.
+3. A host reports being forced to poke `agent.tools.register(...)` and hitting the bare-tool (FS/shell unbound) pitfall.
+
+Until then this doc is a spec on the shelf, ensuring the implementation lands in days, not weeks, when triggered.
+
+## 9. Open questions (out of v1 scope, recorded for later)
+
+**v1 converges to three steps, no expansion:** `ToolRegistry.unregister()` + `Agentao.add_tool()` (reusing `_bind_and_register`) + `Agentao.remove_tool()` (name validation then `unregister`). All of the following are **not done** for now:
+
+- **Should `add_tool(replace=False)` raise or warn on a name clash?** (Decide at implementation; leaning raise — a deliberate host call, stricter than `register`'s warn — and distinguish it from `register`'s semantics in the docs.)
+- **Concurrency lock / snapshot versioning** — see §7, await a real signal.
+- **`has_tool(name)` / `list_tool_names()` read-only query surface** — `list_tools()` exists (`base.py:240`) but returns instances; add on demand.
+- **`AgentManager` coupling after `remove_tool` removes an agent tool** — v1 assumes the registry is the sole exposure surface and the sub-agent path holds no dangling references; confirm at implementation, don't pre-build a coupling mechanism.
+
+## 10. What this doc is not
+
+- **Not mid-turn mutation**. A frozen tool surface within a single `chat()` / `arun()` is a deliberate invariant.
+- **Not MCP runtime management**. MCP add/remove goes through `mcp_manager=` / `extra_mcp_servers=`.
+- **Not `tool_options`**. Configuring built-ins stays deferred per `host-tool-injection` §10.
+- **Not a permission-engine bypass**. `remove_tool` reduces schema exposure, not a security boundary; security / authorization stays with the permission engine.
+
+## 11. References
+
+- **Predecessor design:** `host-tool-injection.md` (construction-time injection, PR #64), its §9 (landing prerequisites).
+- **Agentao touch points (verified 2026-06-01):**
+  - `agentao/tools/base.py:198-263` — `ToolRegistry` (no `unregister`).
+  - `agentao/runtime/chat_loop/_runner.py:201` — the `to_openai_format` snapshot taken before `chat()`/`arun()` enters the LLM iteration loop (the *only* runtime tool-surface build point; the `to_openai_format` in `agent.py`'s `get_conversation_summary()` is token estimation, not the runtime tool surface).
+  - `agentao/tooling/registry.py:67` — `_bind_and_register` (capability binding, reused at runtime).
+  - `agentao/tooling/registry.py:138` — `register_extra_tools` (the construction-time final pass, same-shape reference).
+  - `agentao/mcp/tool.py:19-21` — `make_mcp_tool_name` (source of the `mcp_` prefix).
+  - `agentao/cli/app.py:91-92` — plan tools registered post-construction (the orthogonal path).
+  - `agentao/agent.py:658/681/699` — `add_host_event_observer` / `events` / `active_permissions` (the public-method cluster, where the new methods go).
+- **Tracking:** [issue #65](https://github.com/jin-bo/agentao/issues/65).

--- a/docs/design/runtime-tool-injection.zh.md
+++ b/docs/design/runtime-tool-injection.zh.md
@@ -1,0 +1,157 @@
+# 运行时工具注入：`add_tool` / `remove_tool`（推迟设计）
+
+**状态：** 设计草案,**实现推迟**,直到 demand-gate(见 §8)触发。跟踪于 [issue #65](https://github.com/jin-bo/agentao/issues/65)。
+**读者：** 在构造期工具注入(PR #64)之上,考虑给 host 一个运行时(构造后)增/删工具入口的 agentao 维护者。
+**配套:**
+- `docs/design/runtime-tool-injection.md` — 英文版
+- `docs/design/host-tool-injection.zh.md` — 构造期注入(`extra_tools` / `disable_tools`),本设计的前置
+- `docs/design/embedded-host-contract.md` — host 契约稳定边界(本设计的归属处)
+- `agentao/tools/base.py` — `ToolRegistry`(改造主战场:新增 `unregister`)
+- `agentao/tooling/registry.py` — `_bind_and_register`(运行时注入复用它)
+
+---
+
+## 1. 问题:构造期注入有了,运行时没有
+
+PR #64 落地了**构造期**工具注入——`Agentao(extra_tools=..., disable_tools=...)`(见 `host-tool-injection.zh.md`)。这两个 kwarg 在 `_wire_tooling` 里被消费一次,之后**不再读**。
+
+本设计跟踪它的**运行时**对偶:host 想在构造**之后**、两次 `chat()` 调用**之间**增/替/删一个工具。真实场景:
+
+- ACP 会话中途接入一个 connector(对偶于 `extra_mcp_servers=` 在 `session/new` 的会话级注入,Issue 11)。
+- host 依据运行时状态切换某项能力(如登录后才暴露某工具)。
+- 长会话嵌入里按用户操作动态裁剪工具面。
+
+## 2. 现状(已在 `main` 上 grep 核实)
+
+| 事实 | 锚点 | 含义 |
+|---|---|---|
+| **schema 每次 `chat()` / `arun()` 调用重建一次** | `runtime/chat_loop/_runner.py:201`(`to_openai_format()` 在进入内部 LLM 迭代循环**之前**取一次快照) | 两次 `chat()`/`arun()` 调用**之间**改注册表,下一次调用即生效;一次调用**之内**(含后续 LLM iteration、stop-hook re-entry)工具列表冻结 |
+| **动态增/替技术上能跑** | `tools/base.py:209` `ToolRegistry.register(tool, replace=)` | 但这是捅运行时内部,不在 `agentao.host` 契约面 |
+| **但它绕过两道保障** | `tooling/registry.py:67` `_bind_and_register` | (a) capability 绑定(`working_directory`/`filesystem`/`shell`)丢失 → 工具变"裸"(ACP cwd 隔离 + host FS/shell 重定向失效);(b) 构造期校验(`mcp_` 前缀禁令、空名/类型 guard、override 审计日志)全不生效 |
+| **动态移除完全没 API** | `tools/base.py:198-263`(只有 `register`/`get`/`list_tools`/`to_openai_format`) | 无 `unregister`/`remove`;`disable_tools` 只在构造期过滤 |
+
+一句话:**运行时增/替能做但不安全(裸工具 + 无校验),运行时删根本没接口。** 两者都不在契约面里。（变更的可见性 = 下一次 `chat()`/`arun()` 调用,见 §5。）
+
+## 3. 范围:`add_tool` + `remove_tool`,且 demand-gated
+
+**仅当 §8 触发后**,给 `agentao.host` 契约加两个方法,**复用现有基础设施而非特判**:
+
+```python
+agent.add_tool(tool, *, replace=False)   # 复用 _bind_and_register + extra_tools 的校验
+agent.remove_tool(name) -> bool          # 复用新增的 ToolRegistry.unregister(name)
+```
+
+放在 `Agentao` 公共方法簇里,与 `events()`(`agent.py:681`)、`active_permissions()`(`agent.py:699`)、`add_host_event_observer()`(`agent.py:658`)并列——它们已是契约面方法。
+
+**明确不做:**
+- 不做 mid-turn(单次 `chat()` 内)变更可见——snapshot 已天然约束,见 §5。
+- 不做跨 task 并发修改注册表——v1 只支持在两次 `chat()`/`arun()` 调用之间调用,见 §7。
+- 不做 plan 工具(`_PLAN_ONLY_TOOLS`)的增/删/替换——保留名,`add_tool` / `remove_tool` 均直接 `ValueError`,见 §5。
+- 不做 `tool_options` / settings.json(`host-tool-injection` §10 已推迟)。
+- 不做 MCP 工具的增删——那归 MCP 生命周期(`mcp_manager=` / `extra_mcp_servers=`),见 §5。
+
+## 4. 接口
+
+### 4.1 `Agentao.add_tool`
+
+```python
+def add_tool(self, tool: "RegistrableTool", *, replace: bool = False) -> None:
+    """构造后注册一个工具。下一次 ``chat()`` / ``arun()`` 调用对模型可见(见 §5)。
+
+    与 ``extra_tools=`` 走同一条校验 + capability 绑定路径:
+    - 拒绝**保留名**——``mcp_`` 前缀(MCP 命名空间保留)、``_PLAN_ONLY_TOOLS``
+      (``plan_save`` / ``plan_finalize``,与 plan 状态机绑定)——以及空/非字符串名;
+    - 绑定 ``working_directory`` / ``filesystem`` / ``shell``;
+    - ``replace=False`` 且重名 → ``ValueError``(显式要求 ``replace=True``,
+      比 ``register`` 的 warn-and-overwrite 更严,适合有意的 host 调用);
+    - ``replace=True`` 覆盖内置 / agent / 其它 extra 工具,静默 + INFO 审计行。
+    """
+```
+
+### 4.2 `Agentao.remove_tool`
+
+```python
+def remove_tool(self, name: str) -> bool:
+    """构造后注销一个工具。返回是否真的移除了(不存在 → False,非异常)。
+
+    - ``mcp_`` 前缀 / plan 工具(``plan_save`` / ``plan_finalize``,即
+      ``_PLAN_ONLY_TOOLS``)→ ``ValueError``:前者走 MCP 生命周期,后者与
+      plan 状态机绑定,均不归这里删。
+    - 内置 / extra / agent 工具可删。
+    - 下一次 ``chat()`` / ``arun()`` 调用对模型不可见。
+    """
+```
+
+### 4.3 `ToolRegistry.unregister`(新增底座)
+
+```python
+def unregister(self, name: str) -> bool:
+    """从注册表移除 ``name``。返回是否存在过。纯 dict 操作,无副作用。"""
+    return self.tools.pop(name, None) is not None
+```
+
+## 5. 语义与优先级
+
+1. **可见性 = "下一次 `chat()` / `arun()` 调用"**。`to_openai_format()` 只在每次 `chat()` 进入内部 LLM 迭代循环**之前**取一次快照(`_runner.py:201`),所以构造后的增/删在**下一次 prompt/chat 调用**才生效:**同一次 `chat()` 之内**(后续 LLM iteration、stop-hook re-entry)工具面不变。这是契约,不是缺陷——它让"单次调用内工具面一致"成为不变量(与 plan-mode 的 `plan_*` 过滤同源)。
+2. **`add_tool` 与 `extra_tools` 同校验同绑定**。把 PR #64 里 `_validate_tool_injection`(`agent.py`)的**单工具**校验抽成可复用函数(如 `_validate_one_extra_tool(tool)`),`add_tool` 与构造期循环共用——运行时注入不可能产出裸工具,也不可能用保留名(`mcp_` 前缀 ∪ `_PLAN_ONLY_TOOLS`)替换 MCP / plan 工具。注:把保留名集扩到含 `_PLAN_ONLY_TOOLS` 后,构造期 `extra_tools` 也一并受益——顺手堵上「extra 命名为 `plan_save` 被 CLI 后注册覆盖」的旧灰区,是一致的收紧。
+3. **覆盖范围:内置 + agent + extra,不含 MCP**。`mcp_` 前缀在 `add_tool`/`remove_tool` 都被拒——MCP 工具名恒以 `mcp_` 开头(`mcp/tool.py:19-21` `make_mcp_tool_name`),故运行时注入构造上就碰不到 MCP。MCP 的运行时增删走 `mcp_manager=` / `extra_mcp_servers=`,边界清楚。
+4. **plan 工具不可增/删/替换(保留名)**。`plan_save`/`plan_finalize` 由 CLI 在构造后注册(`cli/app.py:91-92`),只在 plan 模式进 schema(`_PLAN_ONLY_TOOLS`),且与 plan 状态机绑定。`add_tool`(含 `replace=True`)**和** `remove_tool` 对 `_PLAN_ONLY_TOOLS` 名**都直接 `ValueError`**——只禁 remove 会留下 `add_tool(name="plan_save", replace=True)` 这个绕口子,故两端一起禁,不留公共 API 灰区。
+
+## 6. 实现草图(改动面)
+
+| 改动 | 位置 |
+|---|---|
+| `ToolRegistry.unregister(name) -> bool` | `tools/base.py`,紧挨 `register`(:209) |
+| 抽出单工具校验 `_validate_one_extra_tool(tool)` | `agent.py`,从现有 `_validate_tool_injection` 提取;构造期循环与 `add_tool` 共用。**保留名集 = `mcp_` 前缀 ∪ `_PLAN_ONLY_TOOLS`**,加空/非字符串名 guard |
+| `Agentao.add_tool` / `remove_tool` | `agent.py`,与 `events()`/`active_permissions()` 同簇(:681/:699 附近)。两者都先按保留名集校验(`add_tool` 走 `_validate_one_extra_tool`;`remove_tool` 同样拒 `mcp_` + `_PLAN_ONLY_TOOLS`),再绑定/`unregister` |
+| `add_tool` 复用 `_bind_and_register` | 已在 `tooling/registry.py:67`,无需改 |
+| 文档 + 契约面 | `docs/api/host.md` 公共方法表加两行;`host/__init__.py` 无需动(是 `Agentao` 方法,非包级符号) |
+
+路线简明,与 PR #64 同形:**grep 验证 → 设计(本文档)→ patch + 测试**。
+
+## 7. 调用时机与并发(写窄)
+
+v1 **只支持在两次 `chat()` / `arun()` 调用之间**调用 `add_tool` / `remove_tool`。**不承诺**:跨 task 并发修改注册表、在一次 `chat()` 进行中(从另一 task 或从工具自身 `execute()` 内)修改注册表。
+
+理由:`to_openai_format()` 对 `self.tools` 做 `sorted(self.tools.values(), ...)` 迭代取快照,与并发的 `dict` 增删组合**不是**安全的(可能撞上"迭代中改变 size")。把语义写窄到"调用之间"后,这种组合天然不会发生——于是 v1 **无需加锁**,也**无需**依赖任何单操作 GIL 原子性的论证。
+
+若将来出现"会话进行中需并发改工具面"的真实场景,再评估给 `ToolRegistry` 加锁或快照加版本号——那是另一项设计,不是本文档的承诺。
+
+## 8. 实现触发条件(demand gate)
+
+满足**其一**才启动实现(gap≠need):
+
+1. 真实嵌入场景需要会话**中途**增/删工具,且构造期 `extra_tools`/`disable_tools` + 重建 `Agentao` 无法满足(如长 ACP 会话不能重建)。
+2. ACP `session/update` 类需求出现,要求会话级动态工具面。
+3. 有 host 反馈"只能捅 `agent.tools.register(...)`,且踩了裸工具(FS/shell 未绑定)的坑"。
+
+在此之前本文档是"束之高阁的规格",确保触发时实现以日为单位。
+
+## 9. 待定问题(v1 范围外,记录备查)
+
+**v1 收敛为三步,不扩张:** `ToolRegistry.unregister()` + `Agentao.add_tool()`(复用 `_bind_and_register`)+ `Agentao.remove_tool()`(名字校验后 `unregister`)。下列均**先不做**:
+
+- **`add_tool(replace=False)` 重名该 raise 还是 warn?**(实现时定;倾向 raise,显式 host 调用严于 `register` 的 warn——届时在文档里与 `register` 语义区分清楚。)
+- **并发加锁 / 快照版本号**——见 §7,等真实信号。
+- **`has_tool(name)` / `list_tool_names()` 只读查询面**——`list_tools()` 已存在(`base.py:240`)但返回实例;按需再加。
+- **`remove_tool` 删 agent 工具后的 `AgentManager` 联动**——v1 假设注册表是唯一暴露面、sub-agent 路径无悬挂引用,实现时确认即可,不预设联动机制。
+
+## 10. 本文档不是什么
+
+- **不是 mid-turn 变更**。单次 `chat()` / `arun()` 内工具面冻结是有意的不变量。
+- **不是 MCP 运行时管理**。MCP 增删走 `mcp_manager=` / `extra_mcp_servers=`。
+- **不是 `tool_options`**。配置内置仍按 `host-tool-injection` §10 推迟。
+- **不是绕过 permission engine**。`remove_tool` 减的是 schema 暴露,不是安全边界;安全/越权仍归 permission engine。
+
+## 11. 引用
+
+- **前置设计:** `host-tool-injection.zh.md`(构造期注入,PR #64)、其 §9(落地前置)。
+- **Agentao 触及面(2026-06-01 验证):**
+  - `agentao/tools/base.py:198-263` — `ToolRegistry`(无 `unregister`)。
+  - `agentao/runtime/chat_loop/_runner.py:201` — `chat()`/`arun()` 进入 LLM 迭代循环前的 `to_openai_format` 快照(唯一的运行时工具面构建点;`agent.py` 里 `get_conversation_summary()` 那处 `to_openai_format` 是 token 估算,不是运行时工具面)。
+  - `agentao/tooling/registry.py:67` — `_bind_and_register`(capability 绑定,运行时复用)。
+  - `agentao/tooling/registry.py:138` — `register_extra_tools`(构造期最后 pass,同形参照)。
+  - `agentao/mcp/tool.py:19-21` — `make_mcp_tool_name`(`mcp_` 前缀来源)。
+  - `agentao/cli/app.py:91-92` — plan 工具构造后注册(正交路径)。
+  - `agentao/agent.py:658/681/699` — `add_host_event_observer` / `events` / `active_permissions`(公共方法簇,新方法的放置处)。
+- **跟踪:** [issue #65](https://github.com/jin-bo/agentao/issues/65)。


### PR DESCRIPTION
## What

Design doc for the **runtime** (post-construction) counterpart to PR #64's construction-time `extra_tools` / `disable_tools`. A **demand-gated "spec on the shelf"** (same posture as `tool-search`): no implementation, tracked in #65.

Bilingual: `docs/design/runtime-tool-injection.md` + `.zh.md`, cross-linked from `host-tool-injection.zh.md`.

## Design highlights (anchors grep-verified on `main`)

- **Surface:** `Agentao.add_tool(tool, *, replace=False)` / `remove_tool(name) -> bool` + a new `ToolRegistry.unregister()`. Reuses `_bind_and_register` and an extracted per-tool validator instead of special-casing.
- **Visibility = the next `chat()`/`arun()` call.** The tool schema is snapshotted once *before* the inner LLM loop (`runtime/chat_loop/_runner.py:201`), so mutations land on the next call, never mid-call. (`agent.py`'s `get_conversation_summary()` `to_openai_format` is token estimation, not the runtime tool surface — explicitly noted to avoid a phantom second build point.)
- **Concurrency kept narrow:** supported only *between* `chat()`/`arun()` calls. `to_openai_format` iterates `sorted(self.tools.values(), …)`, which isn't safe against concurrent dict mutation — narrowing the contract means v1 needs **no lock** and **no GIL-atomicity argument**.
- **Reserved names (`mcp_` prefix ∪ `_PLAN_ONLY_TOOLS`) rejected by BOTH `add_tool` and `remove_tool`.** MCP stays on its lifecycle (`mcp_manager=` / `extra_mcp_servers=`); plan tools stay bound to the plan state machine. Banning only removal would leave the `add_tool("plan_save", replace=True)` loophole — so both ends are banned. Extracting the shared validator also incidentally closes the construction-time gap where an extra named `plan_save` was clobbered by the CLI's later registration.
- **Scope converged to three steps**, everything else (concurrency lock, `has_tool`/`list_tool_names`, `AgentManager` coupling, plan deletion) explicitly deferred.

## Demand gate

Implementation starts only when a concrete embedding needs mid-session tool mutation that construction-time injection + rebuild can't satisfy (e.g. a long ACP session), an ACP `session/update`-style need appears, or a host reports the bare-tool pitfall from poking `agent.tools.register(...)`. See §8.

Refs: #65, PR #64.

🤖 Generated with [Claude Code](https://claude.com/claude-code)