### PR TITLE
chore: open 0.4.11 dev cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [Unreleased]
+
+_Targeting 0.4.11. Add entries under the relevant heading as work lands._
+
+### Added
+
+### Changed
+
+### Fixed
+
+---
+
 ## [0.4.10] — 2026-06-14
 
 ### Added

--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.10"
+__version__ = "0.4.11-dev"
 
 
 def _ensure_utf8() -> None:


### PR DESCRIPTION
Opens the 0.4.11 development cycle now that v0.4.10 is published to PyPI.

- Bump `__version__` `0.4.10` → `0.4.11-dev`.
- Open the `## [Unreleased]` CHANGELOG draft section (Added / Changed / Fixed) targeting 0.4.11.

Re-establishes the per-PR changelog discipline that lapsed in the 0.4.10 cycle — the `[Unreleased]` section was never opened after cutting v0.4.9, so the entire 0.4.10 entry had to be reconstructed at release time. Adding entries here as work lands keeps the next release cut cheap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)