### PR TITLE
fix(security): resolve-based SSRF guard for web_fetch

### DIFF
--- a/agentao/security/__init__.py
+++ b/agentao/security/__init__.py
@@ -1,9 +1,17 @@
 """Security primitives for agentao tools.
 
-Currently exposes :class:`PathPolicy` which gates filesystem writes to a
-project-rooted workspace.
+Exposes :class:`PathPolicy` (gates filesystem writes to a project-rooted
+workspace) and the outbound-URL SSRF policy (:func:`validate_outbound_url`,
+:func:`guarded_get`) used by the web tools.
 """
 
 from .path_policy import PathPolicy, PathPolicyError
+from .url_policy import UrlPolicyError, guarded_get, validate_outbound_url
 
-__all__ = ["PathPolicy", "PathPolicyError"]
+__all__ = [
+    "PathPolicy",
+    "PathPolicyError",
+    "UrlPolicyError",
+    "guarded_get",
+    "validate_outbound_url",
+]

--- a/agentao/security/url_policy.py
+++ b/agentao/security/url_policy.py
@@ -1,0 +1,234 @@
+"""SSRF policy for outbound web tools.
+
+The PermissionEngine domain blocklist (``permissions.py``) is a static,
+plan-phase **string** check on the URL the model passes. By design it does
+no I/O, so it cannot catch:
+
+* hostnames that *resolve* to a private/loopback/link-local address — i.e.
+  DNS rebinding, or a public name pointed at ``127.0.0.1`` /
+  ``169.254.169.254`` (cloud metadata);
+* alternate encodings of a blocked address (``2130706433`` and ``127.1``
+  both resolve to ``127.0.0.1``; v4-mapped / 6to4 / NAT64 IPv6 forms such as
+  ``[::ffff:127.0.0.1]`` and ``[64:ff9b::169.254.169.254]``);
+* a **redirect hop** to an internal target after an allowed first URL.
+
+This module is the execute-phase complement. It normalizes the hostname,
+rejects local/internal names, and — for non-literal hosts — resolves the
+host and rejects any non-global address. It is applied to the initial URL
+*and every redirect hop* (see :func:`guarded_get`). The two layers are
+defense in depth: the static blocklist stays in the PermissionEngine (fast,
+no I/O, runs before the tool); resolution lives here, in the tool.
+
+Scope is deliberately narrow:
+
+* The legitimate-private-target escape hatch is the PermissionEngine
+  **allowlist**, not a flag here — there is intentionally no per-call
+  bypass.
+* Resolution uses :func:`socket.getaddrinfo`, the same resolver ``httpx``
+  uses to connect, so the address we validate is the address the fetch
+  connects to. A residual TOCTOU window remains (DNS could change between
+  this check and the connection); closing it fully would require pinning
+  the resolved IP and connecting to it with a ``Host`` header. We match the
+  resolve-then-check level rather than pin, which already closes every
+  string-bypass and redirect vector above.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import socket
+from typing import TYPE_CHECKING, Optional
+from urllib.parse import urljoin, urlparse
+
+if TYPE_CHECKING:
+    import httpx
+
+_IPAddress = ipaddress.IPv4Address | ipaddress.IPv6Address
+
+_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+# Exact hostnames that must never be reached even though they may resolve to
+# a public-looking address (or not resolve at all on the host running us).
+_LOCAL_HOSTNAMES = {
+    "localhost",
+    "localhost.localdomain",
+    "metadata.google.internal",
+}
+
+# Suffixes for cloud/k8s/mDNS-internal names. These overlap the
+# PermissionEngine blocklist (``.internal`` / ``.local``) on purpose — this
+# module must stand alone when a host has customised or dropped the presets.
+_LOCAL_HOST_SUFFIXES = (
+    ".localhost",
+    ".local",
+    ".localdomain",
+    ".internal",
+    ".cluster.local",
+)
+
+# Bound the manual redirect chase. Matches httpx's own prior default of 20 so
+# a legitimate long redirect chain (CDN / auth flows) isn't turned into a hard
+# error; each hop costs a DNS round-trip in validation, which 20 bounds.
+_MAX_REDIRECTS = 20
+
+# NAT64 well-known prefix (RFC 6052 / 6147). An address in this range embeds an
+# IPv4 in its low 32 bits that a NAT64 gateway routes to — including
+# 169.254.169.254 (cloud metadata) or 127.0.0.1.
+_NAT64_PREFIX = ipaddress.ip_network("64:ff9b::/96")
+
+
+class UrlPolicyError(ValueError):
+    """Raised when an outbound URL is rejected by the SSRF policy."""
+
+
+def _parse_ip_literal(value: str) -> Optional[_IPAddress]:
+    try:
+        return ipaddress.ip_address(value)
+    except ValueError:
+        return None
+
+
+def _embedded_ipv4(address: _IPAddress) -> Optional[ipaddress.IPv4Address]:
+    """Return an IPv4 embedded in an IPv6 address via a translation mechanism.
+
+    Covers v4-mapped (``::ffff:a.b.c.d``), 6to4 (``2002::/16``) and NAT64
+    (``64:ff9b::/96``); returns ``None`` for a plain IPv4/IPv6 address.
+
+    Without this, an IPv6 literal can smuggle a private/loopback IPv4 past an
+    ``is_global`` check: the IPv6 form reports ``is_global=True`` while a
+    NAT64/6to4 gateway on the host network routes it to the embedded IPv4.
+    """
+    if not isinstance(address, ipaddress.IPv6Address):
+        return None
+    if address.ipv4_mapped is not None:
+        return address.ipv4_mapped
+    if address.sixtofour is not None:
+        return address.sixtofour
+    if address in _NAT64_PREFIX:
+        return ipaddress.IPv4Address(int(address) & 0xFFFFFFFF)
+    return None
+
+
+def _is_disallowed(address: _IPAddress) -> bool:
+    """True if ``address`` is not a globally routable public address.
+
+    An IPv6 address carrying an embedded IPv4 (v4-mapped / 6to4 / NAT64) is
+    judged by that embedded IPv4 — where a translator actually routes it — so a
+    loopback or metadata target can't be smuggled through the v6 form.
+    """
+    embedded = _embedded_ipv4(address)
+    if embedded is not None:
+        return not embedded.is_global
+    return not address.is_global
+
+
+def _normalized_hostname(hostname: str) -> str:
+    # Trailing dot ("localhost.") is a fully-qualified form that bypasses an
+    # exact-string blocklist but resolves identically; case is irrelevant.
+    return hostname.rstrip(".").lower()
+
+
+def validate_outbound_url(url: str) -> None:
+    """Reject loopback / private / link-local / internal HTTP(S) targets.
+
+    Raises :class:`UrlPolicyError` for a non-http(s) scheme, embedded
+    credentials, a missing/invalid host or port, a local/internal hostname,
+    a single-label hostname (resolves via the host's search domain — never a
+    real public target), an IP literal that is not globally routable, or a
+    hostname that resolves to any non-global address.
+    """
+    parsed = urlparse(url)
+    scheme = (parsed.scheme or "").lower()
+    if scheme not in _DEFAULT_PORTS:
+        raise UrlPolicyError(f"only http/https URLs are allowed: {url!r}")
+    if parsed.username or parsed.password:
+        raise UrlPolicyError("URLs with embedded credentials are not allowed")
+
+    raw_host = parsed.hostname
+    if not raw_host:
+        raise UrlPolicyError(f"URL has no host: {url!r}")
+    hostname = _normalized_hostname(raw_host)
+
+    literal = _parse_ip_literal(hostname)
+    if literal is not None:
+        if _is_disallowed(literal):
+            raise UrlPolicyError(
+                f"target is a non-public address: {hostname}"
+            )
+        return
+
+    if hostname in _LOCAL_HOSTNAMES or any(
+        hostname.endswith(suffix) for suffix in _LOCAL_HOST_SUFFIXES
+    ):
+        raise UrlPolicyError(f"local/internal hostnames are not allowed: {hostname}")
+    if "." not in hostname:
+        raise UrlPolicyError(f"single-label hostnames are not allowed: {hostname}")
+
+    try:
+        explicit_port = parsed.port
+    except ValueError as exc:
+        raise UrlPolicyError(f"invalid port in URL: {url!r}") from exc
+    # ``or`` would treat an explicit ``:0`` as absent; use ``is not None``.
+    port = explicit_port if explicit_port is not None else _DEFAULT_PORTS[scheme]
+
+    addresses = _resolve_host_addresses(hostname, port)
+    if not addresses:
+        raise UrlPolicyError(f"host did not resolve: {hostname}")
+    blocked = sorted({str(a) for a in addresses if _is_disallowed(a)})
+    if blocked:
+        rendered = ", ".join(blocked[:3]) + (", ..." if len(blocked) > 3 else "")
+        raise UrlPolicyError(
+            f"{hostname} resolves to non-public address(es): {rendered}"
+        )
+
+
+def _resolve_host_addresses(host: str, port: int) -> set[_IPAddress]:
+    """Resolve ``host`` to its concrete IP addresses via ``getaddrinfo``."""
+    try:
+        infos = socket.getaddrinfo(host, port, proto=socket.IPPROTO_TCP)
+    except (OSError, UnicodeError):
+        # gaierror (an OSError subclass), socket.timeout, and IDNA UnicodeError
+        # (e.g. a DNS label >63 chars) all mean "no usable address" — fail
+        # closed by returning none so the caller rejects the URL.
+        return set()
+    addresses: set[_IPAddress] = set()
+    for info in infos:
+        sockaddr = info[4]
+        candidate = sockaddr[0] if sockaddr else None
+        if not isinstance(candidate, str):
+            continue
+        parsed = _parse_ip_literal(candidate)
+        if parsed is not None:
+            addresses.add(parsed)
+    return addresses
+
+
+def guarded_get(
+    client: "httpx.Client",
+    url: str,
+    *,
+    headers: Optional[dict[str, str]] = None,
+    max_redirects: int = _MAX_REDIRECTS,
+) -> "httpx.Response":
+    """GET ``url`` with SSRF validation on the initial URL and every hop.
+
+    ``client`` MUST be constructed with ``follow_redirects=False`` so this
+    function controls the chase: each ``Location`` is resolved against the
+    current URL and re-validated before the next request. The final
+    non-redirect response is returned (caller handles status / body).
+
+    Raises :class:`UrlPolicyError` on a disallowed target (initial or any
+    hop) or when the redirect budget is exhausted.
+    """
+    current = url
+    for _ in range(max_redirects + 1):
+        validate_outbound_url(current)
+        response = client.get(current, headers=headers)
+        if response.status_code in (301, 302, 303, 307, 308):
+            location = response.headers.get("location")
+            if location:
+                response.close()
+                current = urljoin(current, location)
+                continue
+        return response
+    raise UrlPolicyError(f"too many redirects ({max_redirects}) for {url!r}")

--- a/agentao/tools/web.py
+++ b/agentao/tools/web.py
@@ -14,6 +14,7 @@ if TYPE_CHECKING:
     from bs4 import BeautifulSoup as _BeautifulSoup_t
 
 from .base import Tool
+from ..security.url_policy import UrlPolicyError, guarded_get
 
 logger = logging.getLogger("agentao.tools.web")
 
@@ -196,8 +197,14 @@ class WebFetchTool(Tool):
         }
 
         try:
-            with httpx.Client(follow_redirects=True, timeout=30.0) as client:
-                response = client.get(url, headers=headers)
+            # SSRF guard: follow_redirects=False so guarded_get owns the
+            # redirect chase and re-validates the target on every hop. The
+            # static PermissionEngine blocklist already ran at the plan-phase
+            # gate on the original URL; this catches what a string check
+            # can't — names that *resolve* to private/loopback addresses and
+            # redirects into the internal network.
+            with httpx.Client(follow_redirects=False, timeout=30.0) as client:
+                response = guarded_get(client, url, headers=headers)
                 response.raise_for_status()
 
             html = response.text
@@ -225,6 +232,11 @@ class WebFetchTool(Tool):
                 f"{_truncate(body, 10000)}"
             )
 
+        except UrlPolicyError as e:
+            # Blocked target — do NOT fall through to the jina/crawl4ai
+            # fallbacks: those would exfiltrate the internal URL through a
+            # third party or fetch it via a local headless browser.
+            return f"Error: blocked outbound request — {e}"
         except httpx.TimeoutException:
             fallback_result = self._run_fallback(url, reason="httpx timeout")
             if fallback_result is not None:
@@ -240,7 +252,18 @@ class WebFetchTool(Tool):
 
     def _run_fallback(self, url: str, *, reason: str) -> str | None:
         """Returns None when fallback is ``none``, signalling the caller to
