### PR TITLE
feat(prompts): strip leading YAML frontmatter from AGENTAO.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ _Targeting 0.4.11. Add entries under the relevant heading as work lands._
 
 ### Changed
 
+- **`AGENTAO.md` now drops a leading YAML frontmatter block before injecting
+  it into the system prompt.** Previously the file was read verbatim, so a
+  frontmatter block carried over from a Cursor rule or another tool's
+  instruction file (`---\nname: ...\n---`) leaked into the prompt as literal
+  text. `load_project_instructions` now routes the contents through a new
+  `agentao.prompts.strip_frontmatter()` helper. Stripping is conservative — it
+  only fires when the document genuinely opens with a frontmatter *mapping*
+  (opening `---` fence + YAML mapping + closing `---` fence); an absent block,
+  malformed YAML, or a stray `---` thematic break wrapping prose is left
+  untouched so real instructions are never silently dropped. The disk-read
+  path only; a host-injected `project_instructions=` string stays the host's
+  responsibility. The ignored-frontmatter case is logged at INFO.
+
 ### Fixed
 
 ---

--- a/agentao/prompts/__init__.py
+++ b/agentao/prompts/__init__.py
@@ -7,7 +7,7 @@ existing tests and any external callers continue to work.
 """
 
 from .builder import SystemPromptBuilder
-from .helpers import extract_context_hints, load_project_instructions
+from .helpers import extract_context_hints, load_project_instructions, strip_frontmatter
 from .sections import (
     build_identity_section,
     build_reliability_section,
@@ -29,4 +29,5 @@ __all__ = [
     "build_operational_guidelines",
     "extract_context_hints",
     "load_project_instructions",
+    "strip_frontmatter",
 ]

--- a/agentao/prompts/helpers.py
+++ b/agentao/prompts/helpers.py
@@ -14,8 +14,40 @@ import re
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+import yaml
+
 
 _PATH_RE = re.compile(r'[\w./\\-]+\.\w{2,6}')
+
+# A YAML frontmatter block: an opening ``---`` fence on its own line, a body,
+# and a closing ``---`` fence on its own line. Both fences must be line-anchored
+# so a lone ``---`` thematic break in the middle of the document never matches.
+_FRONTMATTER_RE = re.compile(
+    r"^---[ \t]*\r?\n(?P<meta>.*?)\r?\n---[ \t]*(?:\r?\n|$)(?P<body>.*)$",
+    re.DOTALL,
+)
+
+
+def strip_frontmatter(content: str) -> str:
+    """Drop a leading YAML frontmatter block, returning just the body.
+
+    Stripping happens only when the document genuinely opens with a
+    frontmatter block — an opening ``---`` fence, a YAML *mapping*, and a
+    closing ``---`` fence. If the block is absent, malformed YAML, or parses
+    to a non-mapping (e.g. a stray ``---`` horizontal rule wrapping prose),
+    the content is returned untouched so real instructions are never silently
+    dropped.
+    """
+    match = _FRONTMATTER_RE.match(content)
+    if match is None:
+        return content
+    try:
+        meta = yaml.safe_load(match.group("meta"))
+    except yaml.YAMLError:
+        return content
+    if not isinstance(meta, dict):
+        return content
+    return match.group("body").lstrip("\n")
 
 
 def extract_context_hints(messages: List[Dict[str, Any]]) -> List[str]:
@@ -47,17 +79,27 @@ def load_project_instructions(
 ) -> Optional[str]:
     """Load project-specific instructions from ``AGENTAO.md`` if present.
 
