### PR TITLE
fix(context): close compaction summary with an end-of-summary marker

### DIFF
--- a/agentao/context_manager.py
+++ b/agentao/context_manager.py
@@ -64,6 +64,7 @@ class ContextManager:
     CIRCUIT_BREAKER_LIMIT = 3       # Stop auto-compact after N consecutive failures
     MICROCOMPACT_TOOL_LIMIT = 3_000 # Max chars kept from any old tool result in microcompact
     MICROCOMPACT_PRESERVE_RECENT = 5  # Keep the most recent N tool results at full fidelity
+    SUMMARY_END_MARKER = "--- END OF CONTEXT SUMMARY ---"  # Closes the summary block
 
     def __init__(self, llm_client, memory_tool, max_tokens: int = DEFAULT_MAX_TOKENS, memory_manager=None):  # Optional[MemoryManager]
         """Initialize ContextManager.
@@ -352,7 +353,12 @@ class ContextManager:
 
         summary_msg = {
             "role": "system",
-            "content": f"[Conversation Summary]\n{summary}",
+            "content": (
+                f"[Conversation Summary]\n{summary}\n"
+                f"{self.SUMMARY_END_MARKER}\n"
+                "(The above is historical context. Resume from the live messages "
+                "below; do not re-execute already-completed work.)"
+            ),
         }
 
         file_hint_msgs: List[Dict[str, Any]] = []
@@ -524,6 +530,16 @@ class ContextManager:
                     for b in content
                     if isinstance(b, dict) and b.get("type") == "text"
                 )
+            if (
+                isinstance(content, str)
+                and content.startswith("[Conversation Summary]")
+                and self.SUMMARY_END_MARKER in content
+            ):
+                # Strip a prior summary's end-marker + framing note on rehydration
+                # so it doesn't accumulate when an old summary is re-summarized.
+                # Anchored on the summary prefix so an unrelated message that merely
+                # contains the marker substring is never truncated.
+                content = content.split(self.SUMMARY_END_MARKER)[0].rstrip()
             if role == "tool":
                 tool_name = msg.get("name", "")
                 limit = (


### PR DESCRIPTION
## What

The compaction summary message in `context_manager.py` was opened by the `[Compact Boundary …]` system message but had **no terminator**. Two consequences:

- The summarizer's `## 9. Next Step` section (last line of the summary) could read as a *live instruction*, causing the model to re-execute already-completed work after compaction.
- The kept messages appended right after the summary (`[boundary][summary][file_hint][pinned][recent…]`) blurred into the summary block.

## Change

- Add `SUMMARY_END_MARKER = "--- END OF CONTEXT SUMMARY ---"` and append it to the summary message, plus a one-line *"historical context, resume from the live messages below, do not re-execute already-completed work"* frame. The compaction block is now symmetrically bracketed (open `[Compact Boundary]` → close marker).
- On the next compaction an old summary is itself re-summarized; `_format_for_summary` strips the marker + frame so they don't accumulate. The strip is **anchored on the `[Conversation Summary]` prefix** so an unrelated message that merely contains the marker substring is never truncated (review hardening).

## Why this depth

Idea borrowed from hermes-agent's compaction hardening, scoped to agentao: agentao already uses `role: "system"` for the summary (dampening the "model re-speaks the summary" failure mode), so this lands as boundary-clarity + stale-task hygiene rather than a dramatic fix.

## Consumers verified safe

- `cli/commands/compact.py:_produced_fresh_compaction` keys detection off the `[Compact Boundary` head — untouched.
- `memory/render.py` references `[Conversation Summary]` only in a docstring.
- The `[Conversation Summary]` prefix is preserved.

## Test

Full suite green: **2970 passed, 2 skipped** locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)