-        keep the primary result."""
+        keep the primary result.
+
+        SSRF note: ``url`` reaching here has already passed
+        ``validate_outbound_url`` on the primary path (a blocked target raises
+        ``UrlPolicyError``, which the caller returns without falling back). But
+        the fallbacks themselves are NOT per-hop guarded — Jina fetches the
+        target server-side and the crawl4ai headless browser follows
+        redirects / JS navigation on its own. Both are opt-in
+        (``AGENTAO_WEB_FETCH_FALLBACK``, default ``none``) and surfaced in the
+        tool description; closing the in-browser redirect path would require
+        intercepting Chromium's network, which is out of scope here.
+        """
         if self._fallback == _FALLBACK_NONE:
             return None
         if self._fallback == _FALLBACK_JINA:

--- a/tests/test_url_policy.py
+++ b/tests/test_url_policy.py
@@ -1,0 +1,261 @@
+"""Unit tests for the outbound-URL SSRF policy.
+
+Covers every bypass class that the static PermissionEngine string blocklist
+cannot catch and that ``validate_outbound_url`` / ``guarded_get`` close:
+IP-literal encodings (decimal/short/v4-mapped-v6), hostname normalization
+(trailing dot / case), local & internal names, single-label hosts, embedded
+credentials, non-http schemes, DNS rebinding (name resolves to a private
+address), and redirect hops into the internal network.
+
+Resolution and HTTP are faked so the suite is hermetic — no network. The
+fake resolver maps hostnames to IP strings; numeric/short host forms
+(``127.1``, ``2130706433``) are validated through that resolver exactly as
+``socket.getaddrinfo`` would resolve them at runtime.
+"""
+
+from __future__ import annotations
+
+import ipaddress
+
+import pytest
+
+from agentao.security import UrlPolicyError, guarded_get, validate_outbound_url
+from agentao.security import url_policy
+
+
+@pytest.fixture
+def fake_resolver(monkeypatch):
+    """Install a hostname -> [ip, ...] resolver in place of getaddrinfo."""
+    table: dict[str, list[str]] = {}
+
+    def _resolve(host, port):
+        return {ipaddress.ip_address(ip) for ip in table.get(host, [])}
+
+    monkeypatch.setattr(url_policy, "_resolve_host_addresses", _resolve)
+    return table
+
+
+# --------------------------------------------------------------------------
+# IP literals — no resolution needed
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://127.0.0.1/",
+        "http://127.0.0.2/",            # loopback range, not just .1
+        "http://0.0.0.0/",
+        "http://169.254.169.254/latest/meta-data/",  # AWS metadata
+        "http://10.0.0.5/",             # private
+        "http://[::1]/",                # v6 loopback
+        "http://[::ffff:127.0.0.1]/",   # v4-mapped v6 loopback
+    ],
+)
+def test_blocks_non_public_ip_literals(url):
+    with pytest.raises(UrlPolicyError):
+        validate_outbound_url(url)
+
+
+def test_allows_public_ip_literal():
+    validate_outbound_url("http://8.8.8.8/")  # no raise
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://[64:ff9b::169.254.169.254]/",  # NAT64 -> metadata
+        "http://[64:ff9b::7f00:1]/",           # NAT64 -> 127.0.0.1
+        "http://[2002:a9fe:a9fe::]/",          # 6to4 -> 169.254.169.254
+    ],
+)
+def test_blocks_ipv6_with_embedded_private_ipv4(url):
+    # is_global is True for these v6 forms; a NAT64/6to4 gateway would route
+    # them to the embedded (private/metadata) IPv4.
+    with pytest.raises(UrlPolicyError):
+        validate_outbound_url(url)
+
+
+def test_allows_ipv6_translation_embedding_public_ipv4():
+    # NAT64/6to4 wrapping a *public* v4 is a legitimate public target.
+    validate_outbound_url("http://[64:ff9b::8.8.8.8]/")  # no raise
+    validate_outbound_url("http://[2002:0808:0808::]/")  # 6to4 -> 8.8.8.8
+
+
+# --------------------------------------------------------------------------
+# Hostname classification — no resolution needed
+# --------------------------------------------------------------------------
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "http://localhost/admin",
+        "http://LOCALHOST/admin",       # case
+        "http://localhost./admin",      # trailing dot (FQDN form)
+        "http://metadata.google.internal/computeMetadata/v1/",
+        "http://foo.internal/",
+        "http://foo.local/",
+        "http://svc.cluster.local/",
+        "http://myinternalbox/secret",  # single-label
+    ],
+)
+def test_blocks_local_and_internal_names(url):
+    with pytest.raises(UrlPolicyError):
+        validate_outbound_url(url)
+
+
+@pytest.mark.parametrize(
+    "url",
+    [
+        "ftp://example.com/",
+        "file:///etc/passwd",
+        "http://user:pass@example.com/",  # embedded credentials
+        "http://",                        # no host
+    ],
+)
+def test_blocks_bad_scheme_or_credentials(url):
+    with pytest.raises(UrlPolicyError):
+        validate_outbound_url(url)
+
+
+# --------------------------------------------------------------------------
+# Resolution-dependent — DNS rebinding and numeric host forms
+# --------------------------------------------------------------------------
+
+def test_blocks_name_resolving_to_loopback(fake_resolver):
+    fake_resolver["evil.example.com"] = ["127.0.0.1"]
+    with pytest.raises(UrlPolicyError):
+        validate_outbound_url("http://evil.example.com/")
+
+
+def test_blocks_name_resolving_to_metadata(fake_resolver):
+    fake_resolver["rebind.example.com"] = ["169.254.169.254"]
+    with pytest.raises(UrlPolicyError):
+        validate_outbound_url("http://rebind.example.com/")
+
+
+def test_blocks_numeric_host_forms_via_resolution(fake_resolver):
+    # urlparse/ip_address don't parse these as literals; getaddrinfo does.
+    fake_resolver["127.1"] = ["127.0.0.1"]
+    fake_resolver["2130706433"] = ["127.0.0.1"]
+    with pytest.raises(UrlPolicyError):
+        validate_outbound_url("http://127.1/")
+    with pytest.raises(UrlPolicyError):
+        validate_outbound_url("http://2130706433/")
+
+
+def test_allows_public_name(fake_resolver):
+    fake_resolver["example.com"] = ["93.184.216.34"]
+    validate_outbound_url("http://example.com/")  # no raise
+
+
+def test_blocks_unresolvable_name(fake_resolver):
+    # Empty resolution -> reject rather than fall through.
+    with pytest.raises(UrlPolicyError):
+        validate_outbound_url("http://nope.example.com/")
+
+
+def test_blocks_when_any_resolved_address_is_private(fake_resolver):
+    # Mixed result set: one public, one loopback -> blocked.
+    fake_resolver["mixed.example.com"] = ["93.184.216.34", "127.0.0.1"]
+    with pytest.raises(UrlPolicyError):
+        validate_outbound_url("http://mixed.example.com/")
+
+
+def test_unresolvable_or_invalid_host_fails_closed():
+    # A real getaddrinfo call (no fake_resolver): an over-long DNS label raises
+    # UnicodeError (IDNA), not gaierror — must be caught and treated as "no
+    # address" -> UrlPolicyError, never an escaping raw exception.
+    with pytest.raises(UrlPolicyError):
+        validate_outbound_url("http://" + "a" * 64 + ".invalid/")
+
+
+def test_explicit_port_zero_is_not_treated_as_default(fake_resolver):
+    # Regression: `parsed.port or default` would swallow an explicit :0.
+    # Validation should still classify by the resolved address, not crash.
+    fake_resolver["example.com"] = ["93.184.216.34"]
+    validate_outbound_url("http://example.com:0/")  # no raise
+
+
+# --------------------------------------------------------------------------
+# guarded_get — per-redirect-hop re-validation
+# --------------------------------------------------------------------------
+
+class _FakeResponse:
+    def __init__(self, status_code, location=None):
+        self.status_code = status_code
+        self.headers = {"location": location} if location else {}
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+
+
+class _FakeClient:
+    """Returns queued responses keyed by requested URL."""
+
+    def __init__(self, responses):
+        self._responses = dict(responses)
+        self.requested: list[str] = []
+
+    def get(self, url, headers=None):
+        self.requested.append(url)
+        return self._responses[url]
+
+
+def test_guarded_get_returns_final_non_redirect(fake_resolver):
+    fake_resolver["example.com"] = ["93.184.216.34"]
+    client = _FakeClient({"http://example.com/": _FakeResponse(200)})
+    resp = guarded_get(client, "http://example.com/")
+    assert resp.status_code == 200
+    assert client.requested == ["http://example.com/"]
+
+
+def test_guarded_get_follows_public_redirect(fake_resolver):
+    fake_resolver["a.example.com"] = ["93.184.216.34"]
+    fake_resolver["b.example.com"] = ["93.184.216.35"]
+    client = _FakeClient(
+        {
+            "http://a.example.com/": _FakeResponse(302, "http://b.example.com/"),
+            "http://b.example.com/": _FakeResponse(200),
+        }
+    )
+    resp = guarded_get(client, "http://a.example.com/")
+    assert resp.status_code == 200
+    assert client.requested == ["http://a.example.com/", "http://b.example.com/"]
+
+
+def test_guarded_get_blocks_redirect_to_internal(fake_resolver):
+    # Public first hop 302-redirects to the cloud metadata endpoint.
+    fake_resolver["a.example.com"] = ["93.184.216.34"]
+    client = _FakeClient(
+        {
+            "http://a.example.com/": _FakeResponse(
+                302, "http://169.254.169.254/latest/meta-data/"
+            ),
+        }
+    )
+    with pytest.raises(UrlPolicyError):
+        guarded_get(client, "http://a.example.com/")
+
+
+def test_guarded_get_resolves_relative_redirect(fake_resolver):
+    fake_resolver["a.example.com"] = ["93.184.216.34"]
+    client = _FakeClient(
+        {
+            "http://a.example.com/start": _FakeResponse(302, "/next"),
+            "http://a.example.com/next": _FakeResponse(200),
+        }
+    )
+    resp = guarded_get(client, "http://a.example.com/start")
+    assert resp.status_code == 200
+    assert client.requested[-1] == "http://a.example.com/next"
+
+
+def test_guarded_get_redirect_budget(fake_resolver):
+    fake_resolver["loop.example.com"] = ["93.184.216.34"]
+    # Always redirects to itself -> exhausts the budget.
+    client = _FakeClient(
+        {"http://loop.example.com/": _FakeResponse(302, "http://loop.example.com/")}
+    )
+    with pytest.raises(UrlPolicyError):
+        guarded_get(client, "http://loop.example.com/", max_redirects=3)