-    Returns the file contents or ``None`` when the file is absent or
-    cannot be read. Errors are logged at WARNING and swallowed — the
-    agent should still start when the project has no AGENTAO.md.
+    A leading YAML frontmatter block (e.g. carried over from a Cursor rule or
+    another tool's instruction file) is stripped via :func:`strip_frontmatter`
+    so it does not leak into the system prompt. Returns the (frontmatter-free)
+    file contents or ``None`` when the file is absent or cannot be read. Errors
+    are logged at WARNING and swallowed — the agent should still start when the
+    project has no AGENTAO.md.
     """
     try:
         agentao_md = working_directory / "AGENTAO.md"
         if agentao_md.exists():
             content = agentao_md.read_text(encoding="utf-8")
+            body = strip_frontmatter(content)
             if logger is not None:
-                logger.info(f"Loaded project instructions from {agentao_md}")
-            return content
+                if body != content:
+                    logger.info(
+                        f"Loaded project instructions from {agentao_md} "
+                        f"(ignored leading YAML frontmatter)"
+                    )
+                else:
+                    logger.info(f"Loaded project instructions from {agentao_md}")
+            return body
     except Exception as exc:
         if logger is not None:
             logger.warning(f"Could not load AGENTAO.md: {exc}")

--- a/tests/test_agentao_md_frontmatter.py
+++ b/tests/test_agentao_md_frontmatter.py
@@ -1,0 +1,96 @@
+"""AGENTAO.md leading-YAML-frontmatter stripping.
+
+`load_project_instructions` drops a leading YAML frontmatter block so it does
+not leak into the system prompt, but only when the document genuinely opens
+with a frontmatter *mapping* — a stray `---` thematic break must never cause
+real instructions to be dropped.
+"""
+
+from pathlib import Path
+from unittest.mock import Mock
+
+import pytest
+
+from agentao.prompts.helpers import load_project_instructions, strip_frontmatter
+
+
+# --- strip_frontmatter: unit cases -----------------------------------------
+
+
+def test_strips_leading_frontmatter_mapping():
+    content = "---\nname: my-rules\ndescription: project rules\n---\n# Heading\n\nBody text.\n"
+    assert strip_frontmatter(content) == "# Heading\n\nBody text.\n"
+
+
+def test_no_frontmatter_passthrough():
+    content = "# Heading\n\nUse uv, not pip.\n"
+    assert strip_frontmatter(content) == content
+
+
+def test_single_fence_is_not_frontmatter():
+    # A lone opening fence with no closing fence is not frontmatter.
+    content = "---\n# Heading after a rule\n"
+    assert strip_frontmatter(content) == content
+
+
+def test_thematic_rule_wrapping_prose_is_kept():
+    # `---` ... `---` around prose parses to a YAML string, not a mapping —
+    # stripping it would drop real content, so it must be kept verbatim.
+    content = "---\njust some prose between rules\n---\nmore text\n"
+    assert strip_frontmatter(content) == content
+
+
+def test_malformed_yaml_is_kept():
+    content = "---\nname: [unclosed\n---\nBody.\n"
+    assert strip_frontmatter(content) == content
+
+
+def test_empty_frontmatter_is_kept():
+    # Degenerate empty block parses to None (non-mapping) → keep untouched.
+    content = "---\n\n---\nBody.\n"
+    assert strip_frontmatter(content) == content
+
+
+def test_crlf_frontmatter_stripped():
+    content = "---\r\nname: r\r\n---\r\nBody.\r\n"
+    assert strip_frontmatter(content) == "Body.\r\n"
+
+
+def test_frontmatter_only_no_body():
+    content = "---\nname: only\n---\n"
+    assert strip_frontmatter(content) == ""
+
+
+def test_body_internal_triple_dash_preserved():
+    content = "---\nname: x\n---\nA\n\n---\n\nB\n"
+    assert strip_frontmatter(content) == "A\n\n---\n\nB\n"
+
+
+# --- load_project_instructions: integration on disk ------------------------
+
+
+def test_loader_strips_frontmatter(tmp_path: Path):
+    (tmp_path / "AGENTAO.md").write_text(
+        "---\nname: rules\n---\nUse uv, not pip.\n", encoding="utf-8"
+    )
+    logger = Mock()
+    result = load_project_instructions(tmp_path, logger)
+    assert result == "Use uv, not pip.\n"
+    # The ignored-frontmatter branch logs an explicit note.
+    assert any(
+        "frontmatter" in str(call.args[0]).lower() for call in logger.info.call_args_list
+    )
+
+
+def test_loader_passthrough_without_frontmatter(tmp_path: Path):
+    body = "# Project\n\nUse uv, not pip.\n"
+    (tmp_path / "AGENTAO.md").write_text(body, encoding="utf-8")
+    assert load_project_instructions(tmp_path) == body
+
+
+def test_loader_missing_file_returns_none(tmp_path: Path):
+    assert load_project_instructions(tmp_path) is None
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What

`AGENTAO.md` was read verbatim into the system prompt, so a leading YAML frontmatter block carried over from a Cursor rule or another tool's instruction file (`---\nname: ...\n---`) leaked into the prompt as literal text. This strips it.

`load_project_instructions` now routes the file contents through a new `agentao.prompts.strip_frontmatter()` helper.

## Conservative by design

Stripping fires **only** when the document genuinely opens with a frontmatter *mapping*: opening `---` fence → YAML mapping → closing `---` fence. Left untouched (returned verbatim) when:

- there is no frontmatter block;
- the block is malformed YAML;
- the block parses to a non-mapping — e.g. a stray `---` thematic break wrapping prose.

So real instructions are never silently dropped. Plain AGENTAO.md files (the common case, including this repo's own) are unaffected.

## Scope / boundaries

- **Disk-read path only.** A host-injected `project_instructions=` string stays the host's responsibility (embedded-harness boundary).
- The ignored-frontmatter case is logged at INFO.

## Tests

`tests/test_agentao_md_frontmatter.py` — 12 cases (unit `strip_frontmatter` + on-disk loader): mapping strip, passthrough, single-fence, thematic-rule-wrapping-prose, malformed YAML, empty block, CRLF, frontmatter-only, body-internal `---`, loader strip/passthrough/missing. Full related suite green (54 passed).

## Not in this PR (noted for later)

`_parse_yaml_frontmatter` is duplicated ~5× across skills/agents/plugins. Consolidating all of them onto one shared parser is a separate, behavior-sensitive cleanup — out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)