### PR TITLE
fix(session): don't restore persisted model on resume

### DIFF
--- a/agentao/acp/session_load.py
+++ b/agentao/acp/session_load.py
@@ -49,11 +49,14 @@ Out of scope for v1
   silently replacing the running session — the client should issue
   ``session/cancel`` first if they want to overwrite a live session.
 
-- **Restoring tool execution state, sub-agents, plan mode, or active
-  skills.** Only the message history and (best effort) the model name
-  carry over. Skill activation and plan-mode flags are deliberately
-  reset because they depend on runtime SKILL.md / project state that
-  may have changed since the session was persisted.
+- **Restoring tool execution state, sub-agents, plan mode, active
+  skills, or the model.** Only the message history carries over. The
+  persisted model name is NOT re-bound (provider is never on disk, so
+  re-binding the name onto the current provider can be inconsistent);
+  the runtime keeps its process-default model. Skill activation and
+  plan-mode flags are likewise reset because they depend on runtime
+  SKILL.md / project state that may have changed since the session was
+  persisted.
 
 - **Streaming chunked replay.** Messages are emitted one notification
   per persisted entry; large historical messages are NOT split into
@@ -127,9 +130,10 @@ def handle_session_load(
       3. Refuse if the session id is already live in the registry —
          this is a protocol bug worth surfacing rather than racing.
       4. Look up the session on disk via :func:`load_session`. Missing
-         id → ``INVALID_REQUEST``. The persisted ``model`` is forwarded
-         to the factory so the loaded session continues on the same
-         model it was originally saved under.
+         id → ``INVALID_REQUEST``. The persisted ``model`` is loaded for
+         metadata only — it is NOT re-bound onto the runtime (see
+         :func:`_instantiate_loaded_session`); the loaded session keeps
+         the process-default model.
       5. Build the :class:`ACPTransport` + :class:`Agentao` runtime via
          the injected factory (same path as ``session/new``).
       6. Hydrate the runtime's ``messages`` list from the loaded
@@ -176,7 +180,7 @@ def handle_session_load(
 
     # 4) Pull the persisted history off disk.
     try:
-        messages, model, active_skills = load_session(
+        messages, _model, active_skills = load_session(
             session_id=session_id, project_root=cwd
         )
     except FileNotFoundError as e:
@@ -200,7 +204,6 @@ def handle_session_load(
         cwd=cwd,
         mcp_servers=mcp_servers,
         messages=messages,
-        model=model,
         agent_factory=agent_factory,
         origin="session/load",
     )
@@ -223,7 +226,6 @@ def _instantiate_loaded_session(
     cwd: Path,
     mcp_servers: List[Dict[str, Any]],
     messages: List[Dict[str, Any]],
-    model: str,
     agent_factory: AgentFactory,
     origin: str,
 ) -> AcpSessionState:
@@ -235,6 +237,15 @@ def _instantiate_loaded_session(
     session through one code path. Registration happens **after** replay so
     a pipelined ``session/prompt`` cannot interleave a live turn with the
     historical updates.
+
+    The persisted ``model`` is intentionally **not** restored: a session
+    stores only the model *name*, never its provider (api_key / base_url
+    never touch disk). Re-binding the name onto whatever provider this
+    process now uses can yield an inconsistent (provider, model) pair that
+    only fails on the next LLM call. The runtime is built with the
+    process-default model (``model=None``) so (provider, model) stays
+    consistent; the saved name remains available in ``session/list`` for
+    reference.
 
     ``origin`` is a label used only in log lines (e.g. ``"session/load"`` vs
     ``"resume"``). On any failure the partially-built runtime is closed so
@@ -269,7 +280,7 @@ def _instantiate_loaded_session(
             transport=transport,
             permission_engine=permission_engine,
             mcp_servers=mcp_servers_internal,
-            model=model or None,  # forward persisted model; "" → default
+            model=None,  # use process-default model — persisted model not restored
         )
 
         # Bind the persisted ACP session id onto the agent so subsequent
@@ -403,7 +414,7 @@ def resume_session_on_new(
     """
     selector = directive.session_id
     try:
-        session_id, messages, model, _active_skills = load_session_record(
+        session_id, messages, _model, _active_skills = load_session_record(
             session_id=selector, project_root=cwd
         )
     except (OSError, ValueError) as e:
@@ -444,7 +455,6 @@ def resume_session_on_new(
         cwd=cwd,
         mcp_servers=mcp_servers,
         messages=messages,
-        model=model,
         agent_factory=agent_factory,
         origin="resume",
     )

--- a/agentao/acp/session_new.py
+++ b/agentao/acp/session_new.py
@@ -57,10 +57,12 @@ mcp_servers, model) -> Agentao``.
 
 All parameters are keyword-only at call sites to reduce the risk that a
 future signature change silently rebinds positional arguments. The
-``mcp_servers`` argument was added by Issue 11 and ``model`` by the
-``session/load`` model-restoration fix — factories that ignore extra
-kwargs (the test ``FakeAgent`` factory pattern) keep working unchanged
-because they accept ``**kwargs``.
+``mcp_servers`` argument was added by Issue 11; ``model`` lets a caller
+pin a specific model (session/new and session/load both leave it ``None``
+— the loader deliberately does not restore a session's persisted model;
+see ``default_agent_factory``). Factories that ignore extra kwargs (the
+test ``FakeAgent`` factory pattern) keep working unchanged because they
+accept ``**kwargs``.
 """
 
 
@@ -98,10 +100,11 @@ def default_agent_factory(
     overrides any file-loaded servers of the same name. ``None`` means
     "no extras" — the runtime falls back to file-only behavior.
 
-    ``model`` (session/load model-restoration fix) lets the loader
-    re-bind a session to the model it was originally saved under. ``None``
-    or empty string means "use the runtime default" — that's the
-    ``session/new`` path which has no persisted model to restore.
+    ``model`` lets a caller pin the runtime to a specific model. ``None``
+    or empty string means "use the runtime default". Both ``session/new``
+    and ``session/load`` pass ``None`` — the loader deliberately does not
+    restore a session's persisted model (only its name is on disk, never
+    its provider), so a reloaded session keeps the process-default model.
     """
     # Local import avoids pulling openai/tools/llm into the ACP package
     # at import time — handler modules stay lightweight for testing.

--- a/agentao/cli/commands/sessions.py
+++ b/agentao/cli/commands/sessions.py
@@ -119,11 +119,13 @@ def resume_session(cli: AgentaoCLI, session_id: Optional[str] = None) -> None:
         return
 
     cli.agent.messages = messages
-    if model:
-        try:
-            cli.agent.set_model(model)
-        except Exception:
-            pass
+    # Intentionally do NOT restore the persisted model. A session stores only
+    # the model *name*, not its provider (api_key / base_url never touch disk).
+    # Re-binding the name onto whatever provider the current process happens to
+    # use yields an inconsistent (provider, model) pair — e.g. a model saved
+    # under provider A that does not exist on the now-current provider B, which
+    # only fails on the next LLM call. Keep the current process's already-
+    # consistent (provider, model) and surface the saved name for reference.
     for skill_name in active_skills:
         try:
             cli.agent.skill_manager.activate_skill(skill_name, "Restored from session")
@@ -147,8 +149,12 @@ def resume_session(cli: AgentaoCLI, session_id: Optional[str] = None) -> None:
     msg_count = len(messages)
     console.print(f"\n[success]↩ Resuming session {sid_display}{title_display}[/success]")
     console.print(f"[dim]{msg_count} messages loaded.[/dim]")
-    if model:
-        console.print(f"[dim]Model: {model}[/dim]")
+    current_model = cli.agent.get_current_model()
+    console.print(f"[dim]Model: {current_model}[/dim]")
+    if model and model != current_model:
+        console.print(
+            f"[dim](session was saved on {model}; keeping current model)[/dim]"
+        )
     if active_skills:
         console.print(f"[dim]Active skills: {', '.join(active_skills)}[/dim]")
     console.print()


### PR DESCRIPTION
## Problem

Resuming a session restored the persisted **model name** but never its **provider** (`api_key` / `base_url` are intentionally never written to disk). Re-binding the saved name onto whatever provider the current process happens to use produces an inconsistent `(provider, model)` pair — e.g. a model saved under provider A that doesn't exist on the now-current provider B. The mismatch is silent at resume time and only surfaces on the next LLM call.

## Fix

Stop applying the persisted model on resume in **both** paths; keep the process's already-consistent `(provider, model)`. The saved model name is still persisted and shown for reference.

- **`cli/commands/sessions.py`** — drop the `set_model()` call (and its silent `except: pass`) on resume; display the *current* model, and note the saved one when it differs.
- **`acp/session_load.py`** — `_instantiate_loaded_session` no longer forwards the persisted model (builds with `model=None`); both call sites (`session/load` + startup-resume) updated; docstrings refreshed.
- **`acp/session_new.py`** — refresh factory docstrings: `session/new` and `session/load` both pass `None`.

Persistence is unchanged — `save_session` still stores `model` (used by `/sessions list` and the resume hint), it's just no longer applied.

## Tests

`tests/test_session.py` + `tests/test_acp_session_load.py` + `tests/test_acp_resume_on_startup.py`: **81 passed**. No test asserted model re-binding on resume, so none required changes. (Pre-existing `test_model_switching_flow` failure is unrelated — it needs a real `OPENAI_API_KEY`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)