### PR TITLE
refactor(frontmatter): consolidate 5 duplicated YAML parsers into one

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,19 @@ _Targeting 0.4.11. Add entries under the relevant heading as work lands._
   path only; a host-injected `project_instructions=` string stays the host's
   responsibility. The ignored-frontmatter case is logged at INFO.
 
+- **Consolidated five copies of the YAML frontmatter parser (internal,
+  behavior-preserving).** The private `_parse_yaml_frontmatter` was duplicated
+  across `skills/installer.py`, `skills/manager.py`, `agents/manager.py`, and
+  `embedding/plugins/resolvers/{agents,skills}.py`, having drifted on value
+  coercion, body stripping, and malformed-YAML fallback. All now delegate to a
+  single `agentao.frontmatter.parse_frontmatter(content, *, coerce_str=False)`:
+  `coerce_str=True` for the skill / plugin loaders (string values), the native
+  default for the agent loaders (so `tools: [read_file]` stays a list). The
+  shared parser adopts the safest behavior of the five — a malformed or
+  non-mapping block degrades to `{}` instead of raising `AttributeError`. (The
+  AGENTAO.md `strip_frontmatter` helper stays separate by design: it uses a
+  stricter, line-anchored fence match for free-form prose.)
+
 ### Fixed
 
 ---

--- a/agentao/agents/manager.py
+++ b/agentao/agents/manager.py
@@ -3,7 +3,7 @@
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, TYPE_CHECKING
 
-import yaml
+from agentao.frontmatter import parse_frontmatter
 
 from ..tools.base import RegistrableTool, Tool
 from .tools import AgentToolWrapper, CheckBackgroundAgentTool
@@ -43,7 +43,7 @@ class AgentManager:
         for md_file in sorted(directory.glob("*.md")):
             try:
                 content = md_file.read_text(encoding="utf-8")
-                frontmatter, body = self._parse_yaml_frontmatter(content)
+                frontmatter, body = parse_frontmatter(content)
 
                 name = frontmatter.get("name", md_file.stem)
                 description = frontmatter.get("description", "")
@@ -70,22 +70,6 @@ class AgentManager:
                 }
             except Exception:
                 continue
-
-    @staticmethod
-    def _parse_yaml_frontmatter(content: str) -> tuple:
-        if not content.startswith("---"):
-            return {}, content
-
-        parts = content.split("---", 2)
-        if len(parts) < 3:
-            return {}, content
-
-        try:
-            frontmatter = yaml.safe_load(parts[1]) or {}
-        except yaml.YAMLError:
-            frontmatter = {}
-
-        return frontmatter, parts[2]
 
     # ------------------------------------------------------------------
     # Plugin agent registration
@@ -114,7 +98,7 @@ class AgentManager:
             return errors
 
         for defn in agent_defs:
-            frontmatter, body = self._parse_yaml_frontmatter(defn.raw_markdown)
+            frontmatter, body = parse_frontmatter(defn.raw_markdown)
 
             tools_list = frontmatter.get("tools")
             if isinstance(tools_list, str):

--- a/agentao/embedding/plugins/resolvers/agents.py
+++ b/agentao/embedding/plugins/resolvers/agents.py
@@ -10,10 +10,8 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any
 
