### PR TITLE
chore: open 0.4.12 dev cycle

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,18 @@ Format follows [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ---
 
+## [Unreleased]
+
+_Targeting 0.4.12. Add entries under the relevant heading as work lands._
+
+### Added
+
+### Changed
+
+### Fixed
+
+---
+
 ## [0.4.11] — 2026-06-14
 
 ### Changed

--- a/agentao/__init__.py
+++ b/agentao/__init__.py
@@ -7,7 +7,7 @@ from typing import TYPE_CHECKING
 
 warnings.filterwarnings("ignore", message="urllib3.*or chardet.*doesn't match")
 
-__version__ = "0.4.11"
+__version__ = "0.4.12.dev0"
 
 
 def _ensure_utf8() -> None:


### PR DESCRIPTION
Opens the 0.4.12 development cycle now that v0.4.11 is published to PyPI.

- Bump `__version__` `0.4.11` → `0.4.12.dev0` (PEP 440 canonical `.dev0` form, per the convention normalized in #97).
- Open the `## [Unreleased]` CHANGELOG draft section (Added / Changed / Fixed) targeting 0.4.12.

Add entries to `[Unreleased]` as work lands so the next release cut is just a rename, not a reconstruction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)