### PR TITLE
chore(release): cut v0.4.11

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
-## [Unreleased]
-
-_Targeting 0.4.11. Add entries under the relevant heading as work lands._
-
-### Added
+## [0.4.11] — 2026-06-14
 
 ### Changed
 
@@ -38,8 +34,6 @@ _Targeting 0.4.11. Add entries under the relevant heading as work lands._
   non-mapping block degrades to `{}` instead of raising `AttributeError`. (The
   AGENTAO.md `strip_frontmatter` helper stays separate by design: it uses a
   stricter, line-anchored fence match for free-form prose.)
-
-### Fixed
 
 ---
 

--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.11.dev0"
+__version__ = "0.4.11"
 
 
 def _ensure_utf8() -> None:

--- a/docs/releases/v0.4.11.md
+++ b/docs/releases/v0.4.11.md
@@ -1,0 +1,103 @@
+# Agentao 0.4.11
+
+A small **frontmatter-handling** release on top of 0.4.10. `AGENTAO.md` now
+strips a leading YAML frontmatter block instead of leaking it into the system
+prompt, and the five copy-pasted YAML frontmatter parsers behind SKILL.md,
+agent definitions, and plugin manifests are consolidated into one shared,
+hardened parser. Everything upgrades in place via `pip install -U agentao`; no
+public API, schema, or config break.
+
+The headline:
+
+- **`AGENTAO.md` ignores a leading YAML frontmatter block.** A frontmatter
+  block carried over from a Cursor rule or another tool's instruction file
+  (`---\nname: ...\n---`) used to land in the system prompt as literal text; it
+  is now stripped — conservatively, so a stray `---` never drops real
+  instructions.
+- **One YAML frontmatter parser instead of five.** The private
+  `_parse_yaml_frontmatter` duplicated across skills / agents / plugins —
+  drifted on value coercion, body stripping, and malformed-YAML fallback — is
+  unified into `agentao.frontmatter.parse_frontmatter`, adopting the safest
+  behavior of the five.
+
+## Why this release
+
+Both changes came out of the 0.4.11 cycle's work on how Agentao reads
+markdown definition files. AGENTAO.md was the one instruction surface that
+read its file verbatim, so frontmatter pasted from another tool leaked into
+the prompt. Fixing that surfaced the latent duplication: five near-identical
+frontmatter parsers had quietly diverged, and one of them could raise
+`AttributeError` on a malformed block. Consolidating them removes the drift
+and the latent crash in a single behavior-preserving pass.
+
+## `AGENTAO.md` frontmatter stripping
+
+`load_project_instructions` previously returned the file verbatim. It now
+routes the contents through a new `agentao.prompts.strip_frontmatter()` helper:
+
+- Stripping fires **only** when the document genuinely opens with a
+  frontmatter *mapping* — an opening `---` fence, a YAML mapping, and a closing
+  `---` fence (line-anchored).
+- An absent block, malformed YAML, or a stray `---` thematic break wrapping
+  prose is left untouched, so real instructions are never silently dropped.
+  Plain AGENTAO.md files (the common case) are unaffected.
+- Disk-read path only — a host-injected `project_instructions=` string stays
+  the host's responsibility. The ignored-frontmatter case is logged at INFO.
+
+## One shared frontmatter parser
+
+`agentao.frontmatter.parse_frontmatter(content, *, coerce_str=False)` replaces
+the five private copies in `skills/installer.py`, `skills/manager.py`,
+`agents/manager.py`, and `embedding/plugins/resolvers/{agents,skills}.py`:
+
+- `coerce_str=True` for the skill / plugin loaders (string-valued frontmatter);
+  the native default for the agent loaders, so `tools: [read_file]` stays a
+  list.
+- Adopts the **isinstance guard** only the agent resolver previously had, so a
+  malformed or non-mapping block degrades to `{}` instead of raising
+  `AttributeError` on `.items()`.
+- The body is always returned stripped; the agent call sites already did
+  `body.strip()` themselves, so this is idempotent there.
+
+The AGENTAO.md `strip_frontmatter` helper stays separate by design — free-form
+prose needs the stricter, line-anchored fence rather than the lenient `split`
+the definition-file parser uses.
+
+## What did **not** change
+
+- The `agentao.host` Python contract and the ACP schema snapshot
+  (`docs/schema/host.acp.v1.json`) are unchanged — replay and host
+  schema-drift checks pass clean.
+- Both changes are behavior-preserving for well-formed files; only the edge
+  cases (frontmatter-in-AGENTAO.md, malformed/non-mapping definition
+  frontmatter) change, and only toward safer handling.
+- Deprecations stay on schedule: `agentao.harness` (→ `agentao.host`) and the 8
+  legacy constructor callbacks still warn and are removed in 0.5.0.
+- Permission semantics, memory, replay, plugins, MCP: untouched.
+
+## Tests
+
+Full suite green locally and across the Python 3.10/3.11/3.12 CI matrix, plus
+the clean-install smoke matrix, the mypy `--strict` typing gate on
+`agentao.host`, and the replay + host schema-drift checks. New coverage:
+`tests/test_agentao_md_frontmatter.py` and `tests/test_frontmatter.py`.
+
+## Upgrade
+
+```bash
+pip install -U agentao        # library
+pip install -U 'agentao[cli]' # interactive CLI
+```
+
+No migration needed from 0.4.10. If your `AGENTAO.md` intentionally began with
+a `---\nkey: value\n---` block whose contents you wanted in the prompt, move
+that text below the frontmatter — a leading YAML mapping is now treated as
+metadata and dropped.
+
+## Out of scope (deferred)
+
+- Using the AGENTAO.md frontmatter for anything (it is stripped-and-ignored,
+  not parsed for fields).
+- Unifying `strip_frontmatter` with `parse_frontmatter` (different fence
+  policies by design).
+- The 0.5.0 deprecation removals.


### PR DESCRIPTION
## Release v0.4.11

Cuts **v0.4.11** — a small frontmatter-handling release on top of v0.4.10. Bumps `__version__` `0.4.11.dev0` → `0.4.11`, converts `[Unreleased]` → `[0.4.11]`, and writes `docs/releases/v0.4.11.md`.

### What's in this release (#95, #96)

| PR | Group | Change |
|----|-------|--------|
| #95 | Changed | `AGENTAO.md` strips a leading YAML frontmatter block before injecting into the system prompt (conservative — never drops a stray `---`) |
| #96 | Changed | Consolidate 5 duplicated `_parse_yaml_frontmatter` copies into one shared `agentao.frontmatter.parse_frontmatter` (adopts the safest behavior; internal, behavior-preserving) |

### Pre-cut verification (local)

- ✅ Full test suite: **3066 passed, 2 skipped**
- ✅ `mypy --strict --package agentao.host`: clean
- ✅ Replay + host schema-drift checks: up to date
- ✅ `agentao.__version__` resolves to `0.4.11` (publish.yml tag-vs-version assertion)

### After merge

Run `gh release create v0.4.11 --target main --notes-file docs/releases/v0.4.11.md` against the merge commit on `origin/main` to trigger the PyPI publish — a bare tag push does **not** publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)