-import yaml
-
+from agentao.frontmatter import parse_frontmatter
 from agentao.plugins.models import (
     LoadedPlugin,
     PluginAgentDefinition,
@@ -116,7 +114,7 @@ def _parse_agent_md(
     except (OSError, UnicodeDecodeError):
         return None
 
-    frontmatter, body = _parse_yaml_frontmatter(content)
+    frontmatter, body = parse_frontmatter(content)
     agent_name = str(frontmatter.get("name", md_file.stem))
     description = str(frontmatter.get("description", ""))
     runtime_name = f"{plugin_name}:{agent_name}"
@@ -149,27 +147,3 @@ def _check_internal_collisions(
             seen.add(defn.runtime_name)
 
     return errors
-
-
-def _parse_yaml_frontmatter(content: str) -> tuple[dict[str, Any], str]:
-    """Parse YAML frontmatter, preserving native types (lists, ints, etc.).
-
-    Unlike the skill frontmatter parser which coerces everything to str,
-    the agent parser must keep list values (e.g. ``tools: [read_file]``)
-    as lists so that ``AgentManager`` can interpret them correctly.
-    """
-    if not content.startswith("---"):
-        return {}, content
-
-    parts = content.split("---", 2)
-    if len(parts) < 3:
-        return {}, content
-
-    try:
-        fm = yaml.safe_load(parts[1]) or {}
-        if not isinstance(fm, dict):
-            fm = {}
-    except yaml.YAMLError:
-        fm = {}
-
-    return fm, parts[2].strip()

--- a/agentao/embedding/plugins/resolvers/skills.py
+++ b/agentao/embedding/plugins/resolvers/skills.py
@@ -11,8 +11,7 @@ from __future__ import annotations
 import logging
 from pathlib import Path
 
-import yaml
-
+from agentao.frontmatter import parse_frontmatter
 from agentao.plugins.models import (
     LoadedPlugin,
     PluginCommandMetadata,
@@ -105,7 +104,7 @@ def _parse_skill_md(
     except (OSError, UnicodeDecodeError):
         return None
 
-    frontmatter, body = _parse_yaml_frontmatter(content)
+    frontmatter, body = parse_frontmatter(content, coerce_str=True)
     skill_name = frontmatter.get("name", skill_dir.name)
     description = frontmatter.get("description", "")
     runtime_name = f"{plugin_name}:{skill_name}"
@@ -227,7 +226,7 @@ def _md_file_to_entry(
         return None
 
     cmd_name = md_file.stem  # e.g. "review-summary.md" -> "review-summary"
-    frontmatter, body = _parse_yaml_frontmatter(content)
+    frontmatter, body = parse_frontmatter(content, coerce_str=True)
     description = frontmatter.get("description", "")
     runtime_name = f"{plugin_name}:{cmd_name}"
 
@@ -276,7 +275,7 @@ def _metadata_to_entry(
 
         # Strip YAML frontmatter so metadata headers are not injected into
         # the prompt body — matching the behavior of _md_file_to_entry().
-        _fm, body = _parse_yaml_frontmatter(raw_content)
+        _fm, body = parse_frontmatter(raw_content, coerce_str=True)
         description = meta.description or _fm.get("description", "")
 
         return PluginSkillEntry(
@@ -321,24 +320,3 @@ def _check_internal_collisions(
             seen[entry.runtime_name] = entry
 
     return errors
-
-
-# ---------------------------------------------------------------------------
-# YAML frontmatter helper (shared with SkillManager)
-# ---------------------------------------------------------------------------
-
-def _parse_yaml_frontmatter(content: str) -> tuple[dict[str, str], str]:
-    if not content.startswith("---"):
-        return {}, content
-
-    parts = content.split("---", 2)
-    if len(parts) < 3:
-        return {}, content
-
-    try:
-        fm = yaml.safe_load(parts[1]) or {}
-        fm = {k: str(v).strip() if v is not None else "" for k, v in fm.items()}
-    except yaml.YAMLError:
-        fm = {}
-
-    return fm, parts[2].strip()

--- a/agentao/frontmatter.py
+++ b/agentao/frontmatter.py
@@ -1,0 +1,61 @@
+"""Shared YAML-frontmatter parsing for markdown definition files.
+
+A single parser for the ``---\\nkey: val\\n---\\nbody`` convention used by
+SKILL.md, agent ``*.md`` definitions, and plugin manifests. This logic was
+previously copy-pasted as a private ``_parse_yaml_frontmatter`` in five places
+(``skills/installer.py``, ``skills/manager.py``, ``agents/manager.py``,
+``embedding/plugins/resolvers/{agents,skills}.py``) that had drifted on value
+coercion, body stripping, malformed-YAML fallback, and non-mapping handling.
+
+For the *stripping-only* variant used by AGENTAO.md — free-form prose, where a
+stray ``---`` horizontal rule must never be mistaken for a fence — see
+:func:`agentao.prompts.helpers.strip_frontmatter`, which deliberately uses a
+stricter, line-anchored fence match instead of this lenient ``split``.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import yaml
+
+
+def parse_frontmatter(
+    content: str, *, coerce_str: bool = False
+) -> tuple[dict[str, Any], str]:
+    """Split a leading YAML frontmatter block from a markdown document.
+
+    Returns ``(frontmatter, body)``:
+
+    - ``frontmatter`` is the parsed mapping, or ``{}`` when there is no
+      frontmatter block, the block is malformed YAML, or it parses to a
+      non-mapping (scalar / list). Guarding the non-mapping case means a
+      malformed block degrades to ``{}`` rather than raising ``AttributeError``
+      on ``.items()`` — the behavior the agent resolver already had and the
+      other four call sites lacked.
+    - ``body`` is everything after the closing ``---`` fence, stripped. When
+      there is no frontmatter block the original ``content`` is returned
+      verbatim as the body (matching every prior call site's guard).
+
+    With ``coerce_str=True`` every value is coerced to a stripped ``str``
+    (``None`` -> ``""``) — what the skill / plugin loaders rely on. With
+    ``coerce_str=False`` (default) native YAML types are preserved, which the
+    agent loaders need so e.g. ``tools: [read_file]`` stays a list.
+    """
+    if not content.startswith("---"):
+        return {}, content
+
+    parts = content.split("---", 2)
+    if len(parts) < 3:
+        return {}, content
+
+    body = parts[2].strip()
+    try:
+        meta = yaml.safe_load(parts[1])
+    except yaml.YAMLError:
+        return {}, body
+    if not isinstance(meta, dict):
+        return {}, body
+    if coerce_str:
+        meta = {k: str(v).strip() if v is not None else "" for k, v in meta.items()}
+    return meta, body

--- a/agentao/skills/installer.py
+++ b/agentao/skills/installer.py
@@ -8,7 +8,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Optional
 
-import yaml
+from agentao.frontmatter import parse_frontmatter
 
 from .registry import (
     InstalledSkillRecord,
@@ -36,31 +36,6 @@ class SkillConflictError(SkillInstallError):
 
 class SkillFetchError(SkillInstallError):
     """Failed to download or extract the skill package."""
-
-
-# ------------------------------------------------------------------
-# YAML frontmatter parser (shared with SkillManager)
-# ------------------------------------------------------------------
-
-def _parse_yaml_frontmatter(content: str) -> tuple:
-    """Parse YAML frontmatter from markdown. Returns (frontmatter_dict, body)."""
-    if not content.startswith("---"):
-        return {}, content
-
-    parts = content.split("---", 2)
-    if len(parts) < 3:
-        return {}, content
-
-    try:
-        frontmatter = yaml.safe_load(parts[1]) or {}
-        frontmatter = {
-            k: str(v).strip() if v is not None else ""
-            for k, v in frontmatter.items()
-        }
-    except yaml.YAMLError:
-        return {}, content
-
-    return frontmatter, parts[2].strip()
 
 
 # ------------------------------------------------------------------
@@ -299,7 +274,7 @@ class SkillInstaller:
         if not content.startswith("---"):
             raise SkillValidationError("SKILL.md missing YAML frontmatter.")
 
-        frontmatter, _body = _parse_yaml_frontmatter(content)
+        frontmatter, _body = parse_frontmatter(content, coerce_str=True)
         if not frontmatter:
             raise SkillValidationError(
                 "SKILL.md frontmatter is empty or malformed."

--- a/agentao/skills/manager.py
+++ b/agentao/skills/manager.py
@@ -6,7 +6,7 @@ import shutil
 from pathlib import Path
 from typing import Dict, List, Optional, Set
 
-import yaml
+from agentao.frontmatter import parse_frontmatter
 
 from ..paths import user_root
 
@@ -183,26 +183,6 @@ class SkillManager:
     # Loading
     # ------------------------------------------------------------------
 
-    def _parse_yaml_frontmatter(self, content: str) -> tuple[Dict[str, str], str]:
-        """Parse YAML frontmatter from markdown file."""
-        if not content.startswith('---'):
-            return {}, content
-
-        parts = content.split('---', 2)
-        if len(parts) < 3:
-            return {}, content
-
-        frontmatter_text = parts[1]
-        remaining_content = parts[2].strip()
-
-        try:
-            frontmatter = yaml.safe_load(frontmatter_text) or {}
-            frontmatter = {k: str(v).strip() if v is not None else "" for k, v in frontmatter.items()}
-        except yaml.YAMLError:
-            frontmatter = {}
-
-        return frontmatter, remaining_content
-
     def _load_skills(self):
         """Load skills from all configured directories.
 
@@ -240,7 +220,7 @@ class SkillManager:
                 with open(skill_md_path, "r", encoding="utf-8") as f:
                     content = f.read()
 
-                frontmatter, body_content = self._parse_yaml_frontmatter(content)
+                frontmatter, body_content = parse_frontmatter(content, coerce_str=True)
 
                 skill_name = frontmatter.get("name", skill_dir.name)
                 description = frontmatter.get("description", "")

--- a/tests/test_frontmatter.py
+++ b/tests/test_frontmatter.py
@@ -1,0 +1,74 @@
+"""Contract for the shared `parse_frontmatter` helper.
+
+Consolidates the five previously-duplicated `_parse_yaml_frontmatter` copies.
+The two behavioral axes that mattered to the call sites — value coercion
+(skills str-coerce vs agents native types) and graceful degradation on
+malformed / non-mapping frontmatter — are pinned here.
+"""
+
+import pytest
+
+from agentao.frontmatter import parse_frontmatter
+
+
+# --- happy path ------------------------------------------------------------
+
+
+def test_parses_mapping_and_strips_body():
+    meta, body = parse_frontmatter("---\nname: x\ndescription: y\n---\n\n# Body\n")
+    assert meta == {"name": "x", "description": "y"}
+    assert body == "# Body"
+
+
+def test_no_frontmatter_returns_content_verbatim():
+    content = "# Just a heading\n\nNo frontmatter.\n"
+    assert parse_frontmatter(content) == ({}, content)
+
+
+def test_missing_closing_fence_returns_content_verbatim():
+    content = "---\nname: x\nno closing fence\n"
+    assert parse_frontmatter(content) == ({}, content)
+
+
+# --- value coercion axis ---------------------------------------------------
+
+
+def test_native_types_preserved_by_default():
+    # Agent loaders rely on this: `tools: [a, b]` must stay a list.
+    meta, _ = parse_frontmatter(
+        "---\ntools:\n  - read_file\n  - glob\nmax_turns: 20\ntemp: 0.5\n---\nbody\n"
+    )
+    assert meta["tools"] == ["read_file", "glob"]
+    assert meta["max_turns"] == 20
+    assert meta["temp"] == 0.5
+
+
+def test_coerce_str_stringifies_values():
+    # Skill / plugin loaders rely on str-coerced, stripped values.
+    meta, _ = parse_frontmatter(
+        "---\nname: x\ncount: 3\nempty:\n---\nbody\n", coerce_str=True
+    )
+    assert meta == {"name": "x", "count": "3", "empty": ""}
+
+
+# --- graceful degradation (the isinstance guard) ---------------------------
+
+
+def test_malformed_yaml_degrades_to_empty_mapping():
+    meta, body = parse_frontmatter("---\nname: [unclosed\n---\nbody\n")
+    assert meta == {}
+    assert body == "body"
+
+
+def test_non_mapping_frontmatter_degrades_to_empty_mapping():
+    # A YAML list/scalar between the fences is not a mapping → {} (no crash).
+    meta, body = parse_frontmatter("---\n- a\n- b\n---\nbody\n")
+    assert meta == {}
+    assert body == "body"
+    # And it must not raise even with coerce_str (the old copies would have
+    # hit `.items()` on a list).
+    assert parse_frontmatter("---\n- a\n---\nbody\n", coerce_str=True) == ({}, "body")
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
## What

Follow-up to #95. The private `_parse_yaml_frontmatter` was copy-pasted across **five** modules, having drifted on three axes:

| Copy | value coercion | body | malformed-YAML fallback | non-mapping guard |
|---|---|---|---|---|
| `skills/installer.py` | str-coerce | `.strip()` | `{}, content` | ❌ (could raise) |
| `skills/manager.py` | str-coerce | `.strip()` | `{}, body` | ❌ |
| `agents/manager.py` | native | **raw** | `{}, raw` | ❌ |
| `resolvers/agents.py` | native | `.strip()` | `{}, body` | ✅ |
| `resolvers/skills.py` | str-coerce | `.strip()` | `{}, body` | ❌ |

## Change

New `agentao/frontmatter.py::parse_frontmatter(content, *, coerce_str=False)`; all five call sites delegate to it.

- **`coerce_str=True`** — skill / plugin loaders (string-valued frontmatter).
- **native default** — agent loaders, so `tools: [read_file]` stays a list (verified required by `resolvers/agents.py`'s own docstring + `test_tools_string_parsed_as_list`).

Adopts the **safest** behavior of the five:
- **isinstance guard** (only the agent resolver had it) → a malformed / non-mapping block degrades to `{}` instead of raising `AttributeError` on `.items()`.
- Body always returned **stripped** — the `agents/manager.py` call sites already did `body.strip()` themselves, so this is idempotent there (verified before changing).

`strip_frontmatter` (AGENTAO.md, from #95) **stays separate by design**: free-form prose needs a stricter, line-anchored fence so a stray `---` rule is never mistaken for a fence.

Also drops the now-unused `import yaml` / `from typing import Any` left in the five files.

## Verification

- Full suite: **3066 passed, 2 skipped**.
- Affected subsystems (skills/agents/plugins/AGENTAO.md): 236 passed.
- New `tests/test_frontmatter.py`: coercion both ways, native-list preservation, malformed + non-mapping degradation, body stripping.
- No test ever called the private `_parse_yaml_frontmatter` directly (all go through manager/resolver APIs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)