### PR TITLE
docs(guide): sync ACP startup-resume into the developer guide (EN+ZH)

### DIFF
--- a/developer-guide/en/appendix/c-acp-messages.md
+++ b/developer-guide/en/appendix/c-acp-messages.md
@@ -77,6 +77,8 @@ Create a fresh session.
 | `-32002` | Called before `initialize` (SERVER_NOT_INITIALIZED) |
 | `-32602` | `cwd` not absolute / doesn't exist / `mcpServers` malformed |
 
+> **Startup resume.** When the server was launched with `agentao --acp --resume [SESSION_ID]`, the **first** `session/new` resumes a persisted session instead of starting blank: it replays history as `session/update` notifications and returns the persisted `sessionId`. A miss (empty store / unknown id / corrupt file / id already active) silently degrades to a normal fresh session. See [3.2 → Resume a session on startup](/en/part-3/2-agentao-as-server#resume-a-session-on-startup).
+
 ## C.3 `session/prompt`
 
 Run one user turn. Returns when the agent stops.

--- a/developer-guide/en/cli/12-non-interactive.md
+++ b/developer-guide/en/cli/12-non-interactive.md
@@ -183,13 +183,17 @@ agentao --resume a1b2c3
 
 Without an id, this resumes the latest session. With an id, it matches by prefix. Inside the REPL, the equivalent is `/sessions resume <id>`.
 
+Combined with `--acp`, `--resume` resumes on the **first `session/new`** instead — see [`--acp --stdio`](#acp-stdio-—-run-as-an-acp-server) below.
+
 ## `--acp --stdio` — run as an ACP server
 
 ```bash
 agentao --acp --stdio
+agentao --acp --resume               # resume the latest session on first session/new
+agentao --acp --resume <SESSION_ID>  # resume a specific session on first session/new
 ```
 
-This starts Agentao as an ACP stdio JSON-RPC server for IDEs, host processes, or other agents. `--stdio` is currently meaningful only with `--acp`.
+This starts Agentao as an ACP stdio JSON-RPC server for IDEs, host processes, or other agents. `--stdio` is currently meaningful only with `--acp`. Adding `--resume` arms a one-shot directive that the first `session/new` consumes to hydrate + replay a persisted session (any miss degrades to a fresh session). See [3.2 Agentao as an ACP Server → Resume a session on startup](/en/part-3/2-agentao-as-server#resume-a-session-on-startup).
 
 ## `--plugin-dir` — load plugins temporarily
 

--- a/developer-guide/en/part-3/2-agentao-as-server.md
+++ b/developer-guide/en/part-3/2-agentao-as-server.md
@@ -16,6 +16,19 @@ agentao --acp --stdio
 
 **Logs**: Agentao writes to `<session-cwd>/agentao.log` (the `cwd` from the handshake). Hosts can tail / inspect it for debugging.
 
+## Resume a session on startup
+
+```bash
+agentao --acp --resume                 # resume the latest saved session
+agentao --acp --resume <SESSION_ID>    # resume a specific session (UUID / prefix / timestamp)
+```
+
+ACP is client-driven — the server can't open a session on its own — so `--resume` arms a **one-shot directive consumed by the first `session/new`**. That request hydrates the persisted history, replays it as `session/update` notifications (exactly like `session/load`), and returns the **persisted `sessionId`** instead of a fresh one. Every later `session/new` on the connection starts blank.
+
+The store is keyed by the client-supplied `cwd`, so the lookup runs at request time against `<cwd>/.agentao/sessions`. Any recoverable miss — empty store, unknown id, corrupt file, or an id already live in the registry — **degrades to a fresh session** (logged at WARNING) rather than failing the client's first `session/new`.
+
+> The resumed `sessionId` is only returned in the `session/new` response, so the replayed `session/update` notifications arrive *before* the client learns that id. Clients that strictly validate `session/update.sessionId` against sessions they opened may drop those early updates; the conversation still continues correctly from the next prompt. See [docs/ACP.md](https://github.com/jin-bo/agentao/blob/main/docs/ACP.md#resume-a-session-on-startup).
+
 ## Full method catalog
 
 ### Host → Agent (5 request methods)

--- a/developer-guide/en/part-7/2-ide-plugin.md
+++ b/developer-guide/en/part-7/2-ide-plugin.md
@@ -168,6 +168,8 @@ const sessionId = saved
 ctx.globalState.update("agentao.sessionId", sessionId);
 ```
 
+> If your plugin doesn't track ids and just wants the **last** conversation back, spawn the server with `agentao --acp --resume` instead — the first `session/new` then resumes the latest session automatically (no `session/load` round trip). See [3.2 → Resume a session on startup](/en/part-3/2-agentao-as-server#resume-a-session-on-startup).
+
 ## Configuration file the plugin ships with
 
 Drop `.agentao/acp.json` at workspace root so users can customize without touching extension code:

--- a/developer-guide/zh/appendix/c-acp-messages.md
+++ b/developer-guide/zh/appendix/c-acp-messages.md
@@ -77,6 +77,8 @@ Agentao 的 ACP 服务器/客户端发出的每种消息的字段级速查。端
 | `-32002` | 在 `initialize` 之前调（SERVER_NOT_INITIALIZED） |
 | `-32602` | `cwd` 不是绝对/不存在，或 `mcpServers` 格式错 |
 
+> **启动时恢复。** 当 server 以 `agentao --acp --resume [SESSION_ID]` 启动时，**第一个** `session/new` 会恢复持久化会话而非新建空会话：把历史作为 `session/update` 通知重放，并返回持久化的 `sessionId`。未命中（空存储 / 未知 id / 文件损坏 / id 已存活）会静默降级为普通的全新会话。见 [3.2 → 启动时恢复会话](/zh/part-3/2-agentao-as-server#启动时恢复会话)。
+
 ## C.3 `session/prompt`
 
 跑一轮用户交互，返回时 agent 已停。

--- a/developer-guide/zh/cli/12-non-interactive.md
+++ b/developer-guide/zh/cli/12-non-interactive.md
@@ -183,13 +183,17 @@ agentao --resume a1b2c3
 
 不带 id 恢复最近会话；带 id 时按前缀匹配。REPL 内同等命令是 `/sessions resume <id>`。
 
+与 `--acp` 同时使用时，`--resume` 改为在**第一个 `session/new`** 上恢复——见下方 [`--acp --stdio`](#acp-stdio-—-作为-acp-server)。
+
 ## `--acp --stdio` — 作为 ACP Server
 
 ```bash
 agentao --acp --stdio
+agentao --acp --resume               # 第一个 session/new 恢复最近会话
+agentao --acp --resume <SESSION_ID>  # 第一个 session/new 恢复指定会话
 ```
 
-这会把 Agentao 作为 ACP stdio JSON-RPC server 启动，供 IDE、宿主进程或其他 agent 调用。`--stdio` 当前只在 `--acp` 下有效。
+这会把 Agentao 作为 ACP stdio JSON-RPC server 启动，供 IDE、宿主进程或其他 agent 调用。`--stdio` 当前只在 `--acp` 下有效。加上 `--resume` 会装载一个一次性指令，由第一个 `session/new` 消费来注入并重放持久化会话（任何未命中都降级为全新会话）。见 [3.2 Agentao 作为 ACP Server → 启动时恢复会话](/zh/part-3/2-agentao-as-server#启动时恢复会话)。
 
 ## `--plugin-dir` — 临时加载插件
 

--- a/developer-guide/zh/part-3/2-agentao-as-server.md
+++ b/developer-guide/zh/part-3/2-agentao-as-server.md
@@ -16,6 +16,19 @@ agentao --acp --stdio
 
 **日志**：Agentao 会把日志写入 `<session-cwd>/agentao.log`（ACP 握手里客户端传入的 `cwd`）。宿主可以轮询/监听这个文件做调试。
 
+## 启动时恢复会话
+
+```bash
+agentao --acp --resume                 # 恢复最近保存的会话
+agentao --acp --resume <SESSION_ID>    # 恢复指定会话（UUID / 前缀 / 时间戳）
+```
+
+ACP 是客户端驱动的——server 不能自己开会话——所以 `--resume` 装载一个**由第一个 `session/new` 消费的一次性指令**。该请求会注入持久化历史、把它作为 `session/update` 通知重放（和 `session/load` 完全一致），并返回**持久化的 `sessionId`** 而非新生成的。此后该连接上的每个 `session/new` 都是全新空会话。
+
+会话存储以客户端传入的 `cwd` 为键，因此查找在请求时针对 `<cwd>/.agentao/sessions` 进行。任何可恢复的未命中——空存储、未知 id、文件损坏、或 id 已在注册表中存活——都会**降级为全新会话**（以 WARNING 记录），而不是让客户端的第一个 `session/new` 失败。
+
+> 恢复出的 `sessionId` 只在 `session/new` 响应里返回，因此重放的 `session/update` 通知会**先于**客户端得知该 id 到达。对 `session/update.sessionId` 做严格校验的客户端可能会丢弃这些早到的更新；但从下一次 prompt 起对话仍能正确续上。参见 [docs/ACP.md](https://github.com/jin-bo/agentao/blob/main/docs/ACP.md#resume-a-session-on-startup)。
+
 ## 完整方法清单
 
 ### 宿主 → Agent（5 个请求方法）

--- a/developer-guide/zh/part-7/2-ide-plugin.md
+++ b/developer-guide/zh/part-7/2-ide-plugin.md
@@ -168,6 +168,8 @@ const sessionId = saved
 ctx.globalState.update("agentao.sessionId", sessionId);
 ```
 
+> 如果插件不想自己记 id，只想把**最近**那次对话拿回来，可以改用 `agentao --acp --resume` 启动 server——这样第一个 `session/new` 会自动恢复最近会话（省去一次 `session/load` 往返）。见 [3.2 → 启动时恢复会话](/zh/part-3/2-agentao-as-server#启动时恢复会话)。
+
 ## 插件自带的配置文件
 
 在 workspace 根目录放 `.agentao/acp.json`，用户无需改扩展代码就能定制：


### PR DESCRIPTION
## What

Follow-up to #76. The `agentao --acp --resume [SESSION_ID]` feature was documented in `docs/ACP.md` but not the VitePress developer guide. This syncs it across every guide surface that describes the ACP server or the `--resume` flag, in **both EN and ZH**.

## Changes (8 files)

| Page | Change |
|---|---|
| `part-3/2-agentao-as-server` | New **"Resume a session on startup"** section — semantics, permissive fallback (empty store / unknown id / corrupt file / already-active → fresh), and the replay-before-response caveat |
| `cli/12-non-interactive` | `--resume` section notes ACP behavior; `--acp --stdio` section shows the `--resume` form |
| `appendix/c-acp-messages` | Startup-resume note on **C.2 `session/new`** |
| `part-7/2-ide-plugin` | Cross-ref from "Persist + resume across IDE restart" — `--acp --resume` as the no-id alternative to `session/load` |

## Verification

- `vitepress build` compiles clean (no errors).
- Every new/referenced anchor checked against the generated HTML. Fixed a slug detail: VitePress **keeps the em-dash** in flag-heading slugs (`acp-stdio-—-run-as-an-acp-server`), so the `--acp --stdio` self-links use that form (EN + ZH).

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)