### PR TITLE
chore: normalize dev version to PEP 440 canonical 0.4.11.dev0

### DIFF
--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.11-dev"
+__version__ = "0.4.11.dev0"
 
 
 def _ensure_utf8() -> None:


### PR DESCRIPTION
Standardizes the development-cycle version literal to the PEP 440 canonical form.

`agentao/__init__.py`: `0.4.11-dev` → `0.4.11.dev0`.

## Why

The source literal had flip-flopped between two spellings across cycles:

- `0.4.9.dev0` (PEP 440 canonical)
- `0.4.10-dev` / `0.4.11-dev` (hyphenated)

Both build identically — hatchling PEP 440-normalizes the hyphen form to `.dev0` in the wheel/metadata (the installed `0.4.10-dev` editable reports `0.4.10.dev0`). But the runtime `agentao.__version__` string differed from the distribution version, and direct string comparisons were mildly surprising. This makes `agentao.__version__` == the built metadata version and ends the flip-flop.

No functional change; release-cut still drops the `.dev0` suffix to `0.4.11`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)