### PR TITLE
chore: bump version to 0.4.10-dev

### DIFF
--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.9"
+__version__ = "0.4.10-dev"
 
 
 def _ensure_utf8() -> None:


### PR DESCRIPTION
Bumps `__version__` in `agentao/__init__.py` from `0.4.9` → `0.4.10-dev` to open the next development cycle.

`pyproject.toml` uses `dynamic = ["version"]` via `[tool.hatch.version]`, so it picks this up automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)