### PR TITLE
fix(skills): resolve SKILL.md relative paths against the skill directory

### DIFF
--- a/agentao/prompts/builder.py
+++ b/agentao/prompts/builder.py
@@ -249,6 +249,12 @@ class SystemPromptBuilder:
             if when_to_use:
                 out += f"  Activate when: {when_to_use}\n"
         out += "\nWhen the user's request matches a skill's description, use the activate_skill tool before proceeding with the task."
+        out += (
+            "\nSkill files (SKILL.md, scripts/, references/) live in each "
+            "skill's own directory, which is usually NOT your current working "
+            "directory; activation reports that directory when the skill has "
+            "one, and relative paths in skill instructions resolve against it."
+        )
         return out
 
     def _todos_block(self) -> str:

--- a/agentao/skills/manager.py
+++ b/agentao/skills/manager.py
@@ -25,6 +25,23 @@ _PROJECT_SKILLS_DIR = Path.cwd() / ".agentao" / "skills"
 _CONFIG_DIR = Path.cwd() / ".agentao"
 _CONFIG_FILE = _CONFIG_DIR / "skills_config.json"
 
+# Single source of truth for the relative-path resolution rule injected next
+# to every "Skill directory:" line (activation message + per-turn context).
+_SKILL_DIR_NOTE = (
+    "Relative paths in the skill's instructions (e.g. scripts/foo.py) "
+    "resolve against this skill directory, NOT your current working "
+    "directory. Build absolute paths from the skill directory before "
+    "reading or running them.\n"
+)
+
+# Resource subdirectories enumerated per skill. references/ and assets/ are
+# documentation (*.md only); scripts/ is executable surface, so every file
+# counts. Hidden files and __pycache__ are skipped everywhere, and listings
+# are capped so a large tree cannot flood the system prompt (the listing is
+# re-rendered every turn for active skills).
+_RESOURCE_SPECS = (("references", "*.md"), ("assets", "*.md"), ("scripts", "*"))
+_RESOURCE_FILE_CAP = 50
+
 
 class SkillManager:
     """Manager for Agentao skills.
@@ -237,7 +254,10 @@ class SkillManager:
                     "title": title,
                     "description": description,
                     "when_to_use": when_to_use,
-                    "path": str(skill_md_path),
+                    # Resolved so the paths surfaced to the model (Skill
+                    # directory, resource listings) work from any cwd even
+                    # when a host passes a relative skills_dir.
+                    "path": str(skill_md_path.resolve()),
                     "content": body_content[:500],
                     "frontmatter": frontmatter,
                 }
@@ -265,23 +285,45 @@ class SkillManager:
     def get_skill_info(self, skill_name: str) -> Optional[dict]:
         return self.available_skills.get(skill_name)
 
+    @staticmethod
+    def _skill_dir(skill_info: Optional[dict]) -> Optional[Path]:
+        """Directory owning the skill's files, or None when there isn't one.
+
+        None for path-less entries (inline plugin content) and for plugin
+        commands — command ``.md`` files sit in a shared ``commands/``
+        folder that is not a skill directory, so reporting it (or scanning
+        it for resources) would misattribute sibling files to every
+        command.
+        """
+        if not skill_info or not skill_info.get('path'):
+            return None
+        if skill_info.get('source_kind') == "plugin-command":
+            return None
+        return Path(skill_info['path']).parent
+
     def _list_skill_resources(self, skill_name: str) -> Dict[str, List[str]]:
-        skill_info = self.get_skill_info(skill_name)
-        if not skill_info or 'path' not in skill_info:
-            return {"references": [], "assets": []}
+        resources: Dict[str, List[str]] = {key: [] for key, _ in _RESOURCE_SPECS}
+        skill_dir = self._skill_dir(self.get_skill_info(skill_name))
+        if skill_dir is None:
+            return resources
 
-        skill_dir = Path(skill_info['path']).parent
-        resources = {"references": [], "assets": []}
-
-        references_dir = skill_dir / "references"
-        if references_dir.exists() and references_dir.is_dir():
-            for file_path in references_dir.rglob("*.md"):
-                resources["references"].append(str(file_path))
-
-        assets_dir = skill_dir / "assets"
-        if assets_dir.exists() and assets_dir.is_dir():
-            for file_path in assets_dir.rglob("*.md"):
-                resources["assets"].append(str(file_path))
+        for key, pattern in _RESOURCE_SPECS:
+            base = skill_dir / key
+            if not base.is_dir():
+                continue
+            files = [
+                f for f in sorted(base.rglob(pattern))
+                if f.is_file() and not any(
+                    part.startswith(".") or part == "__pycache__"
+                    for part in f.relative_to(base).parts
+                )
+            ]
+            resources[key] = [str(f) for f in files[:_RESOURCE_FILE_CAP]]
+            if len(files) > _RESOURCE_FILE_CAP:
+                resources[key].append(
+                    f"... ({len(files) - _RESOURCE_FILE_CAP} more files "
+                    f"under {base} not shown)"
+                )
 
         return resources
 
@@ -305,20 +347,29 @@ class SkillManager:
         if skill_info.get('description'):
             message += f"Description: {skill_info['description'][:200]}...\n"
         message += f"Task: {task_description}\n"
-        message += f"Documentation: {skill_info.get('path', 'N/A')}\n"
+        skill_path = skill_info.get('path')
+        message += f"Documentation: {skill_path or 'N/A'}\n"
+        skill_dir = self._skill_dir(skill_info)
+        if skill_dir is not None:
+            message += f"Skill directory: {skill_dir}\n"
+            message += _SKILL_DIR_NOTE
 
         resources = self._list_skill_resources(skill_name)
-        if resources["references"] or resources["assets"]:
+        if any(resources.values()):
             message += "\n=== Available Resource Files ===\n"
             message += "You can use the read_file tool to load these files as needed:\n\n"
             if resources["references"]:
                 message += "References:\n"
-                for ref_path in sorted(resources["references"]):
+                for ref_path in resources["references"]:
                     message += f"  - {ref_path}\n"
             if resources["assets"]:
                 message += "\nAssets:\n"
-                for asset_path in sorted(resources["assets"]):
+                for asset_path in resources["assets"]:
                     message += f"  - {asset_path}\n"
+            if resources["scripts"]:
+                message += "\nScripts (prefer running or patching these instead of retyping their code):\n"
+                for script_path in resources["scripts"]:
+                    message += f"  - {script_path}\n"
 
         message += "\nThe skill is now active. You can reference its documentation for detailed usage."
         return message
@@ -345,18 +396,21 @@ class SkillManager:
             skill_info = info['skill_info']
             context += f"\n## {name} - {skill_info.get('title', name)}\n"
             context += f"Task: {info['task']}\n"
+            skill_dir = self._skill_dir(skill_info)
+            if skill_dir is not None:
+                context += f"Skill directory: {skill_dir}\n"
+                context += _SKILL_DIR_NOTE
 
             skill_content = self.get_skill_content(name)
             if skill_content:
                 context += f"\n{skill_content}\n"
 
             resources = self._list_skill_resources(name)
-            if resources["references"] or resources["assets"]:
-                context += "\nAvailable resource files (use read_file to load):\n"
-                for ref in sorted(resources.get("references", [])):
-                    context += f"  - {ref}\n"
-                for asset in sorted(resources.get("assets", [])):
-                    context += f"  - {asset}\n"
+            if any(resources.values()):
+                context += "\nAvailable resource files (use read_file to load; prefer running scripts directly):\n"
+                for key, _ in _RESOURCE_SPECS:
+                    for path in resources.get(key, []):
+                        context += f"  - {path}\n"
 
         return context
 

--- a/developer-guide/en/cli/5-skills-crystallize.md
+++ b/developer-guide/en/cli/5-skills-crystallize.md
@@ -197,9 +197,9 @@ cp -R examples/skills/ocr ~/.agentao/skills/
 cp -R examples/skills/zootopia-ppt /path/to/your/project/.agentao/skills/
 cp -R examples/skills/pro-ppt      /path/to/your/project/.agentao/skills/
 
-# Each skill ships a requirements.txt — install Python deps once
+# The PPT skills ship a requirements.txt — install Python deps once
+# (ocr needs none: its script carries PEP 723 inline metadata for `uv run`)
 pip install -r examples/skills/zootopia-ppt/requirements.txt
-pip install -r examples/skills/ocr/requirements.txt
 ```
 
 Then `/skills reload` (or restart) and the new skills show up in `/skills`.

--- a/developer-guide/zh/cli/5-skills-crystallize.md
+++ b/developer-guide/zh/cli/5-skills-crystallize.md
@@ -197,9 +197,9 @@ cp -R examples/skills/ocr ~/.agentao/skills/
 cp -R examples/skills/zootopia-ppt /path/to/your/project/.agentao/skills/
 cp -R examples/skills/pro-ppt      /path/to/your/project/.agentao/skills/
 
-# 每个 skill 带 requirements.txt — Python 依赖装一次
+# 两个 PPT skill 带 requirements.txt — Python 依赖装一次
+# （ocr 不需要：脚本内置 PEP 723 行内元数据，`uv run` 自动解析）
 pip install -r examples/skills/zootopia-ppt/requirements.txt
-pip install -r examples/skills/ocr/requirements.txt
 ```
 
 然后 `/skills reload`（或重启），新 skill 会出现在 `/skills` 列表里。

--- a/docs/guides/skills.md
+++ b/docs/guides/skills.md
@@ -217,6 +217,16 @@ skills/
     └── scripts/          # Helper scripts (optional)
 ```
 
+On activation, the agent is told the skill's directory and that relative
+paths inside SKILL.md (e.g. `scripts/foo.py`) resolve against that
+directory rather than the agent's current working directory — the skill is
+usually installed under `~/.agentao/skills/` or `.agentao/skills/`, not in
+the cwd. The activation message also enumerates resource files by absolute
+path: `references/` and `assets/` (`*.md`), and helper files under
+`scripts/` (hidden files and caches such as `__pycache__` are skipped, and
+very long listings are truncated). Skill authors therefore don't need to
+hardcode absolute paths; plain relative references work from any cwd.
+
 ### SKILL.md Content
 
 1. **Clear Trigger Description**: Explain when to use this skill

--- a/examples/skills/README.md
+++ b/examples/skills/README.md
@@ -40,14 +40,17 @@ Restart Agentao (or run `/skills` to list) — the skill should appear under "Av
 
 ## Install (with deps)
 
-Each gallery skill ships a `requirements.txt` listing its Python deps:
+The PPT skills ship a `requirements.txt` listing their Python deps:
 
 ```bash
 # Inside your project venv
 pip install -r examples/skills/zootopia-ppt/requirements.txt
-pip install -r examples/skills/ocr/requirements.txt
 # pro-ppt's requirements.txt re-exports zootopia-ppt's via `-r ../zootopia-ppt/requirements.txt`
 ```
+
+`ocr` needs no install step: its script carries PEP 723 inline metadata, so
+`uv run` resolves its deps automatically (without uv: `pip install openai
+python-dotenv`).
 
 The image-gen backends in `zootopia-ppt` (`google-genai`, `dashscope`, etc.) are alternatives — comment out the lines you don't use.
 

--- a/examples/skills/README.zh.md
+++ b/examples/skills/README.zh.md
@@ -40,14 +40,16 @@ cp -R examples/skills/pro-ppt      /path/to/your/project/.agentao/skills/
 
 ## 安装（含依赖）
 
-每个 skill 都自带 `requirements.txt`：
+两个 PPT skill 自带 `requirements.txt`：
 
 ```bash
 # 在你的项目 venv 里
 pip install -r examples/skills/zootopia-ppt/requirements.txt
-pip install -r examples/skills/ocr/requirements.txt
 # pro-ppt 的 requirements.txt 通过 `-r ../zootopia-ppt/requirements.txt` 复用
 ```
+
+`ocr` 无需安装步骤：脚本内置 PEP 723 行内元数据，`uv run` 会自动解析依赖
+（没有 uv 的环境：`pip install openai python-dotenv`）。
 
 `zootopia-ppt` 里的图像生成后端（`google-genai`、`dashscope` 等）是**互为替代**的——只装你要用的那一个，其他用 `#` 注释掉。
 

--- a/examples/skills/ocr/SKILL.md
+++ b/examples/skills/ocr/SKILL.md
@@ -1,32 +1,45 @@
 ---
 name: ocr
-description: OCR image files using the Qwen VL model via scripts/ocr.py. Use when the user asks to extract text from an image, perform OCR on a photo or screenshot, or recognize characters in an image file (.jpg, .jpeg, .png, .gif, .webp). Requires QWEN_API_KEY and QWEN_BASE_URL in a .env file in the project directory.
+description: OCR image files using the Qwen VL model via the bundled scripts/ocr.py (lives in this skill's directory, NOT your cwd). Use when the user asks to extract text from an image, perform OCR on a photo or screenshot, or recognize characters in an image file (.jpg, .jpeg, .png, .gif, .webp). Requires QWEN_API_KEY and QWEN_BASE_URL (env vars, or a .env in the skill directory).
 ---
 
 # OCR Skill
 
 Extract text from images using `scripts/ocr.py` (Qwen VL OCR model).
 
+**Path note**: this skill's files live in the directory containing this
+SKILL.md — written as `<skill-dir>` below. It is shown on the
+`Skill directory:` line when the skill is activated (the activation message
+also lists the script's absolute path). The script is at
+`<skill-dir>/scripts/ocr.py`, NOT in your current working directory.
+
 ## Prerequisites
 
-`.env` in the project directory:
+`QWEN_API_KEY` and `QWEN_BASE_URL`, read in this order (first found wins):
+
+1. process environment variables
+2. `.env` in your current working directory
+3. `<skill-dir>/.env` (recommended place to keep them)
+4. `~/.env` (user-wide fallback)
+
 ```
 QWEN_API_KEY=your_key
 QWEN_BASE_URL=https://your-base-url
 ```
 
-Dependencies (if not already installed):
-```bash
-uv add openai python-dotenv
-```
+No dependency setup needed: the script carries inline metadata (PEP 723), so
+`uv run` resolves `openai` / `python-dotenv` automatically in any directory.
+Do NOT run `uv add` — your cwd is usually not a Python project.
 
 ## Usage
 
 ```bash
-uv run scripts/ocr.py <image_file>
+uv run "<skill-dir>/scripts/ocr.py" <image_file>
 ```
 
-Output is printed to stdout.
+Substitute `<skill-dir>` with the absolute skill directory before running —
+it is NOT a shell variable. Output is printed to stdout. If credentials are missing, the script exits
+with an error telling you where to put them.
 
 ## Workflow
 

--- a/examples/skills/ocr/requirements.txt
+++ b/examples/skills/ocr/requirements.txt
@@ -1,2 +1,0 @@
-openai>=1.40
-python-dotenv>=1.0

--- a/examples/skills/ocr/scripts/ocr.py
+++ b/examples/skills/ocr/scripts/ocr.py
@@ -1,3 +1,7 @@
+# /// script
+# requires-python = ">=3.10"
+# dependencies = ["openai", "python-dotenv"]
+# ///
 import sys
 import base64
 import os
@@ -5,7 +9,13 @@ from pathlib import Path
 from dotenv import load_dotenv
 from openai import OpenAI
 
-load_dotenv()
+SKILL_DIR = Path(__file__).resolve().parent.parent
+
+# Searched in order; load_dotenv never overwrites variables that are already
+# set, so earlier sources win (process env beats all files).
+ENV_FILES = [Path.cwd() / ".env", SKILL_DIR / ".env", Path.home() / ".env"]
+for _env_file in ENV_FILES:
+    load_dotenv(_env_file)
 
 API_KEY = os.getenv("QWEN_API_KEY")
 BASE_URL = os.getenv("QWEN_BASE_URL")
@@ -48,6 +58,17 @@ def main():
     image_path = sys.argv[1]
     if not Path(image_path).exists():
         print(f"Error: file not found: {image_path}", file=sys.stderr)
+        sys.exit(1)
+
+    if not API_KEY or not BASE_URL:
+        candidates = "\n  ".join(str(p) for p in ENV_FILES)
+        print(
+            "Error: QWEN_API_KEY / QWEN_BASE_URL not set.\n"
+            "Set them as environment variables, or put them in one of:\n"
+            f"  {candidates}\n"
+            f"(recommended: {SKILL_DIR / '.env'})",
+            file=sys.stderr,
+        )
         sys.exit(1)
 
     result = ocr(image_path)

--- a/tests/test_skills_manager.py
+++ b/tests/test_skills_manager.py
@@ -427,6 +427,122 @@ def test_resource_enumeration_references(tmp_path):
     assert any("guide.md" in r for r in resources["references"])
 
 
+def test_resource_enumeration_scripts_any_extension(tmp_path):
+    g = tmp_path / "global"
+    skill_dir = _write_skill(g, "alpha")
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "run.py").write_text("print('hi')", encoding="utf-8")
+    (scripts_dir / "helper.sh").write_text("echo hi", encoding="utf-8")
+    with patch.multiple(_mod,
+                        _GLOBAL_SKILLS_DIR=g,
+                        _PROJECT_SKILLS_DIR=tmp_path / "p",
+                        _BUNDLED_SKILLS_DIR=tmp_path / "b",
+                        _CONFIG_FILE=tmp_path / "cfg.json",
+                        _CONFIG_DIR=tmp_path):
+        m = SkillManager()
+        resources = m._list_skill_resources("alpha")
+    assert any("run.py" in s for s in resources["scripts"])
+    assert any("helper.sh" in s for s in resources["scripts"])
+
+
+def test_resource_enumeration_skips_junk_and_caps(tmp_path):
+    g = tmp_path / "global"
+    skill_dir = _write_skill(g, "alpha")
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "run.py").write_text("print('hi')", encoding="utf-8")
+    (scripts_dir / ".DS_Store").write_text("junk", encoding="utf-8")
+    (scripts_dir / ".env").write_text("SECRET=1", encoding="utf-8")
+    pycache = scripts_dir / "__pycache__"
+    pycache.mkdir()
+    (pycache / "run.cpython-312.pyc").write_text("", encoding="utf-8")
+    with patch.multiple(_mod,
+                        _GLOBAL_SKILLS_DIR=g,
+                        _PROJECT_SKILLS_DIR=tmp_path / "p",
+                        _BUNDLED_SKILLS_DIR=tmp_path / "b",
+                        _CONFIG_FILE=tmp_path / "cfg.json",
+                        _CONFIG_DIR=tmp_path):
+        m = SkillManager()
+        resources = m._list_skill_resources("alpha")
+    assert [Path(s).name for s in resources["scripts"]] == ["run.py"]
+
+    # Cap: with the limit patched down, the list is truncated and says so.
+    for i in range(4):
+        (scripts_dir / f"s{i}.py").write_text("", encoding="utf-8")
+    with patch.multiple(_mod,
+                        _GLOBAL_SKILLS_DIR=g,
+                        _PROJECT_SKILLS_DIR=tmp_path / "p",
+                        _BUNDLED_SKILLS_DIR=tmp_path / "b",
+                        _CONFIG_FILE=tmp_path / "cfg.json",
+                        _CONFIG_DIR=tmp_path,
+                        _RESOURCE_FILE_CAP=2):
+        m = SkillManager()
+        resources = m._list_skill_resources("alpha")
+    assert len(resources["scripts"]) == 3  # 2 paths + truncation marker
+    assert "3 more files" in resources["scripts"][-1]
+
+
+def test_plugin_command_entry_gets_no_skill_directory(tmp_path):
+    """Command .md files live in a shared commands/ folder — reporting it
+    as a skill directory (or scanning it for resources) would misattribute
+    sibling files to every command."""
+    commands_dir = tmp_path / "plug" / "commands"
+    scripts_dir = commands_dir / "scripts"
+    scripts_dir.mkdir(parents=True)
+    (commands_dir / "foo.md").write_text("# Foo", encoding="utf-8")
+    (scripts_dir / "shared.py").write_text("", encoding="utf-8")
+    with patch.multiple(_mod,
+                        _GLOBAL_SKILLS_DIR=tmp_path / "g",
+                        _PROJECT_SKILLS_DIR=tmp_path / "p",
+                        _BUNDLED_SKILLS_DIR=tmp_path / "b",
+                        _CONFIG_FILE=tmp_path / "cfg.json",
+                        _CONFIG_DIR=tmp_path):
+        m = SkillManager()
+        m.available_skills["plug:foo"] = {
+            "name": "plug:foo",
+            "path": str(commands_dir / "foo.md"),
+            "source_kind": "plugin-command",
+        }
+        resources = m._list_skill_resources("plug:foo")
+        result = m.activate_skill("plug:foo", "task")
+    assert resources["scripts"] == []
+    assert "Skill directory:" not in result
+
+
+def test_list_skill_resources_tolerates_pathless_entry(tmp_path):
+    """Plugin-style entries carry path=None — must not raise."""
+    with patch.multiple(_mod,
+                        _GLOBAL_SKILLS_DIR=tmp_path / "g",
+                        _PROJECT_SKILLS_DIR=tmp_path / "p",
+                        _BUNDLED_SKILLS_DIR=tmp_path / "b",
+                        _CONFIG_FILE=tmp_path / "cfg.json",
+                        _CONFIG_DIR=tmp_path):
+        m = SkillManager()
+        m.available_skills["inline"] = {"name": "inline", "path": None}
+        resources = m._list_skill_resources("inline")
+    assert resources == {"references": [], "assets": [], "scripts": []}
+
+
+def test_activate_skill_reports_skill_directory_and_scripts(tmp_path):
+    g = tmp_path / "global"
+    skill_dir = _write_skill(g, "alpha", description="Alpha skill")
+    scripts_dir = skill_dir / "scripts"
+    scripts_dir.mkdir()
+    (scripts_dir / "ocr.py").write_text("print('ocr')", encoding="utf-8")
+    with patch.multiple(_mod,
+                        _GLOBAL_SKILLS_DIR=g,
+                        _PROJECT_SKILLS_DIR=tmp_path / "p",
+                        _BUNDLED_SKILLS_DIR=tmp_path / "b",
+                        _CONFIG_FILE=tmp_path / "cfg.json",
+                        _CONFIG_DIR=tmp_path):
+        m = SkillManager()
+        result = m.activate_skill("alpha", "test task")
+    assert f"Skill directory: {skill_dir}" in result
+    assert "NOT your current working directory" in result
+    assert str(scripts_dir / "ocr.py") in result
+
+
 def test_skills_context_includes_active_skill(tmp_path):
     g = tmp_path / "global"
     _write_skill(g, "alpha", body="## Alpha Content\nSpecific instructions.")
@@ -441,3 +557,5 @@ def test_skills_context_includes_active_skill(tmp_path):
         ctx = m.get_skills_context()
     assert "alpha" in ctx
     assert "Alpha Content" in ctx
+    assert f"Skill directory: {g / 'alpha'}" in ctx
+    assert "NOT your current working directory" in ctx


### PR DESCRIPTION
Fixes #83

## Problem

SKILL.md instructions referencing relative paths (`scripts/ocr.py`) fail whenever cwd ≠ skill directory — the common case, since skills install under `~/.agentao/skills/` or `<project>/.agentao/skills/`. The activation message gave no skill directory and no resolution rule, and `scripts/` was invisible to the model.

## Fix (load/activation layer — all skills self-heal, incl. third-party)

- `activate_skill()` adds `Skill directory: <abs path>` + the resolution rule ("relative paths resolve against this skill directory, NOT your cwd"); the same line + rule is injected per active skill in `get_skills_context()` every turn, and the Available Skills prompt block states the rule for non-activated use. Single text source: `_SKILL_DIR_NOTE`.
- `_list_skill_resources()` now enumerates `scripts/` (all file types) alongside `references/`/`assets/`, data-driven via `_RESOURCE_SPECS`; hidden files and `__pycache__` are skipped (no `scripts/.env` secrets advertised into the prompt), listings sorted + capped at 50 with an explicit truncation marker.
- New `_skill_dir()` accessor centralizes the path-`None` guard (pathless plugin entries no longer crash `Path(None)`) and returns `None` for `plugin-command` entries — a shared `commands/` folder is not a skill directory.
- Skill paths are `.resolve()`d at load so surfaced paths work from any cwd even when a host passes a relative `skills_dir`.

## ocr example skill

- PEP 723 inline metadata → `uv run` works from any cwd; `requirements.txt` deleted and the 4 doc references to it updated (gallery READMEs en/zh, developer-guide crystallize pages en/zh).
- `ENV_FILES` as single source for the .env precedence chain (loads + error message).
- SKILL.md uses an explicit `<skill-dir>` placeholder (substitute before running) instead of an undefined `$SKILL_DIR` shell variable, and the Path note points at the `Skill directory:` activation line.

## Testing

- 5 new tests: scripts enumeration (any extension), junk filtering + cap marker, plugin-command gets no skill directory, pathless entry tolerance, directory line + rule on both surfaces.
- Full suite: 2943 passed, 2 skipped.
- Self-reviewed via /code-review (7 finder angles + adversarial verification); confirmed findings fixed in this branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)