### PR TITLE
chore(release): cut v0.4.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,98 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [0.4.10] — 2026-06-14
+
+### Added
+
+- **Host LLM request passthrough: `Agentao(extra_body=...)`.** The LLM request
+  kwargs were a closed set, so a host could not reach `reasoning_effort` /
+  `top_p` / `seed` / `response_format` or any provider-specific body field
+  without subclassing `LLMClient` or monkeypatching — both off the
+  `agentao.host` contract. `extra_body` is the SDK-blessed escape hatch, now a
+  first-class harness primitive. (#91)
+  - Forwarded verbatim to the OpenAI SDK `.create()` body on both the
+    non-streaming and streaming paths via a single `_build_request_kwargs()`
+    (de-dups the previously closed kwargs dict); omitted when empty so requests
+    stay byte-identical.
+  - **Keyword-only** on the constructor so it never shifts the legacy
+    positional callback args; mutually exclusive with `llm_client=` (a loud
+    `ValueError`, not a silent no-op); deep-copied at construction so a host
+    mutating a nested value it still holds cannot alter in-flight requests.
+  - Sub-agents inherit it via the `_llm_config` snapshot. `reconfigure()`
+    preserves it across a model switch with **no auto-recovery latch** — the
+    host owns dropping model-specific keys (a stale `reasoning_effort` will 400
+    until cleared), unlike the `omit_temperature` / `max_completion_tokens`
+    latches that are reset.
+  - Logged with recursive credential redaction (exact lower-cased key-name
+    match over dict/list/tuple; covers body and header-style names like
+    `x-api-key`, `authorization`, `client_secret`) so a benign `*_tokens` key
+    is not over-redacted.
+  - Env var `LLM_EXTRA_BODY` (JSON object; malformed or valid-but-non-object →
+    warn + skip; empty → unset). `extra_headers`, `settings.json`, and a
+    `/param` command are deferred (§8).
+  - Design: `docs/design/host-llm-extra-params.md` / `.zh.md`.
+
+### Changed
+
+- **Context-window threshold checks anchor to the real Tier-1 prompt-token
+  count.** `needs_compression` / `needs_microcompaction` re-encoded the entire
+  history through tiktoken twice per turn even though the real `prompt_tokens`
+  from the prior API response was already recorded and went unused. The
+  threshold estimate now reuses that count for the already-sent prefix and
+  locally estimates only the messages appended since. (#90)
+  - Behavior note: the Tier-1 count includes system + tool-schema tokens the
+    old local estimate omitted, so thresholds now fire on the true prompt
+    size — marginally earlier and more accurate.
+  - The anchor is invalidated on every history-replace path — full
+    compression, microcompaction (previously a latent staleness bug),
+    `/sessions resume`, ACP session load, in-loop overflow recovery, manual
+    `/compact`, `clear_history`, and model/provider switch — via a single
+    `invalidate_token_anchor()` helper that keeps the paired `(count, tokens)`
+    invariant. A malformed provider `prompt_tokens` field falls back to the
+    full local estimate rather than crashing the threshold path.
+
+### Fixed
+
+- **Context-overflow detection hardened with a provider table + negative
+  guard.** `is_context_too_long_error` was a 7-phrase substring matcher with no
+  negative guard: it missed overflow errors from xAI / Google / Bedrock /
+  OpenRouter / Together / Mistral / llama.cpp / LM Studio / Kimi / Ollama, and
+  its fallback phrase "too many tokens" misclassified Bedrock throttling
+  (`ThrottlingException: Too many tokens...`) as overflow — triggering a
+  destructive history compaction on a transient error. Rewritten as a two-tier
+  compiled-regex table: a broadened positive pattern set, plus a negative set
+  (throttling / rate limit / 429 / 503) checked first that short-circuits to
+  `False`. Adds 22 positive provider cases + 5 guard cases. (#88)
+- **Compaction summary now closes with an end-of-summary marker.** The summary
+  was opened by the `[Compact Boundary]` system message but had no terminator,
+  so the summarizer's "## 9. Next Step" section could read as a live
+  instruction and the kept messages after it blurred into the summary. A
+  `SUMMARY_END_MARKER` plus a one-line "historical context, resume below, do
+  not re-execute completed work" frame gives the block a symmetric open/close
+  bracket; on re-summarization the marker and frame are stripped (anchored on
+  the `[Conversation Summary]` prefix) so they never accumulate or truncate an
+  unrelated message that merely contains the marker substring. (#89)
+
+### Security
+
+- **Resolve-based SSRF guard for `web_fetch`.** The only SSRF defense was the
+  `PermissionEngine` string blocklist, matched on the original URL at the
+  plan-phase gate — it missed hostnames that *resolve* to private / loopback /
+  link-local addresses (DNS rebinding, public names pointed at `127.0.0.1` /
+  `169.254.169.254`), alternate IP encodings, and redirect hops into the
+  internal network (the client used `follow_redirects=True` with no per-hop
+  check); 8 of 13 bypass vectors slipped through. New
+  `agentao/security/url_policy.py`: `validate_outbound_url()` resolves the host
+  and rejects any non-global address, normalizes the hostname (trailing dot /
+  case), rejects local/internal names, single-label hosts and embedded creds,
+  and unwraps v4-mapped / 6to4 / NAT64 IPv6 forms; `guarded_get()` drives the
+  redirect chase with `follow_redirects=False` and re-validates every hop. Both
+  are wired into `WebFetchTool.execute()`; the static blocklist stays as the
+  I/O-free first layer (defense in depth). (#92)
+
+---
+
 ## [0.4.9] — 2026-06-10
 
 ### Added

--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.10-dev"
+__version__ = "0.4.10"
 
 
 def _ensure_utf8() -> None:

--- a/docs/releases/v0.4.10.md
+++ b/docs/releases/v0.4.10.md
@@ -1,0 +1,180 @@
+# Agentao 0.4.10
+
+A **context-window robustness + host LLM passthrough** release on top of 0.4.9.
+The headline is a trio of context-management fixes that stop the harness from
+mis-handling provider errors and stale token counts, plus `extra_body` — the
+first-class escape hatch that lets an embedding host reach
+`reasoning_effort` / `top_p` / `seed` / `response_format` and any
+provider-specific request field. A resolve-based SSRF guard hardens `web_fetch`
+against DNS-rebinding and redirect bypasses. Everything upgrades in place via
+`pip install -U agentao`; no public API, schema, or config break.
+
+The headline:
+
+- **Host LLM request passthrough (`extra_body`).** A single keyword-only
+  constructor arg (and `LLM_EXTRA_BODY` env var) forwarded verbatim to the SDK
+  `.create()` body — `reasoning_effort`, `top_p`, `seed`, `response_format`, or
+  any provider field — with credential-redacted logging and sub-agent
+  inheritance (#91).
+- **Context-overflow detection won't false-fire on throttling.** A two-tier
+  regex table broadens provider coverage (xAI / Google / Bedrock / OpenRouter /
+  Together / Mistral / llama.cpp / LM Studio / Kimi / Ollama) and adds a
+  negative guard so a Bedrock `ThrottlingException: Too many tokens...` no
+  longer triggers a destructive history compaction on a transient error (#88).
+- **Threshold checks anchor to the real prompt-token count.** Compaction
+  decisions reuse the Tier-1 `prompt_tokens` from the prior API response
+  instead of re-encoding the whole history through tiktoken twice per turn —
+  more accurate, and the stale-anchor paths (resume, microcompaction, switch)
+  are all invalidated (#90).
+- **Compaction summary has a symmetric open/close bracket.** An end-of-summary
+  marker stops the summarizer's "Next Step" section from reading as a live
+  instruction and the kept tail from blurring into the summary (#89).
+- **Resolve-based SSRF guard for `web_fetch`.** Outbound URLs are validated
+  *after* DNS resolution and re-validated on every redirect hop, closing 8 of
+  13 bypass vectors the string blocklist missed (#92).
+
+## Why this release
+
+0.4.9 consolidated the embedded-host tool surface and process lifecycle; 0.4.10
+turns to the **LLM request path and context-window machinery** — the parts that
+decide what gets sent to the model and what happens when the window fills or the
+provider errors. The context fixes came from running agentao against a wider
+provider set than the OpenAI-shaped happy path: overflow phrasing varies per
+provider, throttling errors look superficially like overflow, and a token
+anchor reused across a session swap silently corrupts the next compaction
+decision. `extra_body` answers the recurring host need to set reasoning effort
+or a structured-output schema without subclassing the client. The SSRF guard
+closes a gap surfaced by an external network-hardening review.
+
+## Host LLM request passthrough (`extra_body`)
+
+The LLM request kwargs were a closed set — a host could not reach
+`reasoning_effort`, `top_p`, `seed`, `response_format`, or any
+provider-specific body field without subclassing `LLMClient` or monkeypatching,
+both off the `agentao.host` contract. `extra_body` is the SDK-blessed escape
+hatch, now a harness primitive (#91):
+
+- Forwarded verbatim to the OpenAI SDK `.create()` body on both the
+  non-streaming and streaming paths via a single `_build_request_kwargs()` (the
+  same helper that de-dups the previously closed kwargs dict). Omitted when
+  empty, so requests stay byte-identical for hosts that don't set it.
+- **Keyword-only** on the constructor so it never shifts the legacy positional
+  callback args; mutually exclusive with `llm_client=` (a loud `ValueError`,
+  not a silent no-op); deep-copied at construction so a host mutating a nested
+  value it still holds cannot alter in-flight requests.
+- Sub-agents inherit it via the `_llm_config` snapshot. `reconfigure()`
+  preserves it across a model switch with **no auto-recovery latch** — the host
+  owns dropping model-specific keys (a stale `reasoning_effort` will 400 until
+  cleared), unlike the `omit_temperature` / `max_completion_tokens` latches
+  that are reset.
+- Logged with recursive credential redaction (exact lower-cased key-name match
+  over dict/list/tuple; covers body and header-style names like `x-api-key`,
+  `authorization`, `client_secret`) so a benign `*_tokens` key isn't
+  over-redacted.
+- `LLM_EXTRA_BODY` accepts a JSON object; malformed or valid-but-non-object
+  input warns and skips, empty is unset.
+
+`extra_headers`, a `settings.json` layer, and a `/param` command are
+deferred (§8 of the design). User-facing docs: developer-guide
+part-2 constructor reference + appendices, the embedding / model-switching /
+logging guides, and `docs/design/host-llm-extra-params.md` (EN+ZH).
+
+## Context-window robustness
+
+Three independent fixes to the context-management hot path:
+
+- **Overflow detection with a provider table + negative guard (#88).**
+  `is_context_too_long_error` was a 7-phrase substring matcher. It missed
+  overflow errors from xAI / Google / Bedrock / OpenRouter / Together /
+  Mistral / llama.cpp / LM Studio / Kimi / Ollama, and its fallback phrase
+  "too many tokens" misclassified Bedrock throttling
+  (`ThrottlingException: Too many tokens...`) as overflow — triggering a
+  *destructive history compaction on a transient error*. It is now a two-tier
+  compiled-regex table: a broadened positive set, plus a negative set
+  (throttling / rate limit / 429 / 503) checked first that short-circuits to
+  `False`. The broad `maximum context length` / `reduce the length` forms are
+  kept — the guard makes them safe from false positives. (Structure borrowed
+  from pi-mono `ai/utils/overflow.ts`.)
+- **Threshold checks anchor to the real Tier-1 count (#90).**
+  `needs_compression` / `needs_microcompaction` re-encoded the entire history
+  through tiktoken twice per turn, even though the real `prompt_tokens` from
+  the prior API response was recorded and unused. The estimate now reuses that
+  count for the already-sent prefix and locally estimates only the messages
+  appended since. The Tier-1 count includes system + tool-schema tokens the
+  old estimate omitted, so thresholds fire on the true prompt size — marginally
+  earlier and more accurate. A single `invalidate_token_anchor()` helper resets
+  the paired `(count, tokens)` invariant on every history-replace path (full
+  compression, microcompaction, `/sessions resume`, ACP session load, in-loop
+  overflow recovery, manual `/compact`, `clear_history`, model/provider
+  switch) — fixing a latent staleness bug where a resumed session reused a
+  token count from an unrelated prefix.
+- **Compaction summary end-marker (#89).** The summary was opened by the
+  `[Compact Boundary]` system message but had no terminator, so the
+  summarizer's "## 9. Next Step" section could read as a live instruction and
+  the kept tail blurred into the summary. A `SUMMARY_END_MARKER` plus a
+  "historical context, resume below, do not re-execute completed work" frame
+  gives the block a symmetric bracket; on re-summarization the marker and frame
+  are stripped (anchored on the `[Conversation Summary]` prefix) so they never
+  accumulate or truncate an unrelated message.
+
+## Security: resolve-based SSRF guard for `web_fetch` (#92)
+
+`web_fetch`'s only SSRF defense was the `PermissionEngine` string blocklist,
+matched on the *original* URL at the plan-phase gate. It missed hostnames that
+**resolve** to private / loopback / link-local addresses (DNS rebinding, public
+names pointed at `127.0.0.1` / `169.254.169.254`), alternate IP encodings, and
+redirect hops into the internal network (the client used
+`follow_redirects=True` with no per-hop check). 8 of 13 bypass vectors slipped
+through.
+
+New `agentao/security/url_policy.py`:
+
+- `validate_outbound_url()` resolves the host and rejects any non-global
+  address, normalizes the hostname (trailing dot / case), rejects
+  local/internal names, single-label hosts and embedded credentials, and
+  unwraps v4-mapped / 6to4 / NAT64 IPv6 forms.
+- `guarded_get()` drives the redirect chase with `follow_redirects=False` and
+  re-validates every hop.
+
+Both are wired into `WebFetchTool.execute()`. The static blocklist stays as the
+I/O-free first layer — defense in depth.
+
+## What did **not** change
+
+- The `agentao.host` Python contract and the ACP schema snapshot
+  (`docs/schema/host.acp.v1.json`) are unchanged — the replay and host
+  schema-drift checks both pass clean.
+- `extra_body` is purely additive and keyword-only: existing constructor calls
+  and positional callback bindings are untouched.
+- Deprecations stay on schedule: `agentao.harness` (→ `agentao.host`) and the 8
+  legacy constructor callbacks still warn and are removed in 0.5.0.
+- Permission semantics, memory, replay, plugins, skills, MCP: untouched.
+
+## Tests
+
+Full suite green locally (3047 passed, 2 skipped) and across the Python
+3.10/3.11/3.12 CI matrix, plus the clean-install smoke matrix, the mypy
+`--strict` typing gate on `agentao.host`, and the replay + host schema-drift
+checks. New coverage: `tests/test_context_overflow_detection.py`,
+`tests/test_context_manager.py`, `tests/test_sessions_resume_anchor.py`,
+`tests/test_llm_client_extra_body.py` (32 cases), and `tests/test_url_policy.py`.
+
+## Upgrade
+
+```bash
+pip install -U agentao        # library
+pip install -U 'agentao[cli]' # interactive CLI
+```
+
+No migration needed from 0.4.9. To set provider-specific request params, pass
+`Agentao(extra_body={...})` or export `LLM_EXTRA_BODY='{"reasoning_effort":"high"}'`
+— and remember there is no auto-recovery latch, so drop model-specific keys
+yourself before switching to a model that rejects them.
+
+## Out of scope (deferred)
+
+- `extra_headers` passthrough (a credential vector — needs its own redaction
+  design), an `llm.extra_params` `settings.json` layer, and a `/param` CLI
+  command (#91 §8).
+- MCP resources/prompts surfacing (demand-gated).
+- The 0.5.0 deprecation removals.


### PR DESCRIPTION
## Release v0.4.10

Cuts **v0.4.10** — a context-window robustness + host LLM passthrough release on top of v0.4.9. Bumps `__version__` `0.4.10-dev` → `0.4.10`, adds the CHANGELOG entry, and writes `docs/releases/v0.4.10.md`.

### What's in this release (#88–#92)

| PR | Group | Change |
|----|-------|--------|
| #91 | Added | `Agentao(extra_body=...)` — host LLM request passthrough (keyword-only, sub-agent inheritance, redacted logging, `LLM_EXTRA_BODY` env) |
| #90 | Changed | Context threshold checks anchor to the real Tier-1 `prompt_tokens` count; all history-replace paths invalidate the anchor |
| #88 | Fixed | Context-overflow detection → two-tier regex table (broader provider coverage + throttling negative-guard) |
| #89 | Fixed | Compaction summary closes with an end-of-summary marker |
| #92 | Security | Resolve-based SSRF guard for `web_fetch` (per-hop redirect re-validation) |

### Pre-cut verification (local)

- ✅ Full test suite: **3047 passed, 2 skipped** (172s)
- ✅ `mypy --strict --package agentao.host`: clean
- ✅ Replay + host schema-drift checks: up to date
- ✅ `agentao.__version__` resolves to `0.4.10` (publish.yml tag-vs-version assertion)

### After merge

Per the release workflow, run `gh release create v0.4.10` against the merge commit on `origin/main` to trigger the PyPI publish — a bare tag push does **not** publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)