### PR TITLE
fix(acp): persist session on shutdown and close stdin gracefully

### DIFF
--- a/agentao/acp/models.py
+++ b/agentao/acp/models.py
@@ -262,17 +262,31 @@ class AcpSessionState:
 
         1. Mark ``closed`` first so a concurrent second call (or a close
            during an error unwind) short-circuits immediately.
-        2. Cancel the active turn's token if any — this unblocks the LLM
+        2. Persist the conversation via :meth:`_save_session` *before*
+           cancelling the active turn. Cancelling can leave a half-emitted
+           tool call dangling in ``agent.messages``; saving first captures
+           the cleaner committed state. Mirrors the CLI, which persists in
+           its session-end hook rather than inside ``agent.close()`` — this
+           is the ACP-layer analog of that hook. Best-effort.
+        3. Cancel the active turn's token if any — this unblocks the LLM
            call and tool execution before we start disconnecting MCP
            servers, so the runtime doesn't try to use a torn-down
            connection mid-turn.
-        3. Call ``agent.close()`` to disconnect MCP servers. Wrapped in
+        4. Call ``agent.close()`` to disconnect MCP servers. Wrapped in
            try/except because shutdown must be robust — a single hung
            MCP server cannot prevent other sessions from tearing down.
+
+        NOTE: this only runs on a *clean* shutdown — the server's read loop
+        reaches ``close_all`` via its ``finally`` block when stdin hits EOF.
+        A client that kills the subprocess (SIGTERM/SIGKILL) without first
+        closing stdin bypasses this path entirely, so the ACP client's stop
+        sequence must close stdin and wait for graceful exit first.
         """
         if self.closed:
             return
         self.closed = True
+
+        self._save_session()
 
         if self.cancel_token is not None:
             try:
@@ -285,3 +299,22 @@ class AcpSessionState:
                 self.agent.close()
             except Exception:
                 logger.exception("acp: error closing agent for session %s", self.session_id)
+
+    def _save_session(self) -> None:
+        """Persist this session's conversation to disk. Best-effort.
+
+        Keyed by the ACP ``sessionId`` so ``session/load`` (which reads via
+        :func:`agentao.embedding.sessions.load_session` under the same id and
+        cwd) can later resume it. Skips empty conversations so short-lived
+        sessions that never ran a turn don't litter the sessions directory.
+        """
+        agent = self.agent
+        if agent is None or not getattr(agent, "messages", None):
+            return
+        try:
+            from agentao.embedding.sessions import persist_agent_session
+
+            project_root = self.cwd or getattr(agent, "working_directory", None)
+            persist_agent_session(agent, self.session_id, project_root)
+        except Exception:
+            logger.exception("acp: error saving session %s on close", self.session_id)

--- a/agentao/acp_client/process.py
+++ b/agentao/acp_client/process.py
@@ -23,6 +23,12 @@ from .models import AcpProcessInfo, AcpServerConfig, ServerState
 # Default capacity for the stderr ring buffer (number of lines).
 _STDERR_RING_CAPACITY = 200
 
+# Grace period (seconds) to wait for the subprocess to exit on its own after
+# we close its stdin. The ACP server's read loop returns on stdin EOF and runs
+# its shutdown ``finally`` (persist each session, disconnect MCP) on that path,
+# so we give it this long before escalating to SIGTERM/SIGKILL.
+_GRACEFUL_STOP_TIMEOUT = 5.0
+
 logger = logging.getLogger("agentao.acp_client")
 
 
@@ -175,7 +181,9 @@ class ACPProcessHandle:
     def stop(self) -> None:
         """Gracefully stop the subprocess.
 