### PR DESCRIPTION
## Problem

`web_fetch`'s only SSRF defense was the PermissionEngine **string blocklist** (`permissions.py`), matched on the original URL at the plan-phase gate. It does no I/O, so it missed everything that needs resolution:

- hostnames that **resolve** to private/loopback/link-local addresses — DNS rebinding, or a public name pointed at `127.0.0.1` / `169.254.169.254` (cloud metadata);
- alternate IP encodings (`2130706433`, `127.1`, v4-mapped/6to4/NAT64 IPv6);
- **redirect hops** into the internal network — the client used `follow_redirects=True` with no per-hop re-check.

Empirically, **8 of 13 bypass vectors** slipped through the blocklist.

## Fix

New `agentao/security/url_policy.py` (sibling of `path_policy.py`):

- **`validate_outbound_url()`** — normalizes the hostname (trailing dot / case), rejects local/internal names, single-label hosts and embedded credentials, unwraps v4-mapped / 6to4 / NAT64 IPv6 forms, then resolves the host (same `getaddrinfo` httpx uses) and rejects any non-`is_global` address.
- **`guarded_get()`** — drives the redirect chase with `follow_redirects=False`, re-validating **every hop**.

Wired into `WebFetchTool.execute()`; blocked targets return cleanly and never fall through to the jina/crawl4ai fallbacks. The static PermissionEngine blocklist is **kept** as the I/O-free plan-phase first layer (defense in depth — DNS belongs in the tool's execute phase, not the engine).

## Review hardening

Found + fixed via an xhigh multi-agent review (incl. an adversarial SSRF-bypass pass):

- NAT64/6to4 IPv6-literal bypass (`[64:ff9b::169.254.169.254]` reports `is_global=True`) → `_embedded_ipv4` unwrap;
- `getaddrinfo` `except (OSError, UnicodeError)` fail-closed (IDNA >63-char label raises `UnicodeError`, not `gaierror`);
- redirect cap 10 → 20 (httpx-default parity, avoids regressing legit long chains);
- explicit `:0` port no longer treated as default.

**Known residuals (documented, out of scope):** the opt-in jina/crawl4ai fallbacks aren't per-hop guarded (off by default; entry URL pre-validated); DNS-rebind TOCTOU (closing it needs an IP-pinning transport).

## Tests

`tests/test_url_policy.py` — 37 cases (IP-literal vectors, hostname classification, DNS-rebind, NAT64/6to4 block + public-embedded allow, IDNA fail-closed, port-0, redirect re-validation/budget). Full suite green (3047 passed, 2 skipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)