### PR TITLE
fix(search): kill the whole process tree on subprocess timeout

### DIFF
--- a/agentao/tools/search.py
+++ b/agentao/tools/search.py
@@ -1,7 +1,10 @@
 """Search tools."""
 
+import os
 import shutil
+import signal
 import subprocess
+import sys
 import time
 from pathlib import Path
 from typing import Any, Dict, FrozenSet, List, Optional
@@ -15,6 +18,98 @@ from ..capabilities import FileSystem, LocalFileSystem
 def _find_executable(name: str) -> Optional[str]:
     """Locate an external binary on PATH (absolute path) or return None."""
     return shutil.which(name)
+
+
+def _kill_tree(proc: "subprocess.Popen") -> None:
+    """Best-effort kill of ``proc`` *and every descendant it spawned*.
+
+    ``Popen.kill()`` only signals the direct child, so a timed-out ``git``
+    (which on Windows routinely forks helper / credential processes) leaves
+    grandchildren alive — and because they inherit the captured pipe's
+    write end, ``communicate()`` never sees EOF and the search worker hangs.
+    We address the whole tree instead: ``taskkill /T`` on Windows, the
+    process group via ``killpg`` elsewhere.
+    """
+    if sys.platform == "win32":
+        try:
+            subprocess.run(
+                ["taskkill", "/F", "/T", "/PID", str(proc.pid)],
+                stdin=subprocess.DEVNULL,
+                capture_output=True,
+                timeout=5,
+            )
+            return
+        except Exception:
+            pass  # fall through to the single-process kill below
+    else:
+        # ``start_new_session=True`` made the child a session/group leader,
+        # so its pgid == its pid. Use the pid directly rather than
+        # ``os.getpgid(pid)``: if the direct child already exited (leaving a
+        # grandchild holding the pipe), getpgid on the zombie can fail and
+        # we'd lose the whole group. The group id stays valid while any
+        # member lives, so ``killpg(pid)`` still reaps the grandchild.
+        try:
+            os.killpg(proc.pid, signal.SIGKILL)
+            return
+        except Exception:
+            pass  # fall through to the single-process kill below
+    try:
+        proc.kill()
+    except Exception:
+        pass
+
+
+def _run_capture(
+    cmd: List[str],
+    cwd: str,
+    timeout: float,
+) -> subprocess.CompletedProcess:
+    """Run ``cmd`` capturing text stdout/stderr, hardened for timeouts.
+
+    Differs from a plain ``subprocess.run(..., timeout=)`` in three ways
+    that matter for an embedded / ACP-over-stdio host:
+
+    - ``stdin=DEVNULL`` so a child (e.g. ``git`` asking for credentials)
+      can never read — and thereby steal — the host's stdin stream.
+    - The child leads its own process group / session, so a timeout can
+      reap the *entire* tree rather than just the direct child.
+    - On timeout we kill that tree, then drain, and re-raise
+      :class:`subprocess.TimeoutExpired` so callers fall back exactly as
+      they did under ``subprocess.run``.
+
+    ``errors="replace"`` keeps a match line that isn't valid UTF-8 (a
+    Latin-1 source file, a mixed-encoding tree) from raising
+    ``UnicodeDecodeError`` mid-decode — that error is neither
+    ``SubprocessError`` nor ``FileNotFoundError``, so it would escape the
+    callers' ``except`` and abort the whole search instead of degrading
+    gracefully.
+    """
+    popen_kwargs: Dict[str, Any] = {
+        "cwd": cwd,
+        "stdin": subprocess.DEVNULL,
+        "stdout": subprocess.PIPE,
+        "stderr": subprocess.PIPE,
+        "text": True,
+        "errors": "replace",
+    }
+    if sys.platform == "win32":
+        popen_kwargs["creationflags"] = subprocess.CREATE_NEW_PROCESS_GROUP
+    else:
+        popen_kwargs["start_new_session"] = True
+
+    proc = subprocess.Popen(cmd, **popen_kwargs)
+    try:
+        stdout, stderr = proc.communicate(timeout=timeout)
+    except subprocess.TimeoutExpired:
+        _kill_tree(proc)
+        # The group is dead now, so the inherited pipe write ends are
+        # released and this second drain returns promptly.
+        try:
+            proc.communicate(timeout=5)
+        except Exception:
+            pass
+        raise
+    return subprocess.CompletedProcess(cmd, proc.returncode, stdout, stderr)
 
 # Files modified within this window are sorted by recency
 RECENCY_THRESHOLD = 86400  # 24 hours
@@ -227,11 +322,9 @@ class SearchTextTool(Tool):
     def _is_git_repo(self, directory: Path) -> bool:
         """Check if directory is inside a git repository."""
         try:
