### PR TITLE
refactor(shell): share kill_process_tree teardown with the batch runner

### DIFF
--- a/agentao/capabilities/process.py
+++ b/agentao/capabilities/process.py
@@ -19,8 +19,9 @@ before re-raising :class:`subprocess.TimeoutExpired` so callers fall back
 exactly as they did under ``subprocess.run``.
 
 ``LocalShellExecutor`` (``capabilities/shell.py``) keeps its own
-reader-thread variant for streaming/background semantics; batch callers
-(``search_file_content``, plugin hook commands) share this one.
+reader-thread run loop for streaming + inactivity-timeout semantics, but
+shares :func:`kill_process_tree` for teardown; batch callers
+(``search_file_content``, plugin hook commands) use :func:`run_captured`.
 """
 
 from __future__ import annotations
@@ -34,7 +35,7 @@ from typing import Any, Dict, Optional, Sequence, Union
 __all__ = ["run_captured", "kill_process_tree"]
 
 
-def kill_process_tree(proc: "subprocess.Popen[str]") -> None:
+def kill_process_tree(proc: "subprocess.Popen[Any]") -> None:
     """Best-effort kill of ``proc`` *and every descendant it spawned*.
 
     ``Popen.kill()`` only signals the direct child, so a timed-out process

--- a/agentao/capabilities/shell.py
+++ b/agentao/capabilities/shell.py
@@ -14,7 +14,6 @@ byte-equivalent.
 from __future__ import annotations
 
 import os
-import signal
 import subprocess
 import sys
 import threading
@@ -22,6 +21,8 @@ import time
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Protocol, runtime_checkable
+
+from .process import kill_process_tree
 
 IS_WINDOWS = sys.platform == "win32"
 
@@ -138,17 +139,11 @@ class LocalShellExecutor:
         while proc.poll() is None:
             if time.monotonic() - last_activity[0] > timeout:
                 timed_out[0] = True
-                try:
-                    if IS_WINDOWS:
-                        subprocess.run(
-                            ["taskkill", "/T", "/F", "/PID", str(proc.pid)],
-                            stdin=subprocess.DEVNULL,
-                            capture_output=True,
-                        )
-                    else:
-                        os.killpg(os.getpgid(proc.pid), signal.SIGKILL)
-                except ProcessLookupError:
-                    proc.kill()
+                # Shared teardown: kills the whole tree (taskkill /T or
+                # killpg) via the child's pid, so a grandchild holding the
+                # captured pipe can't survive the kill — and sidesteps the
+                # getpgid-on-a-zombie ProcessLookupError this used to hit.
+                kill_process_tree(proc)
                 break
             time.sleep(0.05)
 


### PR DESCRIPTION
## Context

Follow-up to #73 / #74. Those introduced `capabilities/process.kill_process_tree()` and routed `search_file_content` and the plugin hook dispatcher through the shared hardened runner. This converges the **third** teardown copy — the one inlined in `LocalShellExecutor.run()` — onto the same primitive.

## Why

`run()` killed timed-out processes with:

```python
os.killpg(os.getpgid(proc.pid), signal.SIGKILL)   # shell.py
except ProcessLookupError:
    proc.kill()
```

`os.getpgid()` raises `ProcessLookupError` once the direct child has become a zombie (e.g. it exited after backgrounding a grandchild). The fallback `proc.kill()` then signals **only the direct child**, leaving a grandchild that still holds the captured pipe's write end alive — the same hang class #73 fixed for search.

`kill_process_tree()` kills via the child's **pid** (== pgid under `start_new_session`, which `run()` already sets), so it never calls `getpgid`, while keeping the `taskkill /T` (Windows) / `killpg` + `proc.kill()` fallback ladder.

## Change

- `run()`'s inline `taskkill`/`killpg` block → `kill_process_tree(proc)`. Drops the now-unused `signal` import.
- Generalized the helper annotation to `Popen[Any]` (the shell runs in byte mode, `Popen[bytes]`).

**Scope is deliberately narrow:** `run()`'s reader-thread **streaming** + **inactivity-timeout** loop is untouched — those are intentionally different from the batch `communicate()` model in `run_captured`, so only the kill *primitive* is shared, not the run loop. `run_background` is unchanged.

## Tests

- Full suite green: **2918 passed, 2 skipped**.
- Functional check: `LocalShellExecutor.run("sleep 30 & sleep 30", timeout=2)` returns `timed_out=True` and reaps the whole process group.
- New module clean under `mypy --strict`; CI host typing gate passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)