### PR TITLE
perf(context): use Tier-1 API count for hot-path threshold checks

### DIFF
--- a/agentao/acp/session_load.py
+++ b/agentao/acp/session_load.py
@@ -302,6 +302,10 @@ def _instantiate_loaded_session(
         # is the same field ``chat()`` reads from.
         try:
             agent.messages = list(messages)
+            # History replaced wholesale; drop the Tier-1 token anchor so the
+            # first post-load threshold check does not reuse a stale prefix
+            # count from a prior conversation served by this instance.
+            agent.context_manager.invalidate_token_anchor()
         except Exception:
             logger.exception(
                 "acp: %s could not hydrate agent.messages for %s",

--- a/agentao/agent.py
+++ b/agentao/agent.py
@@ -1055,7 +1055,7 @@ class Agentao:
         self.skill_manager.clear_active_skills()
         self.todo_tool.clear()
         # Reset context and session token counters for the fresh session
-        self.context_manager._last_api_prompt_tokens = None
+        self.context_manager.invalidate_token_anchor()
         self.llm.total_prompt_tokens = 0
         self.llm.total_completion_tokens = 0
 

--- a/agentao/cli/commands/compact.py
+++ b/agentao/cli/commands/compact.py
@@ -110,7 +110,7 @@ def handle_compact_command(cli: AgentaoCLI, args: str) -> None:
         return
 
     agent.messages = compacted
-    cm._last_api_prompt_tokens = None  # stale after compression
+    cm.invalidate_token_anchor()  # prefix rewritten; anchor is stale
     system_prompt = agent._build_system_prompt()
     post_msgs = len(agent.messages)
     post_tokens = cm.estimate_tokens(

--- a/agentao/cli/commands/sessions.py
+++ b/agentao/cli/commands/sessions.py
@@ -119,6 +119,9 @@ def resume_session(cli: AgentaoCLI, session_id: Optional[str] = None) -> None:
         return
 
     cli.agent.messages = messages
+    # History was replaced wholesale; the Tier-1 token anchor describes the
+    # prior conversation's prefix and must not survive into the resumed one.
+    cli.agent.context_manager.invalidate_token_anchor()
     # Intentionally do NOT restore the persisted model. A session stores only
     # the model *name*, not its provider (api_key / base_url never touch disk).
     # Re-binding the name onto whatever provider the current process happens to

--- a/agentao/context_manager.py
+++ b/agentao/context_manager.py
@@ -129,15 +129,23 @@ class ContextManager:
         appended since, avoiding a full re-encode of the history every turn.
         Falls back to a full local estimate when no fresh anchor is available
         (no API count yet, or right after compaction).
+
+        Note: ``messages[0]`` (the system prompt) lives inside the anchored
+        prefix, but it is rebuilt every turn with volatile content (memory
+        recall, todos, active skills, timestamp). The anchor therefore charges
+        the *previous* turn's system-prompt size for one turn until the next
+        API response re-anchors — a bounded, self-healing accuracy trade-off,
+        not a correctness bug. Do not "fix" it by trusting the anchor harder.
         """
         anchor = self._last_api_prompt_tokens
         n = self._api_anchor_msg_count
-        # Guard the anchor's types: a provider can return a malformed ``usage``
-        # field (null / non-numeric prompt_tokens). bool is excluded explicitly
-        # since it is an int subclass.
+        # Guard the anchor token count: a provider can return a malformed
+        # ``usage`` field (null / non-numeric prompt_tokens). bool is excluded
+        # explicitly since it is an int subclass. (``n`` comes from ``len()``,
+        # so it is always a plain int when set.)
         if (
             not isinstance(anchor, int) or isinstance(anchor, bool)
-            or not isinstance(n, int) or isinstance(n, bool)
+            or not isinstance(n, int)
             or n > len(messages)
         ):
             return self.estimate_tokens(messages)

--- a/agentao/context_manager.py
+++ b/agentao/context_manager.py
@@ -87,6 +87,10 @@ class ContextManager:
 
         # Tier 1: last real prompt_tokens from API response (updated after each LLM call)
         self._last_api_prompt_tokens: Optional[int] = None
+        # Length of the message list that produced _last_api_prompt_tokens, so the
+        # hot-path threshold check can reuse the real count for the already-sent
+        # prefix and only locally estimate messages appended since.
+        self._api_anchor_msg_count: Optional[int] = None
         # Tier 3: cached tiktoken encoding; None = CJK-aware heuristic fallback
         self._encoding = _get_tiktoken_encoding(self.llm_client.model)
 
@@ -94,9 +98,50 @@ class ContextManager:
     # Token estimation
     # -----------------------------------------------------------------------
 
-    def record_api_usage(self, prompt_tokens: int) -> None:
-        """Store real prompt_tokens from the latest API response (Tier 1)."""
+    def record_api_usage(self, prompt_tokens: int, message_count: Optional[int] = None) -> None:
+        """Store real prompt_tokens from the latest API response (Tier 1).
+
+        ``message_count`` is the length of the message list that produced this
+        count (system + history, as sent). When provided it anchors the
+        hot-path threshold estimate so subsequent turns reuse the real count
+        for the already-sent prefix instead of re-encoding the whole history.
+        Omitting it (legacy callers) clears the anchor and forces the full
+        local estimate.
+        """
         self._last_api_prompt_tokens = prompt_tokens
+        self._api_anchor_msg_count = message_count
+
+    def invalidate_token_anchor(self) -> None:
+        """Drop the Tier-1 anchor after history is mutated in place.
+
+        Both microcompaction and full compression rewrite the already-sent
+        prefix, so the real prompt_tokens no longer describes it; the next API
+        response re-establishes the anchor.
+        """
+        self._last_api_prompt_tokens = None
+        self._api_anchor_msg_count = None
+
+    def _threshold_token_estimate(self, messages: List[Dict[str, Any]]) -> int:
+        """Token count for hot-path threshold checks.
+
+        Reuses the real prompt_tokens from the last API response (Tier 1) for
+        the already-sent prefix and locally estimates only the messages
+        appended since, avoiding a full re-encode of the history every turn.
+        Falls back to a full local estimate when no fresh anchor is available
+        (no API count yet, or right after compaction).
+        """
+        anchor = self._last_api_prompt_tokens
+        n = self._api_anchor_msg_count
+        # Guard the anchor's types: a provider can return a malformed ``usage``
+        # field (null / non-numeric prompt_tokens). bool is excluded explicitly
+        # since it is an int subclass.
+        if (
+            not isinstance(anchor, int) or isinstance(anchor, bool)
+            or not isinstance(n, int) or isinstance(n, bool)
+            or n > len(messages)
+        ):
+            return self.estimate_tokens(messages)
+        return anchor + sum(self._count_message_tokens(m) for m in messages[n:])
 
     def count_tokens_in_text(self, text: str) -> int:
         """Count tokens via tiktoken; fall back to CJK-aware heuristic."""
@@ -173,11 +218,11 @@ class ContextManager:
 
     def needs_compression(self, messages: List[Dict[str, Any]]) -> bool:
         """Return True when full LLM compression is needed (>= 65%)."""
-        return self.estimate_tokens(messages) > self.max_tokens * self.COMPRESSION_THRESHOLD
+        return self._threshold_token_estimate(messages) > self.max_tokens * self.COMPRESSION_THRESHOLD
 
     def needs_microcompaction(self, messages: List[Dict[str, Any]]) -> bool:
         """Return True when cheap tool-result clearing is warranted (55-65%)."""
-        tokens = self.estimate_tokens(messages)
+        tokens = self._threshold_token_estimate(messages)
         return (
             tokens > self.max_tokens * self.MICROCOMPACT_THRESHOLD
             and tokens <= self.max_tokens * self.COMPRESSION_THRESHOLD

--- a/agentao/runtime/chat_loop/_compaction.py
+++ b/agentao/runtime/chat_loop/_compaction.py
@@ -36,6 +36,7 @@ class _CompactionMixin:
         pre_tokens = agent.context_manager.estimate_tokens(messages_with_system)
         pre_msgs = len(agent.messages)
         agent.messages = agent.context_manager.microcompact_messages(agent.messages)
+        agent.context_manager.invalidate_token_anchor()  # tool results truncated in place
         messages_with_system = [
             {"role": "system", "content": system_prompt}
         ] + agent.messages
@@ -67,7 +68,7 @@ class _CompactionMixin:
         pre_tokens = agent.context_manager.estimate_tokens(messages_with_system)
         pre_msgs = len(agent.messages)
         agent.messages = agent.context_manager.compress_messages(agent.messages, is_auto=True)
-        agent.context_manager._last_api_prompt_tokens = None  # stale after compression
+        agent.context_manager.invalidate_token_anchor()  # prefix rewritten; real count is stale
         system_prompt = agent._build_system_prompt()
         messages_with_system = [
             {"role": "system", "content": system_prompt}

--- a/agentao/runtime/chat_loop/_runner.py
+++ b/agentao/runtime/chat_loop/_runner.py
@@ -745,7 +745,7 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
             t0 = time.monotonic()
             pre_msgs = len(agent.messages)
             agent.messages = agent.context_manager.compress_messages(agent.messages)
-            agent.context_manager._last_api_prompt_tokens = None  # stale after compression
+            agent.context_manager.invalidate_token_anchor()  # prefix rewritten; anchor is stale
             system_prompt = agent._build_system_prompt()
             messages_with_system = [
                 {"role": "system", "content": system_prompt}

--- a/agentao/runtime/chat_loop/_runner.py
+++ b/agentao/runtime/chat_loop/_runner.py
@@ -265,7 +265,9 @@ class ChatLoopRunner(_CompactionMixin, _HookDispatchMixin):
 
             # Tier 1 token count: record real prompt_tokens from API response
             if getattr(response, "usage", None) and getattr(response.usage, "prompt_tokens", None):
-                agent.context_manager.record_api_usage(response.usage.prompt_tokens)
+                agent.context_manager.record_api_usage(
+                    response.usage.prompt_tokens, len(messages_with_system)
+                )
 
             assistant_message = response.choices[0].message
 

--- a/agentao/runtime/model.py
+++ b/agentao/runtime/model.py
@@ -50,7 +50,7 @@ def set_provider(
     agent.llm.reconfigure(api_key=api_key, base_url=base_url, model=model)
     if model is not None and model != _old_model:
         agent.context_manager._encoding = _get_tiktoken_encoding(agent.llm.model)
-        agent.context_manager._last_api_prompt_tokens = None
+        agent.context_manager.invalidate_token_anchor()
     try:
         agent.transport.emit(AgentEvent(EventType.MODEL_CHANGED, {
             "old_model": _old_model,
@@ -79,7 +79,7 @@ def set_model(agent: "Agentao", model: str) -> str:
     if hasattr(agent.llm, "reset_capability_latches"):
         agent.llm.reset_capability_latches()
     agent.context_manager._encoding = _get_tiktoken_encoding(model)
-    agent.context_manager._last_api_prompt_tokens = None
+    agent.context_manager.invalidate_token_anchor()
     agent.llm.logger.info(f"Model changed from {old_model} to {model}")
     try:
         agent.transport.emit(AgentEvent(EventType.MODEL_CHANGED, {

--- a/tests/test_context_manager.py
+++ b/tests/test_context_manager.py
@@ -110,6 +110,103 @@ def test_needs_compression_true_above_threshold():
 
 
 # ---------------------------------------------------------------------------
+# Tier-1 anchored threshold estimate
+# ---------------------------------------------------------------------------
+
+def test_threshold_uses_tier1_anchor_not_full_reencode():
+    """When a fresh anchor exists, the threshold check must reuse the real
+    prefix count and only estimate the tail — never re-encode the whole list."""
+    from agentao.context_manager import ContextManager
+    cm = ContextManager(_make_mock_llm(), Mock(), max_tokens=1_000)
+    # Prefix is locally tiny (3 tokens) but the API reported it as 600 tokens.
+    msgs = [{"role": "user", "content": "x" * 4} for _ in range(3)]
+    cm.record_api_usage(600, message_count=3)
+    # Append one tail message: 240 chars / 4 = 60 tokens. anchor+tail = 660.
+    msgs.append({"role": "assistant", "content": "x" * 240})
+
+    # estimate_tokens (full re-encode) must NOT be consulted on the hot path.
+    cm.estimate_tokens = Mock(side_effect=AssertionError("full re-encode on hot path"))
+    # 660 > 1000 * 0.65 (650) -> compress. A full local estimate would be
+    # ~3 + 60 = 63 and would (wrongly) return False, so True proves the anchor.
+    assert cm.needs_compression(msgs) is True
+
+
+def test_threshold_falls_back_to_full_estimate_without_anchor():
+    """No anchor recorded -> full local estimate is used."""
+    from agentao.context_manager import ContextManager
+    cm = ContextManager(_make_mock_llm(), Mock(), max_tokens=1_000)
+    msgs = [{"role": "user", "content": "x" * 4} for _ in range(3)]
+    msgs.append({"role": "assistant", "content": "x" * 240})
+    # No record_api_usage call -> anchor is None -> full estimate (~63 tokens).
+    assert cm.needs_compression(msgs) is False
+    assert cm._threshold_token_estimate(msgs) == cm.estimate_tokens(msgs)
+
+
+def test_invalidate_token_anchor_forces_full_estimate():
+    """After history is mutated in place, the anchor is dropped and the
+    threshold falls back to a full local estimate."""
+    from agentao.context_manager import ContextManager
+    cm = ContextManager(_make_mock_llm(), Mock(), max_tokens=1_000)
+    msgs = [{"role": "user", "content": "x" * 4} for _ in range(3)]
+    cm.record_api_usage(600, message_count=3)
+    msgs.append({"role": "assistant", "content": "x" * 240})
+    assert cm.needs_compression(msgs) is True  # anchor active
+
+    cm.invalidate_token_anchor()
+    assert cm._last_api_prompt_tokens is None
+    assert cm._api_anchor_msg_count is None
+    # Now the stale 600 is gone; full estimate (~63) is below threshold.
+    assert cm.needs_compression(msgs) is False
+
+
+def test_record_api_usage_legacy_no_count_clears_anchor():
+    """Legacy callers passing only prompt_tokens must not engage the anchor
+    (no message_count -> full estimate path stays in effect)."""
+    from agentao.context_manager import ContextManager
+    cm = ContextManager(_make_mock_llm(), Mock(), max_tokens=1_000)
+    msgs = [{"role": "user", "content": "x" * 4} for _ in range(3)]
+    msgs.append({"role": "assistant", "content": "x" * 240})
+    cm.record_api_usage(600)  # no message_count
+    assert cm._api_anchor_msg_count is None
+    # Anchor not engaged -> full estimate (~63) -> below threshold.
+    assert cm.needs_compression(msgs) is False
+
+
+def test_threshold_anchor_count_exceeds_messages_falls_back():
+    """If the anchored count is larger than the current list (e.g. history was
+    trimmed), fall back to the full estimate rather than slice incorrectly."""
+    from agentao.context_manager import ContextManager
+    cm = ContextManager(_make_mock_llm(), Mock(), max_tokens=1_000)
+    msgs = [{"role": "user", "content": "x" * 4} for _ in range(3)]
+    cm.record_api_usage(600, message_count=10)  # count > len(msgs)
+    # Falls back to full estimate (~3 tokens), not anchor.
+    assert cm._threshold_token_estimate(msgs) == cm.estimate_tokens(msgs)
+
+
+def test_threshold_guards_non_numeric_anchor():
+    """A malformed provider usage field (non-int prompt_tokens) must not poison
+    the threshold path; fall back to the full local estimate."""
+    from agentao.context_manager import ContextManager
+    cm = ContextManager(_make_mock_llm(), Mock(), max_tokens=1_000)
+    msgs = [{"role": "user", "content": "x" * 4} for _ in range(3)]
+    cm.record_api_usage(Mock(), message_count=3)  # garbage prompt_tokens
+    # Must not raise; uses full estimate (~3 tokens).
+    assert cm._threshold_token_estimate(msgs) == cm.estimate_tokens(msgs)
+    assert cm.needs_compression(msgs) is False
+
+
+def test_microcompaction_uses_anchored_threshold():
+    """needs_microcompaction shares the anchored estimate (55-65% band)."""
+    from agentao.context_manager import ContextManager
+    cm = ContextManager(_make_mock_llm(), Mock(), max_tokens=1_000)
+    msgs = [{"role": "user", "content": "x" * 4} for _ in range(3)]
+    cm.record_api_usage(580, message_count=3)  # 58% via anchor
+    cm.estimate_tokens = Mock(side_effect=AssertionError("full re-encode on hot path"))
+    # 580 is in (550, 650] -> microcompaction warranted.
+    assert cm.needs_microcompaction(msgs) is True
+
+
+# ---------------------------------------------------------------------------
 # Compression algorithm
 # ---------------------------------------------------------------------------
 

--- a/tests/test_sessions_resume_anchor.py
+++ b/tests/test_sessions_resume_anchor.py
@@ -1,0 +1,52 @@
+"""Regression: resuming a session must drop the Tier-1 token anchor.
+
+``resume_session`` replaces ``agent.messages`` wholesale. The context
+manager's anchored threshold estimate (``_threshold_token_estimate``) reuses
+the last API ``prompt_tokens`` for the already-sent prefix; if the anchor from
+the *previous* conversation survives the swap, the first post-resume threshold
+check mis-sizes the new history (spurious or skipped compaction). The fix calls
+``context_manager.invalidate_token_anchor()`` right after the swap.
+"""
+
+from unittest.mock import Mock
+
+from agentao.context_manager import ContextManager
+
+
+def _make_mock_llm():
+    mock_llm = Mock()
+    mock_llm.logger = Mock()
+    mock_llm.model = "test-model"
+    return mock_llm
+
+
+def test_resume_session_invalidates_token_anchor(monkeypatch):
+    from agentao.cli.commands import sessions as sess_mod
+
+    cm = ContextManager(_make_mock_llm(), Mock(), max_tokens=1_000)
+    # Stale anchor from a prior conversation in this process.
+    cm.record_api_usage(600, message_count=3)
+    assert cm._last_api_prompt_tokens == 600
+    assert cm._api_anchor_msg_count == 3
+
+    resumed = [{"role": "user", "content": "hello again"}]
+
+    cli = Mock()
+    cli.agent.context_manager = cm
+    cli.agent.working_directory = "."
+
+    monkeypatch.setattr(
+        "agentao.embedding.sessions.list_sessions",
+        lambda project_root=None: [{"id": "s1", "session_id": "s1", "title": "t"}],
+    )
+    monkeypatch.setattr(
+        "agentao.embedding.sessions.load_session",
+        lambda sid, project_root=None: (resumed, "saved-model", []),
+    )
+
+    sess_mod.resume_session(cli, "s1")
+
+    assert cli.agent.messages == resumed
+    # The prior conversation's anchor must not survive the swap.
+    assert cm._last_api_prompt_tokens is None
+    assert cm._api_anchor_msg_count is None


### PR DESCRIPTION
## What

`needs_compression` / `needs_microcompaction` re-encoded the **entire history** through tiktoken on every turn (two full passes per iteration), even though the real `prompt_tokens` from the prior API response was already recorded in `record_api_usage` and went unused in the decision.

This anchors the threshold estimate to that real count: reuse it for the already-sent prefix and locally estimate only the messages appended since (`_threshold_token_estimate`). Falls back to a full local estimate when no fresh anchor exists.

## How

- `record_api_usage(prompt_tokens, message_count=None)` now captures the message-list length as an anchor (optional arg → back-compat).
- `invalidate_token_anchor()` is called on **every** path that mutates/replaces history: microcompaction + full compression (the original target), and — found in review — `/sessions resume`, ACP session load, in-loop overflow recovery, manual `/compact`, `clear_history`, and model/provider switch. This closes a real correctness bug where a stale anchor from a prior conversation corrupted the first post-resume threshold check.
- Guards a malformed provider `usage` field (non-numeric `prompt_tokens`) → falls back rather than crashing the threshold path.

## Behavior note

The Tier-1 count includes system + tool-schema tokens the old estimate omitted, so thresholds now fire on the **true** prompt size — marginally earlier and more accurate. The system prompt sits in the anchored prefix, so there's a bounded, self-healing one-turn drift (documented in code).

## Tests

New coverage for the anchored estimate (anchor-vs-full-encode, fallback paths, malformed-anchor guard, microcompaction band) and a regression test for `/sessions resume` anchor invalidation. Full default suite green aside from a pre-existing live-API test (`test_model_command::test_model_switching_flow`, 401 with dummy key — unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)