-            result = subprocess.run(
+            result = _run_capture(
                 ["git", "rev-parse", "--is-inside-work-tree"],
                 cwd=str(directory),
-                capture_output=True,
-                text=True,
                 timeout=5,
             )
             return result.returncode == 0
@@ -268,13 +361,7 @@ class SearchTextTool(Tool):
                 clean_pattern = file_pattern.replace("**/", "")
                 cmd.extend(["--", clean_pattern])
 
-            result = subprocess.run(
-                cmd,
-                cwd=str(directory),
-                capture_output=True,
-                text=True,
-                timeout=30,
-            )
+            result = _run_capture(cmd, cwd=str(directory), timeout=30)
 
             if result.returncode == 1:
                 return f"No matches found for pattern: {pattern}"
@@ -330,13 +417,7 @@ class SearchTextTool(Tool):
             # `--pre=/tmp/payload.sh` is treated as text, not a flag.
             cmd.extend(["--", pattern, "."])
 
-            result = subprocess.run(
-                cmd,
-                cwd=str(directory),
-                capture_output=True,
-                text=True,
-                timeout=30,
-            )
+            result = _run_capture(cmd, cwd=str(directory), timeout=30)
 
             # rg exit codes: 0 = matches, 1 = no matches, 2 = error.
             if result.returncode == 1:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -58,11 +58,15 @@ def search_tool(tmp_path: Path):
 
 @pytest.fixture
 def capture_subprocess_run(monkeypatch) -> List[List[str]]:
-    """Replace ``search.subprocess.run`` with an argv-capturing stub.
+    """Replace ``search._run_capture`` with an argv-capturing stub.
 
     Returns the list that captured argv lists are appended to.  The stub
     returns ``returncode=1`` so the caller hits the "no matches" branch
     and exits without real I/O — keeping tests focused on argv shape.
+
+    ``_run_capture`` (not ``subprocess.run``) is the seam: the search
+    tool runs every external engine through it for stdin-detach /
+    process-group / kill-the-tree-on-timeout hardening.
     """
     from agentao.tools import search as search_mod
 
@@ -72,5 +76,5 @@ def capture_subprocess_run(monkeypatch) -> List[List[str]]:
         captured.append(cmd)
         return SimpleNamespace(returncode=1, stdout="", stderr="")
 
-    monkeypatch.setattr(search_mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(search_mod, "_run_capture", fake_run)
     return captured

--- a/tests/test_search_ripgrep_fallback.py
+++ b/tests/test_search_ripgrep_fallback.py
@@ -226,7 +226,7 @@ def test_ripgrep_internal_error_returns_none(monkeypatch, tmp_path, search_tool)
     def fake_run(cmd, **kwargs):
         return SimpleNamespace(returncode=2, stdout="", stderr="rg: error")
 
-    monkeypatch.setattr(search_mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(search_mod, "_run_capture", fake_run)
 
     result = search_tool._ripgrep(
         directory=tmp_path,
@@ -245,7 +245,7 @@ def test_ripgrep_filenotfound_returns_none(monkeypatch, tmp_path, search_tool):
     def fake_run(cmd, **kwargs):
         raise FileNotFoundError("rg")
 
-    monkeypatch.setattr(search_mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(search_mod, "_run_capture", fake_run)
 
     result = search_tool._ripgrep(
         directory=tmp_path,
@@ -269,7 +269,7 @@ def test_ripgrep_skip_filter_applied_to_lines(monkeypatch, tmp_path, search_tool
     def fake_run(cmd, **kwargs):
         return SimpleNamespace(returncode=0, stdout=stdout, stderr="")
 
-    monkeypatch.setattr(search_mod.subprocess, "run", fake_run)
+    monkeypatch.setattr(search_mod, "_run_capture", fake_run)
 
     out = search_tool._ripgrep(
         directory=tmp_path,

--- a/tests/test_search_run_capture.py
+++ b/tests/test_search_run_capture.py
@@ -1,0 +1,77 @@
+"""Regression coverage for ``search._run_capture`` — the hardened subprocess
+runner behind ``search_file_content``.
+
+Every other search test stubs ``_run_capture`` out to assert argv shape, so
+the hardening it exists for (stdin detached, own process group, kill-the-tree
+on timeout) had no coverage. These drive the *real* helper end to end. They
+spawn ``sys.executable`` so they run identically on POSIX and Windows.
+"""
+
+import subprocess
+import sys
+import time
+
+import pytest
+
+from agentao.tools.search import _run_capture
+
+
+def test_run_capture_returns_completed_process(tmp_path):
+    """Happy path: captures text stdout and the real exit code."""
+    result = _run_capture(
+        [sys.executable, "-c", "print('hello')"],
+        cwd=str(tmp_path),
+        timeout=10,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == "hello"
+
+
+def test_run_capture_stdin_is_devnull(tmp_path):
+    """Children get an immediate-EOF stdin, never the host's stdin stream."""
+    result = _run_capture(
+        [sys.executable, "-c", "import sys; sys.stdout.write(str(len(sys.stdin.read())))"],
+        cwd=str(tmp_path),
+        timeout=10,
+    )
+    assert result.returncode == 0
+    assert result.stdout.strip() == "0"
+
+
+def test_run_capture_decodes_non_utf8_without_raising(tmp_path):
+    """A non-UTF-8 byte on stdout must not raise UnicodeDecodeError.
+
+    ``errors='replace'`` keeps the helper from aborting the whole search
+    (callers only catch SubprocessError/FileNotFoundError) when a match line
+    isn't valid UTF-8.
+    """
+    result = _run_capture(
+        [sys.executable, "-c", r"import sys; sys.stdout.buffer.write(b'\xff\xfe')"],
+        cwd=str(tmp_path),
+        timeout=10,
+    )
+    assert result.returncode == 0  # decoded with replacement, no crash
+
+
+def test_run_capture_timeout_raises_and_does_not_hang_on_grandchild(tmp_path):
+    """The core fix: a child that spawns a grandchild holding the pipe open
+    must still time out promptly.
+
+    Plain ``subprocess.run(timeout=)`` signals only the direct child, so the
+    grandchild keeps the inherited pipe's write end open and ``communicate``
+    blocks far past the timeout. ``_run_capture`` reaps the whole tree, so the
+    call returns near the timeout, not near the grandchild's sleep.
+    """
+    # Child spawns a 30s-sleeping grandchild, then exits immediately.
+    child = (
+        "import subprocess, sys; "
+        "subprocess.Popen([sys.executable, '-c', 'import time; time.sleep(30)']); "
+        "print('started', flush=True)"
+    )
+    start = time.monotonic()
+    with pytest.raises(subprocess.TimeoutExpired):
+        _run_capture([sys.executable, "-c", child], cwd=str(tmp_path), timeout=2)
+    elapsed = time.monotonic() - start
+    # Generous bound: well under the grandchild's 30s sleep. A regression that
+    # drops the kill-tree teardown would blow past this (hang ~= 30s).
+    assert elapsed < 15, f"timeout path hung for {elapsed:.1f}s — tree not reaped"


### PR DESCRIPTION
## Problem

`search_file_content` shells out to `git grep` / `ripgrep` via `subprocess.run(capture_output=True, timeout=)`. On timeout, `subprocess.run` signals **only the direct child**. On Windows, `git` routinely forks helper/credential grandchildren that inherit the captured pipe's write end, so `communicate()` never sees EOF and the search worker **hangs indefinitely** despite the timeout.

This surfaced as an **ACP disconnect**: a turn issued 5 parallel `search_file_content` calls against a Windows Android tree; the hung grep subprocesses saturated the tool pool, the turn never completed, and the ACP client timed out and dropped the stdio connection. The log froze at `Processing 5 tool call(s) in iteration 5` with nothing after.

## Fix

Route all three engine calls (`_is_git_repo`, `_git_grep`, `_ripgrep`) through a new `_run_capture()` helper that:

- **Detaches stdin** (`DEVNULL`) so a child (e.g. `git` asking for credentials) can never read — and thereby steal — the host's stdin, which over ACP is the JSON-RPC channel.
- **Runs the child in its own process group / session** (`start_new_session` on POSIX, `CREATE_NEW_PROCESS_GROUP` on Windows).
- **Kills the entire tree on timeout** — `taskkill /F /T /PID` on Windows, `os.killpg(proc.pid, SIGKILL)` elsewhere (uses `proc.pid` rather than `os.getpgid(pid)` so a zombie direct-child can't orphan the group) — then re-raises `TimeoutExpired` so callers fall back exactly as they did under `subprocess.run`.
- **Decodes with `errors="replace"`** so a non-UTF-8 match line can't raise `UnicodeDecodeError` past the callers' `except (SubprocessError, FileNotFoundError)` and abort the whole search instead of degrading to the Python fallback.

This brings the search tool in line with the stdin-detach / process-group / kill-tree discipline `LocalShellExecutor` already follows.

## Tests

- Moved the argv-capture test seam from `subprocess.run` to `_run_capture`.
- Added `tests/test_search_run_capture.py`: happy-path capture, `stdin=DEVNULL` (immediate EOF), non-UTF-8 decode-without-raising, and the **grandchild-pipe timeout** regression that hangs ~30s if the kill-tree teardown ever regresses.
- All 43 search tests pass; clean `/code-review` (high) and Codex review.

## Follow-ups (out of scope)

- `agentao/plugins/hooks/_dispatcher.py:259` runs arbitrary user hook commands (`shell=True`) with the same unhardened `subprocess.run(timeout=)` pattern — a higher-risk instance worth its own PR.
- Consider extracting a shared hardened runner so `search`, `shell`, and the hook dispatcher don't each maintain their own platform teardown matrix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)