-        Sends SIGTERM, waits up to 5 s, then kills.  Idempotent.
+        Closes stdin first so an ACP server can persist its sessions and exit
+        on EOF, waits up to ``_GRACEFUL_STOP_TIMEOUT`` s, then escalates to
+        SIGTERM (5 s) and finally SIGKILL.  Idempotent.
         """
         with self._lock:
             self._stop_unlocked()
@@ -194,15 +202,43 @@ class ACPProcessHandle:
 
         self._set_state(ServerState.STOPPING)
 
+        # 1. Close stdin to send EOF. The ACP server's read loop returns on
+        #    EOF and runs its shutdown ``finally`` — cancel active turns,
+        #    drain handlers, then ``close_all`` which persists each session
+        #    and disconnects MCP. This graceful path is the ONLY one on which
+        #    a server-side session is saved, so give it a chance before we
+        #    resort to signals (a SIGTERM the server doesn't catch would kill
+        #    it before any of that runs). It also lets the server reap its own
+        #    grandchildren (MCP/shell), which ``terminate()`` here cannot.
         try:
-            self._proc.terminate()
-            self._proc.wait(timeout=5)
+            stdin = self._proc.stdin
+            if stdin is not None and not stdin.closed:
+                stdin.close()
+        except Exception:
+            pass  # already closed / broken pipe — fall through to wait
+
+        try:
+            self._proc.wait(timeout=_GRACEFUL_STOP_TIMEOUT)
         except subprocess.TimeoutExpired:
+            # 2. Graceful EOF exit didn't take — escalate.
             logger.warning(
-                "acp server '%s' did not stop within 5 s — killing", self.name
+                "acp server '%s' did not exit %.0f s after stdin close — terminating",
+                self.name,
+                _GRACEFUL_STOP_TIMEOUT,
             )
-            self._proc.kill()
-            self._proc.wait(timeout=2)
+            try:
+                self._proc.terminate()
+                self._proc.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                logger.warning(
+                    "acp server '%s' did not stop within 5 s — killing", self.name
+                )
+                self._proc.kill()
+                self._proc.wait(timeout=2)
+            except Exception as exc:
+                logger.error(
+                    "acp server '%s': error during stop: %s", self.name, exc
+                )
         except Exception as exc:
             logger.error(
                 "acp server '%s': error during stop: %s", self.name, exc

--- a/agentao/cli/session.py
+++ b/agentao/cli/session.py
@@ -49,13 +49,10 @@ def on_session_end(cli: AgentaoCLI) -> None:
 
     if not cli.agent.messages:
         return
-    from ..embedding.sessions import save_session
+    from ..embedding.sessions import persist_agent_session
     try:
-        active_skills = list(cli.agent.skill_manager.get_active_skills().keys())
-        session_file, sid = save_session(
-            messages=cli.agent.messages,
-            model=cli.agent.get_current_model(),
-            active_skills=active_skills,
+        session_file, sid = persist_agent_session(
+            cli.agent,
             session_id=cli.current_session_id,
             project_root=cli.agent.working_directory,
         )

--- a/agentao/embedding/sessions.py
+++ b/agentao/embedding/sessions.py
@@ -158,6 +158,28 @@ def save_session(
     return session_file, sid
 
 
+def persist_agent_session(
+    agent: Any,
+    session_id: Optional[str] = None,
+    project_root: Optional[Path] = None,
+) -> Tuple[Path, str]:
+    """Persist ``agent``'s conversation, deriving model + active skills from it.
+
+    Shared by the CLI session-end hook and the ACP session teardown so the
+    agent→disk extraction (``messages`` / ``get_current_model()`` /
+    ``skill_manager.get_active_skills()``) lives in exactly one place — adding
+    a field to the persisted contract only has to touch this function.
+    """
+    active_skills = list(agent.skill_manager.get_active_skills().keys())
+    return save_session(
+        messages=agent.messages,
+        model=agent.get_current_model(),
+        active_skills=active_skills,
+        session_id=session_id,
+        project_root=project_root,
+    )
+
+
 def _resolve_session_file(
     session_id: Optional[str] = None,
     project_root: Optional[Path] = None,

--- a/tests/support/acp_agents.py
+++ b/tests/support/acp_agents.py
@@ -22,9 +22,21 @@ from __future__ import annotations
 
 import threading
 import time
+from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from agentao.cancellation import CancellationToken
+
+
+class _FakeSkillManager:
+    """Duck-types the ``skill_manager.get_active_skills()`` call that
+    ``AcpSessionState._save_session`` makes during teardown."""
+
+    def __init__(self, active: Optional[Dict[str, Any]] = None) -> None:
+        self._active = active or {}
+
+    def get_active_skills(self) -> Dict[str, Any]:
+        return dict(self._active)
 
 
 class FakeAgent:
@@ -53,6 +65,8 @@ class FakeAgent:
         *,
         side_effect: Optional[Callable[[CancellationToken], None]] = None,
         track_messages: bool = False,
+        model: str = "test-model",
+        working_directory: Optional[Path] = None,
     ) -> None:
         self.reply = reply
         self.side_effect = side_effect
@@ -61,6 +75,13 @@ class FakeAgent:
         self.chat_calls: List[Tuple[str, CancellationToken]] = []
         self.received_images: List[Any] = []
         self.close_calls = 0
+        # Surface that ``AcpSessionState._save_session`` reads on teardown.
+        self.model = model
+        self.working_directory = working_directory
+        self.skill_manager = _FakeSkillManager()
+
+    def get_current_model(self) -> str:
+        return self.model
 
     def chat(
         self,

--- a/tests/test_acp_client_process.py
+++ b/tests/test_acp_client_process.py
@@ -181,6 +181,29 @@ class TestACPProcessHandle:
 
         handle.stop()
 
+    def test_stop_closes_stdin_for_graceful_exit(self, tmp_path) -> None:
+        """stop() closes stdin first so the child can exit cleanly on EOF.
+
+        The child blocks reading stdin and, on EOF, writes a sentinel file
+        before exiting. If stop() jumped straight to SIGTERM the sentinel
+        would never be written; its presence proves the graceful EOF path
+        ran before any signal escalation. This is what lets an ACP *server*
+        subprocess persist its sessions on shutdown.
+        """
+        sentinel = tmp_path / "graceful.txt"
+        prog = (
+            "import sys; sys.stdin.read(); "
+            f"open({str(sentinel)!r}, 'w').write('ok')"
+        )
+        handle = ACPProcessHandle("graceful", _make_config(args=["-c", prog]))
+        handle.start()
+        assert handle.pid is not None
+
+        handle.stop()
+
+        assert handle.state == ServerState.STOPPED
+        assert sentinel.exists(), "child should exit gracefully on stdin EOF"
+
     def test_stdin_stdout_available(self) -> None:
         handle = ACPProcessHandle("test", _sleeper_config())
         handle.start()

--- a/tests/test_acp_session_manager.py
+++ b/tests/test_acp_session_manager.py
@@ -94,6 +94,57 @@ def test_close_swallows_agent_close_exceptions():
     assert agent.close_calls == 1
 
 
+def test_close_saves_session_for_resume(tmp_path):
+    """close() persists the conversation under the ACP sessionId so a later
+    ``session/load`` can resume it — and still tears the runtime down.
+
+    Regression: stopping the ACP subprocess used to drop the chat history.
+    """
+    from agentao.embedding.sessions import load_session
+
+    agent = FakeAgent()
+    agent.messages = [
+        {"role": "user", "content": "hello"},
+        {"role": "assistant", "content": "hi there"},
+    ]
+    state = _state(session_id="sess-save", agent=agent, cwd=tmp_path)
+
+    state.close()
+
+    messages, _model, _skills = load_session(
+        session_id="sess-save", project_root=tmp_path
+    )
+    assert [m["content"] for m in messages] == ["hello", "hi there"]
+    assert agent.close_calls == 1  # save did not replace teardown
+
+
+def test_close_skips_save_for_empty_conversation(tmp_path):
+    """A session that never ran a turn must not litter the sessions dir."""
+    from agentao.embedding.sessions import list_sessions
+
+    state = _state(session_id="sess-empty", agent=FakeAgent(), cwd=tmp_path)
+
+    state.close()
+
+    assert list_sessions(project_root=tmp_path) == []
+
+
+def test_close_save_failure_does_not_block_teardown(tmp_path):
+    """A failing save must not prevent the agent from being closed —
+    persistence is best-effort, teardown is not."""
+    agent = FakeAgent()
+    agent.messages = [{"role": "user", "content": "hi"}]
+    # A model object that explodes when the saver serializes it forces the
+    # save path into its except branch without touching teardown.
+    agent.get_current_model = lambda: (_ for _ in ()).throw(RuntimeError("boom"))
+    state = _state(session_id="sess-boom", agent=agent, cwd=tmp_path)
+
+    state.close()  # must not raise
+
+    assert state.closed is True
+    assert agent.close_calls == 1
+
+
 # ---------------------------------------------------------------------------
 # AcpSessionManager — happy path
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

When an ACP client stopped an agentao server subprocess (e.g. via `ACPManager.stop_all()`), the chat history (session state) was **dropped** — unlike the interactive CLI, which persists on session end.

Root cause: the ACP server's read loop only reaches its shutdown `finally` → `close_all()` → `state.close()` path when **stdin hits EOF**. The client's `_stop_unlocked()` went straight to `terminate()` (SIGTERM), which Python doesn't catch by default — so the process died before any save path ran. The two sides had to be fixed together.

## Changes

Two coupled fixes plus a small dedup:

- **Server side** (`agentao/acp/models.py`): `AcpSessionState.close()` now persists the conversation via a new best-effort `_save_session()` — keyed by the ACP `sessionId` so `session/load` can resume it — **before** cancelling the turn token (capturing committed state, not a half-emitted tool call). Skips empty conversations so short-lived sessions don't litter the sessions dir.
- **Client side** (`agentao/acp_client/process.py`): `ACPProcessHandle._stop_unlocked()` closes stdin first so the server returns on EOF and runs its `close_all`/save path, waiting `_GRACEFUL_STOP_TIMEOUT` (5s) before escalating to SIGTERM (5s) → SIGKILL (2s). This is the prerequisite that makes the server-side save reachable; it also lets the server reap its own MCP/shell grandchildren, which `terminate()` cannot.
- **Dedup** (`agentao/embedding/sessions.py`): extracted `persist_agent_session(agent, session_id, project_root)` so the CLI session-end hook and ACP teardown derive (`messages` / `model` / active skills) in one place.

### Deliberately not done
Switching the kill-fallback to `kill_process_tree()` — this `Popen` isn't `start_new_session=True`, so `killpg` could hit the host's own process group. Left as a separate, riskier follow-up. The graceful EOF path already lets the server clean up its own children.

## Tests

New regression tests:
- `test_close_saves_session_for_resume` — `close()` persists; `session/load` recovers it.
- `test_close_skips_save_for_empty_conversation` — empty sessions don't write.
- `test_close_save_failure_does_not_block_teardown` — save is best-effort, teardown is not.
- `test_stop_closes_stdin_for_graceful_exit` — child exits on stdin EOF before any signal (sentinel-file proof).

Full ACP + session suite: **811 passed**. Two consecutive clean `codex review` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)